### PR TITLE
Feat(ci): Integrate automated C++ code formatting with clang-format (…

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,71 @@
+# OpenImpala clang-format configuration
+# Based on LLVM style, tuned for C++17 codebase
+---
+Language: Cpp
+BasedOnStyle: LLVM
+
+# C++ standard
+Standard: c++17
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+IndentCaseLabels: false
+NamespaceIndentation: None
+AccessModifierOffset: -4
+
+# Braces
+BreakBeforeBraces: Attach
+
+# Line length
+ColumnLimit: 100
+
+# Includes
+SortIncludes: false
+IncludeBlocks: Preserve
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignTrailingComments: true
+AlignOperands: true
+
+# Packing
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+
+# Penalties
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+
+# Spaces
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyBlock: false
+SpacesInAngles: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+
+# Other
+PointerAlignment: Left
+DerivePointerAlignment: false
+ReflowComments: true
+BinPackArguments: true
+BinPackParameters: true
+AllowAllParametersOfDeclarationOnNextLine: true
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+MaxEmptyLinesToKeep: 2
+...

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,23 @@ on:
   workflow_dispatch: # Allows manual triggering
 
 jobs:
+  format-check:
+    name: C++ Format Check (clang-format)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Run clang-format check
+        run: |
+          find src/ -type f \( -name "*.cpp" -o -name "*.H" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.c" \) \
+            -exec clang-format --dry-run --Werror {} +
+
   build-and-test-openimpala: # Renamed job for clarity
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ These calculated coefficients can directly parameterize continuum-scale models, 
 * [Visualisation](#visualisation)
 * [Applications & Related Publications](#applications--related-publications)
 * [Contributing](#contributing)
+* [Code Formatting](#code-formatting)
 * [Citation](#citation)
 * [License](#license)
 * [Acknowledgements](#acknowledgements)
@@ -329,6 +330,32 @@ Contributions to OpenImpala are welcome! Whether it's reporting bugs, suggesting
         4.  Push your branch to your fork (`git push origin feature/my-new-feature`).
         5.  Submit a [Pull Request](https://github.com/kramergroup/openImpala/pulls) to the main repository.
 * **Documentation:** Improvements to the README, code comments, or other documentation are always appreciated. You can submit these via Pull Requests.
+
+## Code Formatting
+
+This project uses [clang-format](https://clang.llvm.org/docs/ClangFormat.html) to enforce a consistent C++ code style. A `.clang-format` configuration file is provided in the repository root.
+
+**CI enforces formatting** — pull requests with unformatted C++ code will fail the format check.
+
+### Running Locally
+
+To format all C++ files in-place:
+
+```bash
+find src/ -type f \( -name "*.cpp" -o -name "*.H" -o -name "*.h" -o -name "*.hpp" \) \
+  -exec clang-format -i {} +
+```
+
+To check for formatting issues without modifying files:
+
+```bash
+find src/ -type f \( -name "*.cpp" -o -name "*.H" -o -name "*.h" -o -name "*.hpp" \) \
+  -exec clang-format --dry-run --Werror {} +
+```
+
+> **Note:** Fortran files (`.F90`, `.f90`) are not covered by clang-format and should not be passed to it.
+
+---
 
 ## Citation
 

--- a/src/io/CathodeWrite.H
+++ b/src/io/CathodeWrite.H
@@ -17,13 +17,12 @@ namespace OpenImpala { // Wrap in project namespace
  *
  * @warning Document the EXPECTED UNITS for every parameter (e.g., SI units).
  */
-struct CathodeParams
-{
+struct CathodeParams {
     // Example parameters - ADD ALL NECESSARY PARAMETERS HERE
-    amrex::Real volume_fraction_solid = 0.5; // [-] Volume fraction of active material
-    amrex::Real particle_radius = 5e-6;      // [m] Average particle radius
+    amrex::Real volume_fraction_solid = 0.5;          // [-] Volume fraction of active material
+    amrex::Real particle_radius = 5e-6;               // [m] Average particle radius
     amrex::Real active_material_conductivity = 100.0; // [S/m] Solid phase conductivity
-    amrex::Real max_concentration = 51000.0; // [mol/m^3] Max concentration in solid
+    amrex::Real max_concentration = 51000.0;          // [mol/m^3] Max concentration in solid
     // Add diffusivity, reaction rates, porosity (1-vf), Bruggeman coeffs, etc.
     // Add thermal parameters if needed.
     // Add stoichiometric coefficients/ranges if needed.
@@ -40,8 +39,7 @@ struct CathodeParams
  * ParmParse in the future) and writes them into formatted files compatible
  * with specific battery simulation platforms like DandeLiion and PyBamm.
  */
-class CathodeWrite
-{
+class CathodeWrite {
 public:
     /**
      * @brief Constructs the CathodeWrite object using provided parameters.
@@ -69,7 +67,8 @@ public:
      * @param filename The full path and name for the output .txt parameter file.
      * @return true if the file was written successfully, false otherwise (e.g., file open error).
      */
-    bool writeDandeLiionParameters(const std::string& filename) const; // Mark const if state doesn't change
+    bool writeDandeLiionParameters(
+        const std::string& filename) const; // Mark const if state doesn't change
 
     /**
      * @brief Writes a parameter file compatible with the PyBamm model.
@@ -77,7 +76,8 @@ public:
      * @param filename The full path and name for the output .csv parameter file.
      * @return true if the file was written successfully, false otherwise (e.g., file open error).
      */
-    bool writePyBammParameters(const std::string& filename) const; // Mark const if state doesn't change
+    bool
+    writePyBammParameters(const std::string& filename) const; // Mark const if state doesn't change
 
 private:
     // --- Member Variables ---

--- a/src/io/CathodeWrite.cpp
+++ b/src/io/CathodeWrite.cpp
@@ -3,23 +3,22 @@
 #include <AMReX_REAL.H>
 #include <AMReX_Print.H> // For error/warning messages
 
-#include <fstream>   // For std::ofstream
-#include <string>    // For std::string
-#include <iomanip>   // For std::setprecision, std::scientific, std::fixed
-#include <cmath>     // For std::abs
-#include <limits>    // For std::numeric_limits
+#include <fstream> // For std::ofstream
+#include <string>  // For std::string
+#include <iomanip> // For std::setprecision, std::scientific, std::fixed
+#include <cmath>   // For std::abs
+#include <limits>  // For std::numeric_limits
 
 namespace OpenImpala {
 
 // Constructor: Initializes members from the CathodeParams struct
-CathodeWrite::CathodeWrite(const CathodeParams& params) :
-    // Initialize members by copying from the params struct
-    m_vf_solid(params.volume_fraction_solid),
-    m_particle_radius(params.particle_radius),
-    m_conductivity(params.active_material_conductivity),
-    m_max_concentration(params.max_concentration)
-    // Add initializers for ALL other necessary member variables here
-    // e.g., m_some_other_param(params.some_other_param)
+CathodeWrite::CathodeWrite(const CathodeParams& params)
+    : // Initialize members by copying from the params struct
+      m_vf_solid(params.volume_fraction_solid), m_particle_radius(params.particle_radius),
+      m_conductivity(params.active_material_conductivity),
+      m_max_concentration(params.max_concentration)
+// Add initializers for ALL other necessary member variables here
+// e.g., m_some_other_param(params.some_other_param)
 {
     // Optional: Add validation for parameters if needed
     if (m_vf_solid < 0.0 || m_vf_solid > 1.0) {
@@ -32,8 +31,7 @@ CathodeWrite::CathodeWrite(const CathodeParams& params) :
 }
 
 // Write DandeLiion parameter file
-bool CathodeWrite::writeDandeLiionParameters(const std::string& filename) const
-{
+bool CathodeWrite::writeDandeLiionParameters(const std::string& filename) const {
     std::ofstream myfile;
     myfile.open(filename);
 
@@ -69,29 +67,37 @@ bool CathodeWrite::writeDandeLiionParameters(const std::string& filename) const
     myfile << "# Units should correspond to DandeLiion expectations.     #\n";
     myfile << "###########################################################\n";
     myfile << "\n";
-    // Mesh nodes - these seem like simulation settings, not material params? Keep default or make configurable?
+    // Mesh nodes - these seem like simulation settings, not material params? Keep default or make
+    // configurable?
     myfile << "N = 55                # Number of mesh nodes in liquid (Example value)\n";
     myfile << "M = 50                # Number of mesh nodes in solid (Example value)\n";
     myfile << "\n";
     // Use member variables instead of hardcoded values - ADD ALL RELEVANT PARAMS
-    // myfile << "L = 54.0e-6           # Electrode thickness, m (Get from params?)\n"; // Example if thickness is needed
+    // myfile << "L = 54.0e-6           # Electrode thickness, m (Get from params?)\n"; // Example
+    // if thickness is needed
     myfile << "R = " << m_particle_radius << "          # Particle radius, m\n";
     myfile << "\n";
-    // myfile << "act     = 0.58            # Active part of the electrode (Get from params?)\n"; // Example
-    // myfile << "A       = 8.585e-3        # Electrode cross-sectional area, m^2 (Get from params?)\n"; // Example
-    myfile << "el      = " << porosity << "        # Volume fraction of electrolyte, Calculated (1 - vf_solid)\n";
-    myfile << "bet     = " << bet_surface_area << "  # BET surface area, m^-1 (Verify formula: 3*vf_solid/R ?)\n";
-    myfile << "B       = " << permeability_factor_B << "   # Permeability factor of electrolyte (Verify formula: el/1.94 ?)\n";
-    myfile << "cmax    = " << m_max_concentration << "   # Maximum concentration of Li ions in solid, mol m^-3\n";
+    // myfile << "act     = 0.58            # Active part of the electrode (Get from params?)\n"; //
+    // Example myfile << "A       = 8.585e-3        # Electrode cross-sectional area, m^2 (Get from
+    // params?)\n"; // Example
+    myfile << "el      = " << porosity
+           << "        # Volume fraction of electrolyte, Calculated (1 - vf_solid)\n";
+    myfile << "bet     = " << bet_surface_area
+           << "  # BET surface area, m^-1 (Verify formula: 3*vf_solid/R ?)\n";
+    myfile << "B       = " << permeability_factor_B
+           << "   # Permeability factor of electrolyte (Verify formula: el/1.94 ?)\n";
+    myfile << "cmax    = " << m_max_concentration
+           << "   # Maximum concentration of Li ions in solid, mol m^-3\n";
     myfile << "sigma_s = " << m_conductivity << "    # Solid conductivity, S m^-1\n";
     // ... ADD ALL OTHER REQUIRED PARAMETERS FROM MEMBER VARIABLES ...
     myfile << "###########################################################\n";
 
     // Check for write errors before returning
     if (!myfile.good()) {
-         amrex::Print() << "Error: An error occurred during file write operation for " << filename << "\n";
-         myfile.close(); // Attempt to close
-         return false;
+        amrex::Print() << "Error: An error occurred during file write operation for " << filename
+                       << "\n";
+        myfile.close(); // Attempt to close
+        return false;
     }
 
     myfile.close(); // Optional explicit close
@@ -100,8 +106,7 @@ bool CathodeWrite::writeDandeLiionParameters(const std::string& filename) const
 }
 
 // Write PyBamm parameter file
-bool CathodeWrite::writePyBammParameters(const std::string& filename) const
-{
+bool CathodeWrite::writePyBammParameters(const std::string& filename) const {
     std::ofstream myfile;
     myfile.open(filename);
 
@@ -121,7 +126,8 @@ bool CathodeWrite::writePyBammParameters(const std::string& filename) const
     if (m_particle_radius > std::numeric_limits<amrex::Real>::epsilon()) { // Avoid division by zero
         surface_area_density = 3.0 * m_vf_solid / m_particle_radius;
     } else {
-        amrex::Warning("PyBammWrite: Particle radius is near zero, cannot calculate surface area density.");
+        amrex::Warning(
+            "PyBammWrite: Particle radius is near zero, cannot calculate surface area density.");
     }
 
     // Set output formatting (PyBamm CSV might prefer fixed point for some values)
@@ -136,24 +142,35 @@ bool CathodeWrite::writePyBammParameters(const std::string& filename) const
     myfile << ",,,\n";
     myfile << "# Electrode properties,,,\n";
     // Use member variables instead of hardcoded values - ADD ALL RELEVANT PARAMS
-    myfile << "Positive electrode conductivity [S.m-1]," << m_conductivity << ",OpenImpala Calculated Parameter,\n"; // Example
-    myfile << "Maximum concentration in positive electrode [mol.m-3]," << m_max_concentration << ",OpenImpala Calculated Parameter,\n"; // Example
-    myfile << "Positive electrode diffusivity [m2.s-1],[function]lico2_diffusivity_Dualfoil1998,,Requires Function Definition in PyBamm\n"; // Example: Keep function defs if applicable
+    myfile << "Positive electrode conductivity [S.m-1]," << m_conductivity
+           << ",OpenImpala Calculated Parameter,\n"; // Example
+    myfile << "Maximum concentration in positive electrode [mol.m-3]," << m_max_concentration
+           << ",OpenImpala Calculated Parameter,\n"; // Example
+    myfile << "Positive electrode diffusivity "
+              "[m2.s-1],[function]lico2_diffusivity_Dualfoil1998,,Requires Function Definition in "
+              "PyBamm\n"; // Example: Keep function defs if applicable
     myfile << "Positive electrode OCP [V],[function]lico2_ocp_Dualfoil1998,,\n";
     myfile << ",,,\n";
     myfile << "# Microstructure,,,\n";
-    myfile << "Positive electrode porosity," << porosity << ",OpenImpala Calculated Parameter,electrolyte volume fraction (1 - vf_solid)\n";
-    myfile << "Positive electrode active material volume fraction," << m_vf_solid << ",OpenImpala Calculated Parameter,\n"; // Assuming vf_solid was input
-    myfile << "Positive particle radius [m]," << m_particle_radius << ",OpenImpala Calculated Parameter,\n";
-    myfile << "Positive electrode surface area density [m-1]," << surface_area_density << ",OpenImpala Calculated Parameter,Calculated as 3*vf_solid/R (Verify formula)\n";
-    // Assume Bruggeman coeffs are members initialized from CathodeParams, e.g., m_brugg_elec, m_brugg_solid
-    // myfile << "Positive electrode Bruggeman coefficient (electrolyte)," << m_brugg_elec << ",OpenImpala Calculated Parameter,\n";
-    // myfile << "Positive electrode Bruggeman coefficient (electrode)," << m_brugg_solid << ",OpenImpala Calculated Parameter,\n";
+    myfile << "Positive electrode porosity," << porosity
+           << ",OpenImpala Calculated Parameter,electrolyte volume fraction (1 - vf_solid)\n";
+    myfile << "Positive electrode active material volume fraction," << m_vf_solid
+           << ",OpenImpala Calculated Parameter,\n"; // Assuming vf_solid was input
+    myfile << "Positive particle radius [m]," << m_particle_radius
+           << ",OpenImpala Calculated Parameter,\n";
+    myfile << "Positive electrode surface area density [m-1]," << surface_area_density
+           << ",OpenImpala Calculated Parameter,Calculated as 3*vf_solid/R (Verify formula)\n";
+    // Assume Bruggeman coeffs are members initialized from CathodeParams, e.g., m_brugg_elec,
+    // m_brugg_solid myfile << "Positive electrode Bruggeman coefficient (electrolyte)," <<
+    // m_brugg_elec << ",OpenImpala Calculated Parameter,\n"; myfile << "Positive electrode
+    // Bruggeman coefficient (electrode)," << m_brugg_solid << ",OpenImpala Calculated
+    // Parameter,\n";
     myfile << ",,,\n";
     myfile << "# Interfacial reactions,,,\n";
     myfile << "Positive electrode cation signed stoichiometry,-1,,\n"; // Usually fixed
-    myfile << "Positive electrode electrons in reaction,1,,\n"; // Usually fixed
-    // myfile << "Positive electrode reference exchange-current density [A.m-2(m3.mol)1.5]," << m_exchange_current << ",OpenImpala Calculated Parameter,...\n"; // Example
+    myfile << "Positive electrode electrons in reaction,1,,\n";        // Usually fixed
+    // myfile << "Positive electrode reference exchange-current density [A.m-2(m3.mol)1.5]," <<
+    // m_exchange_current << ",OpenImpala Calculated Parameter,...\n"; // Example
     // ... Add ALL OTHER required parameters using member variables ...
     myfile << ",,,\n";
     // ... Other sections (Density, Thermal, Activation Energies) using member variables ...
@@ -162,9 +179,10 @@ bool CathodeWrite::writePyBammParameters(const std::string& filename) const
 
     // Check for write errors before returning
     if (!myfile.good()) {
-         amrex::Print() << "Error: An error occurred during file write operation for " << filename << "\n";
-         myfile.close(); // Attempt to close
-         return false;
+        amrex::Print() << "Error: An error occurred during file write operation for " << filename
+                       << "\n";
+        myfile.close(); // Attempt to close
+        return false;
     }
 
     myfile.close(); // Optional explicit close

--- a/src/io/DatReader.H
+++ b/src/io/DatReader.H
@@ -4,7 +4,7 @@
 #include <cstddef> // <--- ADD THIS LINE
 #include <vector>
 #include <string>
-#include <cstdint> // Use <cstdint> for fixed-width types
+#include <cstdint>   // Use <cstdint> for fixed-width types
 #include <stdexcept> // For exceptions in constructor
 
 #include <AMReX_REAL.H>
@@ -26,8 +26,7 @@ namespace OpenImpala {
  *
  * @warning Copying is disabled due to potentially large raw data size.
  */
-class DatReader
-{
+class DatReader {
 public:
     // --- Define the expected raw data type ---
     // IMPORTANT: Verify this matches the actual DAT file format!
@@ -113,12 +112,14 @@ public:
      * @param value_if_false The integer value to set otherwise.
      * @param mf Output amrex::iMultiFab reference to fill (must be defined).
      */
-    void threshold(DataType raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const;
+    void threshold(DataType raw_threshold, int value_if_true, int value_if_false,
+                   amrex::iMultiFab& mf) const;
 
     /**
      * @brief Returns the index space Box covering the entire image domain.
      * The Box typically starts at (0,0,0).
-     * @return amrex::Box representing the full image dimensions. Returns empty box if data not read.
+     * @return amrex::Box representing the full image dimensions. Returns empty box if data not
+     * read.
      */
     amrex::Box box() const;
 
@@ -158,12 +159,12 @@ private:
     bool readDatFileInternal();
 
     // --- Member Variables ---
-    std::string m_filename;             /**< Filename of the source Dat file */
-    std::vector<DataType> m_raw;        /**< Vector containing the raw data (verify DataType!) */
-    int m_width = 0;                    /**< Width of the domain (X) */
-    int m_height = 0;                   /**< Height of the domain (Y) */
-    int m_depth = 0;                    /**< Depth of the domain (Z) */
-    bool m_is_read = false;             /**< Flag indicating if data has been successfully read */
+    std::string m_filename;      /**< Filename of the source Dat file */
+    std::vector<DataType> m_raw; /**< Vector containing the raw data (verify DataType!) */
+    int m_width = 0;             /**< Width of the domain (X) */
+    int m_height = 0;            /**< Height of the domain (Y) */
+    int m_depth = 0;             /**< Depth of the domain (Z) */
+    bool m_is_read = false;      /**< Flag indicating if data has been successfully read */
 
 }; // class DatReader
 

--- a/src/io/HDF5Reader.H
+++ b/src/io/HDF5Reader.H
@@ -31,8 +31,7 @@ namespace OpenImpala {
  * data needed for its owned patches. For true parallel I/O performance,
  * parallel HDF5 features would be needed.
  */
-class HDF5Reader
-{
+class HDF5Reader {
 public:
     /**
      * @brief Default constructor. Creates an empty reader. Use readFile() later.
@@ -48,7 +47,8 @@ public:
      *
      * @param filename Path to the HDF5 file.
      * @param hdf5dataset Full path to the 3D dataset within the HDF5 file (e.g., "/group/data").
-     * @throws std::runtime_error on HDF5 errors (file not found, dataset not found, invalid rank, etc.).
+     * @throws std::runtime_error on HDF5 errors (file not found, dataset not found, invalid rank,
+     * etc.).
      */
     explicit HDF5Reader(const std::string& filename, const std::string& hdf5dataset);
 
@@ -95,14 +95,15 @@ public:
     void threshold(double raw_threshold, amrex::iMultiFab& mf) const;
 
     /**
-     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding with custom output values.
+     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding with custom output
+     * values.
      *
      * Iterates through the patches of the output iMultiFab `mf`. For each patch,
      * reads the corresponding hyperslab from the HDF5 dataset and fills the
      * patch's FArrayBox based on the threshold comparison.
-     * Sets output cells to `value_if_true` if `native_value > raw_threshold`, else `value_if_false`.
-     * Assumes mf is defined on a box compatible with the dataset dimensions read previously.
-     * Handles conversion from native HDF5 type to double for comparison.
+     * Sets output cells to `value_if_true` if `native_value > raw_threshold`, else
+     * `value_if_false`. Assumes mf is defined on a box compatible with the dataset dimensions read
+     * previously. Handles conversion from native HDF5 type to double for comparison.
      *
      * @param raw_threshold The threshold value (compared against data converted to double).
      * @param value_if_true The integer value to set if condition is true.
@@ -110,11 +111,14 @@ public:
      * @param mf Output amrex::iMultiFab reference to fill (must be defined).
      * @throws std::runtime_error on HDF5 read errors or if metadata not read.
      */
-    void threshold(double raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const;
+    void threshold(double raw_threshold, int value_if_true, int value_if_false,
+                   amrex::iMultiFab& mf) const;
 
     /**
-     * @brief Returns the index space Box covering the entire image domain [0, w-1] x [0, h-1] x [0, d-1].
-     * @return amrex::Box representing the full image dimensions. Returns empty box if metadata not read.
+     * @brief Returns the index space Box covering the entire image domain [0, w-1] x [0, h-1] x [0,
+     * d-1].
+     * @return amrex::Box representing the full image dimensions. Returns empty box if metadata not
+     * read.
      */
     amrex::Box box() const;
 
@@ -137,15 +141,20 @@ public:
     /**
      * @brief Reads all attributes from the HDF5 dataset.
      * Attempts to read attribute values as strings.
-     * @return A map of attribute names to string values. Returns empty map if no attributes or error.
+     * @return A map of attribute names to string values. Returns empty map if no attributes or
+     * error.
      */
     std::map<std::string, std::string> getAllAttributes() const;
 
     /** @brief Check if metadata has been successfully read. */
-    bool isRead() const { return m_is_read; }
+    bool isRead() const {
+        return m_is_read;
+    }
 
     /** @brief Get the native HDF5 data type detected in the dataset. */
-    H5::DataType getNativeDataType() const { return m_native_type; }
+    H5::DataType getNativeDataType() const {
+        return m_native_type;
+    }
 
 
 private:
@@ -159,19 +168,19 @@ private:
 
     // Template function to read a hyperslab and apply thresholding
     // Needed because the native type read from file varies.
-    template<typename T_Native>
-    void readAndThresholdFab(H5::DataSet& dataset, double raw_threshold,
-                             int value_if_true, int value_if_false,
-                             const amrex::Box& box, amrex::IArrayBox& fab) const;
+    template <typename T_Native>
+    void readAndThresholdFab(H5::DataSet& dataset, double raw_threshold, int value_if_true,
+                             int value_if_false, const amrex::Box& box,
+                             amrex::IArrayBox& fab) const;
 
     // --- Member Variables ---
-    std::string m_filename;         /**< Filename of the source HDF5 file */
-    std::string m_hdf5dataset;      /**< Path to the dataset within the HDF5 file */
-    int m_width = 0;                /**< Width of the domain (X) */
-    int m_height = 0;               /**< Height of the domain (Y) */
-    int m_depth = 0;                /**< Depth of the domain (Z) */
-    bool m_is_read = false;         /**< Flag indicating if *metadata* has been successfully read */
-    H5::DataType m_native_type;     /**< Detected native HDF5 data type of the dataset */
+    std::string m_filename;     /**< Filename of the source HDF5 file */
+    std::string m_hdf5dataset;  /**< Path to the dataset within the HDF5 file */
+    int m_width = 0;            /**< Width of the domain (X) */
+    int m_height = 0;           /**< Height of the domain (Y) */
+    int m_depth = 0;            /**< Depth of the domain (Z) */
+    bool m_is_read = false;     /**< Flag indicating if *metadata* has been successfully read */
+    H5::DataType m_native_type; /**< Detected native HDF5 data type of the dataset */
 
 }; // class HDF5Reader
 

--- a/src/io/HDF5Reader.cpp
+++ b/src/io/HDF5Reader.cpp
@@ -19,11 +19,11 @@
 #include <AMReX_iMultiFab.H>
 #include <AMReX_GpuContainers.H> // For amrex::The_Pinned_Arena, amrex::ParallelFor
 #include <AMReX_Utility.H>
-#include <AMReX_MFIter.H>       // Needed for MFIter
-#include <AMReX_BaseFab.H>      // Needed for BaseFab<T> temporary buffer
-#include <AMReX_Array4.H>       // Needed for Array4 access
+#include <AMReX_MFIter.H>             // Needed for MFIter
+#include <AMReX_BaseFab.H>            // Needed for BaseFab<T> temporary buffer
+#include <AMReX_Array4.H>             // Needed for Array4 access
 #include <AMReX_ParallelDescriptor.H> // Needed for IOProcessor
-#include <AMReX_GpuAssert.H>    // Needed for AMREX_ASSERT (Can likely remove if not using)
+#include <AMReX_GpuAssert.H>          // Needed for AMREX_ASSERT (Can likely remove if not using)
 
 // --- HDF5 C++ API Include ---
 #include <H5Cpp.h>
@@ -47,28 +47,28 @@ std::string readAttributeAsString(const H5::H5Object& obj, const std::string& at
             H5::StrType str_type = attr.getStrType();
             attr.read(type, value);
         } else {
-             // Attempt to read as double/int and convert to string for non-string types
-             try {
-                 if (type.getSize() == sizeof(double) && type.getClass() == H5T_FLOAT) {
-                     double dval;
-                     attr.read(H5::PredType::NATIVE_DOUBLE, &dval);
-                     value = std::to_string(dval);
-                 } else if (type.getSize() == sizeof(int) && type.getClass() == H5T_INTEGER) {
-                     int ival;
-                     attr.read(H5::PredType::NATIVE_INT, &ival);
-                     value = std::to_string(ival);
-                 } // Add more types as needed
-                 else {
-                     value = "<Non-string/unhandled Attribute>";
-                 }
-             } catch (...) { // Catch potential errors during non-string read/convert
-                 value = "<Attribute Read Error>";
-             }
+            // Attempt to read as double/int and convert to string for non-string types
+            try {
+                if (type.getSize() == sizeof(double) && type.getClass() == H5T_FLOAT) {
+                    double dval;
+                    attr.read(H5::PredType::NATIVE_DOUBLE, &dval);
+                    value = std::to_string(dval);
+                } else if (type.getSize() == sizeof(int) && type.getClass() == H5T_INTEGER) {
+                    int ival;
+                    attr.read(H5::PredType::NATIVE_INT, &ival);
+                    value = std::to_string(ival);
+                } // Add more types as needed
+                else {
+                    value = "<Non-string/unhandled Attribute>";
+                }
+            } catch (...) { // Catch potential errors during non-string read/convert
+                value = "<Attribute Read Error>";
+            }
         }
-    } catch (H5::Exception& /*error*/) { // Catch HDF5 error specifically
-         value = "<Attribute not found>"; // More specific error
+    } catch (H5::Exception& /*error*/) {    // Catch HDF5 error specifically
+        value = "<Attribute not found>";    // More specific error
     } catch (std::exception& /*std_err*/) { // Catch other potential errors
-         value = "<Attribute Read Error>";
+        value = "<Attribute Read Error>";
     }
     return value;
 }
@@ -79,16 +79,14 @@ std::string readAttributeAsString(const H5::H5Object& obj, const std::string& at
 // Constructor Implementations
 //-----------------------------------------------------------------------
 
-HDF5Reader::HDF5Reader() :
-    m_width(0), m_height(0), m_depth(0), m_is_read(false)
-{
+HDF5Reader::HDF5Reader() : m_width(0), m_height(0), m_depth(0), m_is_read(false) {
     // Initialize native type to something invalid/default
     m_native_type = H5::DataType(H5::PredType::NATIVE_DOUBLE); // Example default
 }
 
 // Constructor that reads metadata and throws on error
-HDF5Reader::HDF5Reader(const std::string& filename, const std::string& hdf5dataset) :
-    HDF5Reader() // Delegate for default member initialization
+HDF5Reader::HDF5Reader(const std::string& filename, const std::string& hdf5dataset)
+    : HDF5Reader() // Delegate for default member initialization
 {
     if (!readFile(filename, hdf5dataset)) {
         throw std::runtime_error("HDF5Reader: Failed to read metadata for dataset '" + hdf5dataset +
@@ -100,18 +98,18 @@ HDF5Reader::HDF5Reader(const std::string& filename, const std::string& hdf5datas
 // Metadata Reading Implementation
 //-----------------------------------------------------------------------
 
-bool HDF5Reader::readFile(const std::string& filename, const std::string& hdf5dataset)
-{
+bool HDF5Reader::readFile(const std::string& filename, const std::string& hdf5dataset) {
     m_filename = filename;
     m_hdf5dataset = hdf5dataset;
     return readMetadataInternal(); // Delegate to internal implementation
 }
 
 // Internal implementation using HDF5 C++ API to read METADATA ONLY
-bool HDF5Reader::readMetadataInternal()
-{
+bool HDF5Reader::readMetadataInternal() {
     // Reset state before reading
-    m_width = 0; m_height = 0; m_depth = 0;
+    m_width = 0;
+    m_height = 0;
+    m_depth = 0;
     m_is_read = false;
     m_native_type = H5::DataType(H5::PredType::NATIVE_DOUBLE); // Reset type
 
@@ -130,7 +128,8 @@ bool HDF5Reader::readMetadataInternal()
             return false;
         }
         hsize_t file_dims[3];
-        // NOTE: HDF5 C API typically returns dimensions in C-order (slowest to fastest index: e.g., Z, Y, X)
+        // NOTE: HDF5 C API typically returns dimensions in C-order (slowest to fastest index: e.g.,
+        // Z, Y, X)
         dataspace.getSimpleExtentDims(file_dims);
 
         // Assuming file_dims[0]=Z, file_dims[1]=Y, file_dims[2]=X for C order
@@ -141,21 +140,21 @@ bool HDF5Reader::readMetadataInternal()
         // Store dimensions as int, check for potential overflow
         if (file_dims[0] > static_cast<hsize_t>(std::numeric_limits<int>::max()) ||
             file_dims[1] > static_cast<hsize_t>(std::numeric_limits<int>::max()) ||
-            file_dims[2] > static_cast<hsize_t>(std::numeric_limits<int>::max()))
-        {
+            file_dims[2] > static_cast<hsize_t>(std::numeric_limits<int>::max())) {
             amrex::Print() << "Error: [HDF5Reader] Dataset dimensions exceed integer limits.\n";
             return false;
         }
 
         // Store in AMReX convention (Width=X, Height=Y, Depth=Z)
-        m_width  = dim_x;
+        m_width = dim_x;
         m_height = dim_y;
-        m_depth  = dim_z;
+        m_depth = dim_z;
 
         if (m_width <= 0 || m_height <= 0 || m_depth <= 0) {
-             amrex::Print() << "Error: [HDF5Reader] Invalid dimensions read from dataset in " << m_filename
-                            << " (X=" << m_width << ", Y=" << m_height << ", Z=" << m_depth << ")\n";
-             return false;
+            amrex::Print() << "Error: [HDF5Reader] Invalid dimensions read from dataset in "
+                           << m_filename << " (X=" << m_width << ", Y=" << m_height
+                           << ", Z=" << m_depth << ")\n";
+            return false;
         }
 
         // --- Get and Store Native Data Type ---
@@ -165,8 +164,9 @@ bool HDF5Reader::readMetadataInternal()
 
         m_is_read = true; // Metadata read successfully
         if (amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "Successfully read HDF5 Metadata: " << m_filename << " [" << m_hdf5dataset << "]"
-                            << " (Dimensions: X=" << m_width << ", Y=" << m_height << ", Z=" << m_depth << ")\n";
+            amrex::Print() << "Successfully read HDF5 Metadata: " << m_filename << " ["
+                           << m_hdf5dataset << "]" << " (Dimensions: X=" << m_width
+                           << ", Y=" << m_height << ", Z=" << m_depth << ")\n";
         }
         return true;
 
@@ -178,7 +178,8 @@ bool HDF5Reader::readMetadataInternal()
         m_is_read = false;
         return false;
     } catch (std::exception& std_err) {
-        std::string err_msg = "Standard Exception during HDF5Reader metadata read: " + std::string(std_err.what());
+        std::string err_msg =
+            "Standard Exception during HDF5Reader metadata read: " + std::string(std_err.what());
         amrex::Warning(err_msg.c_str());
         m_width = m_height = m_depth = 0;
         m_is_read = false;
@@ -189,11 +190,18 @@ bool HDF5Reader::readMetadataInternal()
 //-----------------------------------------------------------------------
 // Getter Implementations
 //-----------------------------------------------------------------------
-int HDF5Reader::width() const { return m_width; }
-int HDF5Reader::height() const { return m_height; }
-int HDF5Reader::depth() const { return m_depth; }
+int HDF5Reader::width() const {
+    return m_width;
+}
+int HDF5Reader::height() const {
+    return m_height;
+}
+int HDF5Reader::depth() const {
+    return m_depth;
+}
 amrex::Box HDF5Reader::box() const {
-    if (!m_is_read) return amrex::Box();
+    if (!m_is_read)
+        return amrex::Box();
     // AMReX Box uses (X, Y, Z) convention
     return amrex::Box(amrex::IntVect::TheZeroVector(),
                       amrex::IntVect(m_width - 1, m_height - 1, m_depth - 1));
@@ -220,31 +228,33 @@ std::string HDF5Reader::getAttribute(const std::string& attr_name) const {
 }
 
 std::map<std::string, std::string> HDF5Reader::getAllAttributes() const {
-     std::map<std::string, std::string> attributes;
-     if (!m_is_read) {
-         return attributes; // Return empty map
-     }
-     try {
-         H5::H5File file(m_filename, H5F_ACC_RDONLY);
-         H5::DataSet dataset = file.openDataSet(m_hdf5dataset);
-         int num_attrs = dataset.getNumAttrs();
+    std::map<std::string, std::string> attributes;
+    if (!m_is_read) {
+        return attributes; // Return empty map
+    }
+    try {
+        H5::H5File file(m_filename, H5F_ACC_RDONLY);
+        H5::DataSet dataset = file.openDataSet(m_hdf5dataset);
+        int num_attrs = dataset.getNumAttrs();
 
-         for (int i = 0; i < num_attrs; ++i) {
-             H5::Attribute attr = dataset.openAttribute(static_cast<unsigned int>(i));
-             std::string name = attr.getName();
-             attributes[name] = readAttributeAsString(dataset, name); // Reuse helper
-         }
-     } catch (H5::Exception& error) {
-         std::string warn_msg = "HDF5 Warning in HDF5Reader::getAllAttributes for file '" + m_filename +
-                                "', dataset '" + m_hdf5dataset + "':\n  " + error.getDetailMsg();
-         amrex::Warning(warn_msg.c_str());
-         attributes.clear();
-     } catch (std::exception& std_err) {
-         std::string err_msg = "Standard Exception in HDF5Reader::getAllAttributes: " + std::string(std_err.what());
-         amrex::Warning(err_msg.c_str());
-         attributes.clear();
-     }
-     return attributes;
+        for (int i = 0; i < num_attrs; ++i) {
+            H5::Attribute attr = dataset.openAttribute(static_cast<unsigned int>(i));
+            std::string name = attr.getName();
+            attributes[name] = readAttributeAsString(dataset, name); // Reuse helper
+        }
+    } catch (H5::Exception& error) {
+        std::string warn_msg = "HDF5 Warning in HDF5Reader::getAllAttributes for file '" +
+                               m_filename + "', dataset '" + m_hdf5dataset + "':\n  " +
+                               error.getDetailMsg();
+        amrex::Warning(warn_msg.c_str());
+        attributes.clear();
+    } catch (std::exception& std_err) {
+        std::string err_msg =
+            "Standard Exception in HDF5Reader::getAllAttributes: " + std::string(std_err.what());
+        amrex::Warning(err_msg.c_str());
+        attributes.clear();
+    }
+    return attributes;
 }
 
 //-----------------------------------------------------------------------
@@ -252,24 +262,35 @@ std::map<std::string, std::string> HDF5Reader::getAllAttributes() const {
 //-----------------------------------------------------------------------
 
 // Private template helper function with corrected memspace and dimension ordering
-template<typename T_Native>
-void HDF5Reader::readAndThresholdFab(H5::DataSet& dataset, double raw_threshold,
-                                     int value_if_true, int value_if_false,
-                                     const amrex::Box& box, amrex::IArrayBox& fab) const
-{
+template <typename T_Native>
+void HDF5Reader::readAndThresholdFab(H5::DataSet& dataset, double raw_threshold, int value_if_true,
+                                     int value_if_false, const amrex::Box& box,
+                                     amrex::IArrayBox& fab) const {
     // Determine PredType
     H5::PredType native_pred_type = H5::PredType::NATIVE_DOUBLE; // Default/fallback
-    if constexpr (std::is_same_v<T_Native, uint8_t>)  { native_pred_type = H5::PredType::NATIVE_UINT8; }
-    else if constexpr (std::is_same_v<T_Native, int8_t>)   { native_pred_type = H5::PredType::NATIVE_INT8; }
-    else if constexpr (std::is_same_v<T_Native, uint16_t>) { native_pred_type = H5::PredType::NATIVE_UINT16; }
-    else if constexpr (std::is_same_v<T_Native, int16_t>)  { native_pred_type = H5::PredType::NATIVE_INT16; }
-    else if constexpr (std::is_same_v<T_Native, uint32_t>) { native_pred_type = H5::PredType::NATIVE_UINT32; }
-    else if constexpr (std::is_same_v<T_Native, int32_t>)  { native_pred_type = H5::PredType::NATIVE_INT32; }
-    else if constexpr (std::is_same_v<T_Native, uint64_t>) { native_pred_type = H5::PredType::NATIVE_UINT64; }
-    else if constexpr (std::is_same_v<T_Native, int64_t>)  { native_pred_type = H5::PredType::NATIVE_INT64; }
-    else if constexpr (std::is_same_v<T_Native, float>)   { native_pred_type = H5::PredType::NATIVE_FLOAT; }
-    else if constexpr (std::is_same_v<T_Native, double>)   { native_pred_type = H5::PredType::NATIVE_DOUBLE; }
-    else { amrex::Abort("readAndThresholdFab: Unsupported native type T_Native"); }
+    if constexpr (std::is_same_v<T_Native, uint8_t>) {
+        native_pred_type = H5::PredType::NATIVE_UINT8;
+    } else if constexpr (std::is_same_v<T_Native, int8_t>) {
+        native_pred_type = H5::PredType::NATIVE_INT8;
+    } else if constexpr (std::is_same_v<T_Native, uint16_t>) {
+        native_pred_type = H5::PredType::NATIVE_UINT16;
+    } else if constexpr (std::is_same_v<T_Native, int16_t>) {
+        native_pred_type = H5::PredType::NATIVE_INT16;
+    } else if constexpr (std::is_same_v<T_Native, uint32_t>) {
+        native_pred_type = H5::PredType::NATIVE_UINT32;
+    } else if constexpr (std::is_same_v<T_Native, int32_t>) {
+        native_pred_type = H5::PredType::NATIVE_INT32;
+    } else if constexpr (std::is_same_v<T_Native, uint64_t>) {
+        native_pred_type = H5::PredType::NATIVE_UINT64;
+    } else if constexpr (std::is_same_v<T_Native, int64_t>) {
+        native_pred_type = H5::PredType::NATIVE_INT64;
+    } else if constexpr (std::is_same_v<T_Native, float>) {
+        native_pred_type = H5::PredType::NATIVE_FLOAT;
+    } else if constexpr (std::is_same_v<T_Native, double>) {
+        native_pred_type = H5::PredType::NATIVE_DOUBLE;
+    } else {
+        amrex::Abort("readAndThresholdFab: Unsupported native type T_Native");
+    }
 
     // (Removed DEBUG prints at function entry)
 
@@ -300,9 +321,9 @@ void HDF5Reader::readAndThresholdFab(H5::DataSet& dataset, double raw_threshold,
     // Define memory dataspace
     // Using 3D memory dataspace (matching hyperslab rank)
     hsize_t mem_dims_3d[3];
-    mem_dims_3d[0] = count[0]; // Size Z
-    mem_dims_3d[1] = count[1]; // Size Y
-    mem_dims_3d[2] = count[2]; // Size X
+    mem_dims_3d[0] = count[0];              // Size Z
+    mem_dims_3d[1] = count[1];              // Size Y
+    mem_dims_3d[2] = count[2];              // Size X
     H5::DataSpace memspace(3, mem_dims_3d); // 3D version
 
     // (Removed DEBUG print for memory dataspace definition)
@@ -314,26 +335,27 @@ void HDF5Reader::readAndThresholdFab(H5::DataSet& dataset, double raw_threshold,
 
     // Apply threshold using Array4 interface
     amrex::Array4<int> const& fab_arr = fab.array(); // Target iMultiFab Array4
-    amrex::Array4<const T_Native> const& temp_arr = temp_fab.const_array(); // Source temp data Array4
+    amrex::Array4<const T_Native> const& temp_arr =
+        temp_fab.const_array(); // Source temp data Array4
 
     // Use ParallelFor for potential OMP/GPU execution
     // Restored noexcept, removed try-catch & asserts
-    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-    {
+    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         // Original logic
         double value_as_double = static_cast<double>(temp_arr(i, j, k));
         fab_arr(i, j, k) = (value_as_double > raw_threshold) ? value_if_true : value_if_false;
     });
 
-     // (Removed DEBUG print after ParallelFor)
+    // (Removed DEBUG print after ParallelFor)
 }
 
 
 // Public threshold method - determines native type and calls template helper
-void HDF5Reader::threshold(double raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const
-{
+void HDF5Reader::threshold(double raw_threshold, int value_if_true, int value_if_false,
+                           amrex::iMultiFab& mf) const {
     if (!m_is_read) {
-        throw std::runtime_error("[HDF5Reader::threshold] Cannot threshold, metadata not read successfully.");
+        throw std::runtime_error(
+            "[HDF5Reader::threshold] Cannot threshold, metadata not read successfully.");
     }
 
     try {
@@ -357,53 +379,67 @@ void HDF5Reader::threshold(double raw_threshold, int value_if_true, int value_if
 
             // Dispatch based on stored native type
             if (m_native_type == H5::PredType::NATIVE_UINT8) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<uint8_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<uint8_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                             tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_INT8) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<int8_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<int8_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                            tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_UINT16) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<uint16_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<uint16_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                              tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_INT16) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<int16_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<int16_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                             tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_UINT32) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<uint32_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<uint32_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                              tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_INT32) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<int32_t>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<int32_t>(dataset, raw_threshold, value_if_true, value_if_false,
+                                             tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_FLOAT) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<float>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<float>(dataset, raw_threshold, value_if_true, value_if_false,
+                                           tile_box, fab);
             } else if (m_native_type == H5::PredType::NATIVE_DOUBLE) {
-                 // (Removed DEBUG print for dispatch type)
-                 readAndThresholdFab<double>(dataset, raw_threshold, value_if_true, value_if_false, tile_box, fab);
+                // (Removed DEBUG print for dispatch type)
+                readAndThresholdFab<double>(dataset, raw_threshold, value_if_true, value_if_false,
+                                            tile_box, fab);
             }
             // Add cases for NATIVE_LONG, NATIVE_ULONG, INT64, UINT64 etc. if needed
             else {
-                 // Handle unsupported type (Corrected error reporting)
-                 H5T_class_t type_class_enum = m_native_type.getClass(); // Correct type
-                 std::string err_msg = "[HDF5Reader::threshold] Unsupported native HDF5 data type detected in file. Class enum value: "
-                                     + std::to_string(static_cast<int>(type_class_enum));
-                 try { err_msg += ", Size (bytes): " + std::to_string(m_native_type.getSize()); } catch (...) {}
-                 throw std::runtime_error(err_msg);
+                // Handle unsupported type (Corrected error reporting)
+                H5T_class_t type_class_enum = m_native_type.getClass(); // Correct type
+                std::string err_msg = "[HDF5Reader::threshold] Unsupported native HDF5 data type "
+                                      "detected in file. Class enum value: " +
+                                      std::to_string(static_cast<int>(type_class_enum));
+                try {
+                    err_msg += ", Size (bytes): " + std::to_string(m_native_type.getSize());
+                } catch (...) {}
+                throw std::runtime_error(err_msg);
             }
         } // End MFIter loop
 
     } catch (H5::Exception& error) {
         // Catch HDF5 specific exceptions during file/dataset open or read
-        throw std::runtime_error("[HDF5Reader::threshold] HDF5 Error during threshold operation:\n  " + error.getDetailMsg());
+        throw std::runtime_error(
+            "[HDF5Reader::threshold] HDF5 Error during threshold operation:\n  " +
+            error.getDetailMsg());
     } catch (std::exception& std_err) {
         // Catch standard exceptions (e.g., from type dispatch error, ParallelFor)
-        throw std::runtime_error("[HDF5Reader::threshold] Standard Exception during threshold operation: " + std::string(std_err.what()));
+        throw std::runtime_error(
+            "[HDF5Reader::threshold] Standard Exception during threshold operation: " +
+            std::string(std_err.what()));
     }
 }
 
 // Original overload (output 1/0) - calls the flexible version
-void HDF5Reader::threshold(double raw_threshold, amrex::iMultiFab& mf) const
-{
+void HDF5Reader::threshold(double raw_threshold, amrex::iMultiFab& mf) const {
     threshold(raw_threshold, 1, 0, mf); // Call the flexible version with 1/0
 }
 

--- a/src/io/RawReader.H
+++ b/src/io/RawReader.H
@@ -31,7 +31,8 @@ enum class RawDataType {
     UNKNOWN,    ///< Default, indicating an uninitialized or invalid type.
     UINT8,      ///< 8-bit unsigned integer (char, byte). Endianness irrelevant.
     INT8,       ///< 8-bit signed integer (signed char). Endianness irrelevant.
-    INT16_LE,   ///< 16-bit signed integer, Little Endian (least significant byte first, common on x86).
+    INT16_LE,   ///< 16-bit signed integer, Little Endian (least significant byte first, common on
+                ///< x86).
     INT16_BE,   ///< 16-bit signed integer, Big Endian (most significant byte first).
     UINT16_LE,  ///< 16-bit unsigned integer, Little Endian.
     UINT16_BE,  ///< 16-bit unsigned integer, Big Endian.
@@ -62,8 +63,7 @@ enum class RawDataType {
  * potential byte swapping between the file's endianness and the host
  * machine's endianness if they differ.
  */
-class RawReader
-{
+class RawReader {
 public:
     /**
      * @brief Type alias for the underlying byte storage.
@@ -96,8 +96,7 @@ public:
      * Must not be `RawDataType::UNKNOWN`.
      * @throws std::runtime_error If reading or validation fails.
      */
-    explicit RawReader(const std::string& filename,
-                       int width, int height, int depth,
+    explicit RawReader(const std::string& filename, int width, int height, int depth,
                        RawDataType data_type);
 
     /**
@@ -135,8 +134,7 @@ public:
      * Must not be `RawDataType::UNKNOWN`.
      * @return `true` if the file was read and validated successfully, `false` otherwise.
      */
-    bool readFile(const std::string& filename,
-                  int width, int height, int depth,
+    bool readFile(const std::string& filename, int width, int height, int depth,
                   RawDataType data_type);
 
     /**
@@ -211,17 +209,19 @@ public:
      * - Otherwise (including if the cell is outside the raw data bounds), the cell
      * in `mf` is set to `value_if_false`.
      *
-     * @param threshold_value The value to compare against. The comparison is strictly greater than (>).
+     * @param threshold_value The value to compare against. The comparison is strictly greater than
+     * (>).
      * @param value_if_true The integer value to write to `mf` for cells exceeding the threshold.
-     * @param value_if_false The integer value to write to `mf` for cells not exceeding the threshold
-     * or outside the bounds of the raw data.
+     * @param value_if_false The integer value to write to `mf` for cells not exceeding the
+     * threshold or outside the bounds of the raw data.
      * @param[out] mf The `amrex::iMultiFab` to be filled. It must be defined (allocated) and
      * is expected to have exactly one component (`nComp() == 1`). The operation
      * is performed in parallel using OpenMP if available.
      * @throws std::runtime_error If the reader is not in a valid state (`isRead()` is false) or
      * if `mf.nComp() != 1`.
      */
-    void threshold(double threshold_value, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const;
+    void threshold(double threshold_value, int value_if_true, int value_if_false,
+                   amrex::iMultiFab& mf) const;
 
     /**
      * @brief Fills an AMReX iMultiFab based on thresholding the raw data (outputting 1 or 0).
@@ -231,7 +231,8 @@ public:
      * mask in the `iMultiFab` where cells corresponding to raw data values greater
      * than `threshold_value` are set to 1, and all others are set to 0.
      *
-     * @param threshold_value The value to compare against. The comparison is strictly greater than (>).
+     * @param threshold_value The value to compare against. The comparison is strictly greater than
+     * (>).
      * @param[out] mf The `amrex::iMultiFab` to be filled. It must be defined (allocated) and
      * is expected to have exactly one component (`nComp() == 1`).
      * @throws std::runtime_error If the reader is not in a valid state (`isRead()` is false) or
@@ -251,8 +252,8 @@ private:
 
     /**
      * @brief Calculates the size in bytes of a single voxel based on the stored `m_data_type`.
-     * @return The number of bytes per voxel (e.g., 1 for UINT8, 2 for INT16, 4 for FLOAT32, 8 for FLOAT64).
-     * Returns 0 if `m_data_type` is `UNKNOWN`.
+     * @return The number of bytes per voxel (e.g., 1 for UINT8, 2 for INT16, 4 for FLOAT32, 8 for
+     * FLOAT64). Returns 0 if `m_data_type` is `UNKNOWN`.
      */
     size_t getBytesPerVoxel() const;
 
@@ -265,16 +266,21 @@ private:
 
 
     // --- Member Variables ---
-    std::string m_filename;       ///< Stores the path to the source raw file provided to the constructor or `readFile`.
-    int m_width = 0;              ///< Width (X dimension) of the dataset in voxels, set by constructor or `readFile`.
-    int m_height = 0;             ///< Height (Y dimension) of the dataset in voxels, set by constructor or `readFile`.
-    int m_depth = 0;              ///< Depth (Z dimension) of the dataset in voxels, set by constructor or `readFile`.
-    RawDataType m_data_type = RawDataType::UNKNOWN; ///< Data type (incl. endianness) specified for the file's content.
+    std::string m_filename; ///< Stores the path to the source raw file provided to the constructor
+                            ///< or `readFile`.
+    int m_width =
+        0; ///< Width (X dimension) of the dataset in voxels, set by constructor or `readFile`.
+    int m_height =
+        0; ///< Height (Y dimension) of the dataset in voxels, set by constructor or `readFile`.
+    int m_depth =
+        0; ///< Depth (Z dimension) of the dataset in voxels, set by constructor or `readFile`.
+    RawDataType m_data_type =
+        RawDataType::UNKNOWN; ///< Data type (incl. endianness) specified for the file's content.
 
     // Internal buffer holding the raw byte data read from the file.
     std::vector<ByteType> m_raw_bytes; ///< Contiguous storage for all voxel data as raw bytes.
 
-    bool m_is_read = false;       ///< Status flag indicating if data was successfully read and validated.
+    bool m_is_read = false; ///< Status flag indicating if data was successfully read and validated.
 };
 
 } // namespace OpenImpala

--- a/src/io/RawReader.cpp
+++ b/src/io/RawReader.cpp
@@ -1,6 +1,6 @@
 #include "RawReader.H"
 
-#include <fstream>   // For std::ifstream
+#include <fstream> // For std::ifstream
 #include <vector>
 #include <string>
 #include <stdexcept> // For std::runtime_error
@@ -14,9 +14,9 @@
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H> // Needed for the fix
 #include <AMReX_iMultiFab.H>
-#include <AMReX_GpuContainers.H> // For amrex::LoopOnCpu
-#include <AMReX_Extension.H>     // For AMREX_ALWAYS_ASSERT_WITH_MESSAGE
-#include <AMReX_GpuQualifiers.H> // For AMREX_FORCE_INLINE
+#include <AMReX_GpuContainers.H>      // For amrex::LoopOnCpu
+#include <AMReX_Extension.H>          // For AMREX_ALWAYS_ASSERT_WITH_MESSAGE
+#include <AMReX_GpuQualifiers.H>      // For AMREX_FORCE_INLINE
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor
 
 namespace OpenImpala {
@@ -40,22 +40,23 @@ const static bool host_is_little_endian = determineHostEndianness();
 
 // Helper function to reconstruct value from bytes, handling endianness
 template <typename T>
-AMREX_FORCE_INLINE T reconstructValue(const RawReader::ByteType* src_ptr, const size_t bytes_to_read, const bool needs_swap)
-{
+AMREX_FORCE_INLINE T reconstructValue(const RawReader::ByteType* src_ptr,
+                                      const size_t bytes_to_read, const bool needs_swap) {
     static_assert(sizeof(T) <= 8, "reconstructValue: Type size mismatch or too large");
     RawReader::ByteType temp_buffer[8]; // Sufficient for up to 64-bit types
 
     if (needs_swap) {
-         for (size_t b = 0; b < bytes_to_read; ++b) {
-             temp_buffer[b] = src_ptr[bytes_to_read - 1 - b];
-         }
+        for (size_t b = 0; b < bytes_to_read; ++b) {
+            temp_buffer[b] = src_ptr[bytes_to_read - 1 - b];
+        }
     } else {
         std::memcpy(temp_buffer, src_ptr, bytes_to_read);
     }
 
     T val;
     // Ensure memcpy reads exactly sizeof(T) bytes, requires bytes_to_read == sizeof(T)
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(bytes_to_read == sizeof(T), "reconstructValue: bytes_to_read does not match sizeof(T)");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(bytes_to_read == sizeof(T),
+                                     "reconstructValue: bytes_to_read does not match sizeof(T)");
     std::memcpy(&val, temp_buffer, sizeof(T));
     return val;
 }
@@ -73,18 +74,15 @@ bool RawReader::isHostLittleEndian() const {
 // Constructor Implementations
 //-----------------------------------------------------------------------
 
-RawReader::RawReader() :
-    m_width(0), m_height(0), m_depth(0),
-    m_data_type(RawDataType::UNKNOWN), m_is_read(false)
-{
+RawReader::RawReader()
+    : m_width(0), m_height(0), m_depth(0), m_data_type(RawDataType::UNKNOWN), m_is_read(false) {
     // Default constructor: initialize members
 }
 
 // Constructor that reads file and throws on error
-RawReader::RawReader(const std::string& filename,
-                     int width, int height, int depth,
-                     RawDataType data_type) :
-    RawReader() // Delegate for default member initialization
+RawReader::RawReader(const std::string& filename, int width, int height, int depth,
+                     RawDataType data_type)
+    : RawReader() // Delegate for default member initialization
 {
     if (!readFile(filename, width, height, depth, data_type)) {
         // Error messages are printed within readFile/readRawFileInternal
@@ -97,10 +95,8 @@ RawReader::RawReader(const std::string& filename,
 // File Reading Implementation
 //-----------------------------------------------------------------------
 
-bool RawReader::readFile(const std::string& filename,
-                         int width, int height, int depth,
-                         RawDataType data_type)
-{
+bool RawReader::readFile(const std::string& filename, int width, int height, int depth,
+                         RawDataType data_type) {
     // --- Reset State ---
     m_raw_bytes.clear(); // Ensure vector is cleared even if readRawFileInternal fails early
     m_is_read = false;
@@ -121,8 +117,8 @@ bool RawReader::readFile(const std::string& filename,
         return false;
     }
     if (m_data_type == RawDataType::UNKNOWN) {
-         amrex::Print() << "Error: [RawReader] Data type cannot be UNKNOWN.\n";
-         return false;
+        amrex::Print() << "Error: [RawReader] Data type cannot be UNKNOWN.\n";
+        return false;
     }
 
     // --- Perform Read ---
@@ -141,8 +137,8 @@ bool RawReader::readFile(const std::string& filename,
     } else {
         // Ensure state reflects failure if readRawFileInternal failed
         // Error message should have been printed by readRawFileInternal
-        m_raw_bytes.clear(); // Clear potentially partially allocated/read data
-        m_width = m_height = m_depth = 0; // Reset dimensions
+        m_raw_bytes.clear();                // Clear potentially partially allocated/read data
+        m_width = m_height = m_depth = 0;   // Reset dimensions
         m_data_type = RawDataType::UNKNOWN; // Reset type
     }
 
@@ -151,13 +147,13 @@ bool RawReader::readFile(const std::string& filename,
 
 
 // <<< START OF CORRECTED readRawFileInternal (DEBUG prints removed) >>>
-bool RawReader::readRawFileInternal()
-{
+bool RawReader::readRawFileInternal() {
     // --- Calculate Expected Size ---
     const size_t bytes_per_voxel = getBytesPerVoxel();
     if (bytes_per_voxel == 0) {
         // This case should ideally be caught by the UNKNOWN check in readFile
-        amrex::Print() << "Internal Error: [RawReader] Invalid data type resulted in zero bytes per voxel.\n";
+        amrex::Print()
+            << "Internal Error: [RawReader] Invalid data type resulted in zero bytes per voxel.\n";
         return false;
     }
 
@@ -167,14 +163,14 @@ bool RawReader::readRawFileInternal()
 
     if (expected_bytes_ll <= 0) {
         // This could happen if dimensions are large enough to overflow 'long long'
-        amrex::Print() << "Error: [RawReader] Calculated data size (" << expected_bytes_ll << ") is zero or negative.\n";
+        amrex::Print() << "Error: [RawReader] Calculated data size (" << expected_bytes_ll
+                       << ") is zero or negative.\n";
         return false;
     }
 
     // --- Check against size_t max ---
     // Revised check: Compare expected_bytes_ll (known positive) as unsigned with size_t::max
-    if (static_cast<unsigned long long>(expected_bytes_ll) > std::numeric_limits<size_t>::max())
-    {
+    if (static_cast<unsigned long long>(expected_bytes_ll) > std::numeric_limits<size_t>::max()) {
         amrex::Print() << "Error: [RawReader] Calculated data size (" << expected_bytes_ll
                        << ") exceeds maximum value representable by size_t ("
                        << std::numeric_limits<size_t>::max() << ").\n"; // Corrected error message
@@ -193,27 +189,29 @@ bool RawReader::readRawFileInternal()
     // --- Check File Size ---
     std::streamsize file_size = file.tellg();
     if (file_size < 0) {
-        amrex::Print() << "Error: [RawReader] Could not determine file size or file size is negative for: " << m_filename << "\n";
+        amrex::Print()
+            << "Error: [RawReader] Could not determine file size or file size is negative for: "
+            << m_filename << "\n";
         file.close();
         return false;
     }
     // Check if file size is smaller than expected (unsigned comparison needed)
     if (static_cast<unsigned long long>(file_size) < expected_bytes) {
         amrex::Print() << "Error: [RawReader] File size (" << file_size
-                       << ") is smaller than expected data size (" << expected_bytes << ") for: "
-                       << m_filename << "\n";
+                       << ") is smaller than expected data size (" << expected_bytes
+                       << ") for: " << m_filename << "\n";
         file.close();
         return false;
     }
-     // Check if file size is different (and issue warning if larger)
-     if (static_cast<size_t>(file_size) != expected_bytes) {
+    // Check if file size is different (and issue warning if larger)
+    if (static_cast<size_t>(file_size) != expected_bytes) {
         // Warning only on IOProcessor to avoid clutter
         if (amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "Warning: [RawReader] File size (" << file_size
                            << ") does not exactly match expected data size (" << expected_bytes
                            << ") for: " << m_filename << ". Reading only expected bytes.\n";
         }
-     }
+    }
 
     // --- Allocate Memory ---
     try {
@@ -229,7 +227,8 @@ bool RawReader::readRawFileInternal()
     file.seekg(0, std::ios::beg); // Go back to the beginning to read
     if (!file.read(reinterpret_cast<char*>(m_raw_bytes.data()), expected_bytes)) {
         // Read failed, report stream state
-        amrex::Print() << "Error: [RawReader] Failed to read " << expected_bytes << " bytes from file: " << m_filename << "\n";
+        amrex::Print() << "Error: [RawReader] Failed to read " << expected_bytes
+                       << " bytes from file: " << m_filename << "\n";
         amrex::Print() << "  Stream state: good=" << file.good() << " eof=" << file.eof()
                        << " fail=" << file.fail() << " bad=" << file.bad() << "\n";
         file.close();
@@ -250,32 +249,55 @@ bool RawReader::readRawFileInternal()
 // Helper Method Implementations
 //-----------------------------------------------------------------------
 
-size_t RawReader::getBytesPerVoxel() const
-{
+size_t RawReader::getBytesPerVoxel() const {
     // Assumes m_data_type is valid (checked in readFile)
     switch (m_data_type) {
-        case RawDataType::UINT8:    case RawDataType::INT8:    return 1;
-        case RawDataType::INT16_LE: case RawDataType::INT16_BE:
-        case RawDataType::UINT16_LE:case RawDataType::UINT16_BE: return 2;
-        case RawDataType::INT32_LE: case RawDataType::INT32_BE:
-        case RawDataType::UINT32_LE:case RawDataType::UINT32_BE:
-        case RawDataType::FLOAT32_LE:case RawDataType::FLOAT32_BE: return 4;
-        case RawDataType::FLOAT64_LE:case RawDataType::FLOAT64_BE: return 8;
-        case RawDataType::UNKNOWN: default: return 0; // Should not happen if called after validation
+    case RawDataType::UINT8:
+    case RawDataType::INT8:
+        return 1;
+    case RawDataType::INT16_LE:
+    case RawDataType::INT16_BE:
+    case RawDataType::UINT16_LE:
+    case RawDataType::UINT16_BE:
+        return 2;
+    case RawDataType::INT32_LE:
+    case RawDataType::INT32_BE:
+    case RawDataType::UINT32_LE:
+    case RawDataType::UINT32_BE:
+    case RawDataType::FLOAT32_LE:
+    case RawDataType::FLOAT32_BE:
+        return 4;
+    case RawDataType::FLOAT64_LE:
+    case RawDataType::FLOAT64_BE:
+        return 8;
+    case RawDataType::UNKNOWN:
+    default:
+        return 0; // Should not happen if called after validation
     }
 }
 
 //-----------------------------------------------------------------------
 // Getter Implementations
 //-----------------------------------------------------------------------
-bool RawReader::isRead() const { return m_is_read; }
-int RawReader::width() const { return m_width; }
-int RawReader::height() const { return m_height; }
-int RawReader::depth() const { return m_depth; }
-RawDataType RawReader::getDataType() const { return m_data_type; }
+bool RawReader::isRead() const {
+    return m_is_read;
+}
+int RawReader::width() const {
+    return m_width;
+}
+int RawReader::height() const {
+    return m_height;
+}
+int RawReader::depth() const {
+    return m_depth;
+}
+RawDataType RawReader::getDataType() const {
+    return m_data_type;
+}
 
 amrex::Box RawReader::box() const {
-    if (!m_is_read) return amrex::Box();
+    if (!m_is_read)
+        return amrex::Box();
     // AMReX Box uses inclusive indices: [low_corner, high_corner]
     return amrex::Box(amrex::IntVect(0, 0, 0),
                       amrex::IntVect(m_width - 1, m_height - 1, m_depth - 1));
@@ -286,8 +308,7 @@ amrex::Box RawReader::box() const {
 // Data Access Implementation (`getValue`)
 //-----------------------------------------------------------------------
 
-double RawReader::getValue(int i, int j, int k) const
-{
+double RawReader::getValue(int i, int j, int k) const {
     // Ensure data has been successfully read before accessing
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_is_read, "[RawReader::getValue] Data not read yet.");
 
@@ -295,10 +316,9 @@ double RawReader::getValue(int i, int j, int k) const
     // Use AMREX_ALWAYS_ASSERT for conditions that MUST be true for correctness
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         i >= 0 && i < m_width && j >= 0 && j < m_height && k >= 0 && k < m_depth,
-        "[RawReader::getValue] Index (" + std::to_string(i) + "," + std::to_string(j) + "," + std::to_string(k)
-        + ") out of bounds (W:" + std::to_string(m_width) + ", H:" + std::to_string(m_height)
-        + ", D:" + std::to_string(m_depth) + ")."
-    );
+        "[RawReader::getValue] Index (" + std::to_string(i) + "," + std::to_string(j) + "," +
+            std::to_string(k) + ") out of bounds (W:" + std::to_string(m_width) +
+            ", H:" + std::to_string(m_height) + ", D:" + std::to_string(m_depth) + ").");
 
     // --- Calculate Byte Offset ---
     const size_t bytes_per_voxel = getBytesPerVoxel();
@@ -316,24 +336,33 @@ double RawReader::getValue(int i, int j, int k) const
     // Ensure the read won't go past the end of the allocated buffer
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
         (offset + bytes_per_voxel) <= m_raw_bytes.size(), // Use <= because offset is 0-based
-        "[RawReader::getValue] Calculated byte offset (" + std::to_string(offset)
-        + ") + size (" + std::to_string(bytes_per_voxel)
-        + ") exceeds raw data vector size (" + std::to_string(m_raw_bytes.size()) + ")."
-    );
+        "[RawReader::getValue] Calculated byte offset (" + std::to_string(offset) + ") + size (" +
+            std::to_string(bytes_per_voxel) + ") exceeds raw data vector size (" +
+            std::to_string(m_raw_bytes.size()) + ").");
 
     // --- Determine Endianness and Need for Swap ---
     bool data_is_le;
-    switch(m_data_type) {
-        case RawDataType::INT16_LE: case RawDataType::UINT16_LE: case RawDataType::INT32_LE:
-        case RawDataType::UINT32_LE: case RawDataType::FLOAT32_LE: case RawDataType::FLOAT64_LE:
-            data_is_le = true; break;
-        case RawDataType::INT16_BE: case RawDataType::UINT16_BE: case RawDataType::INT32_BE:
-        case RawDataType::UINT32_BE: case RawDataType::FLOAT32_BE: case RawDataType::FLOAT64_BE:
-            data_is_le = false; break;
-        default: // UINT8, INT8, UNKNOWN (although UNKNOWN shouldn't happen here)
-            // For single-byte types, endianness doesn't matter for swapping logic
-            data_is_le = host_is_little_endian; // Assign something for consistency
-            break;
+    switch (m_data_type) {
+    case RawDataType::INT16_LE:
+    case RawDataType::UINT16_LE:
+    case RawDataType::INT32_LE:
+    case RawDataType::UINT32_LE:
+    case RawDataType::FLOAT32_LE:
+    case RawDataType::FLOAT64_LE:
+        data_is_le = true;
+        break;
+    case RawDataType::INT16_BE:
+    case RawDataType::UINT16_BE:
+    case RawDataType::INT32_BE:
+    case RawDataType::UINT32_BE:
+    case RawDataType::FLOAT32_BE:
+    case RawDataType::FLOAT64_BE:
+        data_is_le = false;
+        break;
+    default: // UINT8, INT8, UNKNOWN (although UNKNOWN shouldn't happen here)
+        // For single-byte types, endianness doesn't matter for swapping logic
+        data_is_le = host_is_little_endian; // Assign something for consistency
+        break;
     }
     // Need swap only if bytes > 1 AND data endianness differs from host
     const bool needs_swap = (bytes_per_voxel > 1) && (data_is_le != host_is_little_endian);
@@ -345,27 +374,52 @@ double RawReader::getValue(int i, int j, int k) const
 
     // Use the helper function to reconstruct the value based on type
     switch (m_data_type) {
-        case RawDataType::UINT8: {
-            result = static_cast<double>(reconstructValue<uint8_t>(src_ptr, 1, needs_swap)); break; }
-        case RawDataType::INT8: {
-            result = static_cast<double>(reconstructValue<int8_t>(src_ptr, 1, needs_swap)); break; }
-        case RawDataType::UINT16_LE: case RawDataType::UINT16_BE: {
-            result = static_cast<double>(reconstructValue<uint16_t>(src_ptr, 2, needs_swap)); break; }
-        case RawDataType::INT16_LE: case RawDataType::INT16_BE: {
-            result = static_cast<double>(reconstructValue<int16_t>(src_ptr, 2, needs_swap)); break; }
-        case RawDataType::UINT32_LE: case RawDataType::UINT32_BE: {
-            result = static_cast<double>(reconstructValue<uint32_t>(src_ptr, 4, needs_swap)); break; }
-        case RawDataType::INT32_LE: case RawDataType::INT32_BE: {
-            result = static_cast<double>(reconstructValue<int32_t>(src_ptr, 4, needs_swap)); break; }
-        case RawDataType::FLOAT32_LE: case RawDataType::FLOAT32_BE: {
-            static_assert(std::numeric_limits<float>::is_iec559 && sizeof(float) == 4, "Require IEEE 754 32-bit float");
-            result = static_cast<double>(reconstructValue<float>(src_ptr, 4, needs_swap)); break; }
-        case RawDataType::FLOAT64_LE: case RawDataType::FLOAT64_BE: {
-            static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == 8, "Require IEEE 754 64-bit double");
-            result = reconstructValue<double>(src_ptr, 8, needs_swap); break; } // Direct assignment for double
-        case RawDataType::UNKNOWN: default:
-            // Should be caught by validation in readFile, but include for safety
-            amrex::Abort("[RawReader::getValue] Unknown or unsupported data type encountered.");
+    case RawDataType::UINT8: {
+        result = static_cast<double>(reconstructValue<uint8_t>(src_ptr, 1, needs_swap));
+        break;
+    }
+    case RawDataType::INT8: {
+        result = static_cast<double>(reconstructValue<int8_t>(src_ptr, 1, needs_swap));
+        break;
+    }
+    case RawDataType::UINT16_LE:
+    case RawDataType::UINT16_BE: {
+        result = static_cast<double>(reconstructValue<uint16_t>(src_ptr, 2, needs_swap));
+        break;
+    }
+    case RawDataType::INT16_LE:
+    case RawDataType::INT16_BE: {
+        result = static_cast<double>(reconstructValue<int16_t>(src_ptr, 2, needs_swap));
+        break;
+    }
+    case RawDataType::UINT32_LE:
+    case RawDataType::UINT32_BE: {
+        result = static_cast<double>(reconstructValue<uint32_t>(src_ptr, 4, needs_swap));
+        break;
+    }
+    case RawDataType::INT32_LE:
+    case RawDataType::INT32_BE: {
+        result = static_cast<double>(reconstructValue<int32_t>(src_ptr, 4, needs_swap));
+        break;
+    }
+    case RawDataType::FLOAT32_LE:
+    case RawDataType::FLOAT32_BE: {
+        static_assert(std::numeric_limits<float>::is_iec559 && sizeof(float) == 4,
+                      "Require IEEE 754 32-bit float");
+        result = static_cast<double>(reconstructValue<float>(src_ptr, 4, needs_swap));
+        break;
+    }
+    case RawDataType::FLOAT64_LE:
+    case RawDataType::FLOAT64_BE: {
+        static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == 8,
+                      "Require IEEE 754 64-bit double");
+        result = reconstructValue<double>(src_ptr, 8, needs_swap);
+        break;
+    } // Direct assignment for double
+    case RawDataType::UNKNOWN:
+    default:
+        // Should be caught by validation in readFile, but include for safety
+        amrex::Abort("[RawReader::getValue] Unknown or unsupported data type encountered.");
     }
     return result;
 }
@@ -376,12 +430,15 @@ double RawReader::getValue(int i, int j, int k) const
 //-----------------------------------------------------------------------
 
 // Overload with customizable true/false values
-void RawReader::threshold(double threshold_value, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const
-{
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_is_read, "[RawReader::threshold] Cannot threshold, data not read successfully.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mf.nComp() == 1, "[RawReader::threshold] Output iMultiFab must have 1 component.");
+void RawReader::threshold(double threshold_value, int value_if_true, int value_if_false,
+                          amrex::iMultiFab& mf) const {
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_is_read, "[RawReader::threshold] Cannot threshold, data not read successfully.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        mf.nComp() == 1, "[RawReader::threshold] Output iMultiFab must have 1 component.");
 
-    // Capture members needed by the lambda by value or const reference/pointer for safety and potential performance
+    // Capture members needed by the lambda by value or const reference/pointer for safety and
+    // potential performance
     const int current_width = m_width;
     const int current_height = m_height;
     const int current_depth = m_depth;
@@ -395,15 +452,26 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
 
     // Determine if data needs swapping based on type and cached host endianness
     bool data_is_le;
-    switch(current_data_type) { /* Same switch logic as getValue */
-        case RawDataType::INT16_LE: case RawDataType::UINT16_LE: case RawDataType::INT32_LE:
-        case RawDataType::UINT32_LE: case RawDataType::FLOAT32_LE: case RawDataType::FLOAT64_LE:
-            data_is_le = true; break;
-        case RawDataType::INT16_BE: case RawDataType::UINT16_BE: case RawDataType::INT32_BE:
-        case RawDataType::UINT32_BE: case RawDataType::FLOAT32_BE: case RawDataType::FLOAT64_BE:
-            data_is_le = false; break;
-        default:
-            data_is_le = host_is_little_endian; break;
+    switch (current_data_type) { /* Same switch logic as getValue */
+    case RawDataType::INT16_LE:
+    case RawDataType::UINT16_LE:
+    case RawDataType::INT32_LE:
+    case RawDataType::UINT32_LE:
+    case RawDataType::FLOAT32_LE:
+    case RawDataType::FLOAT64_LE:
+        data_is_le = true;
+        break;
+    case RawDataType::INT16_BE:
+    case RawDataType::UINT16_BE:
+    case RawDataType::INT32_BE:
+    case RawDataType::UINT32_BE:
+    case RawDataType::FLOAT32_BE:
+    case RawDataType::FLOAT64_BE:
+        data_is_le = false;
+        break;
+    default:
+        data_is_le = host_is_little_endian;
+        break;
     }
     const bool needs_swap = (bytes_per_voxel > 1) && (data_is_le != host_is_little_endian);
 
@@ -411,24 +479,25 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     // Iterate over the iMultiFab using MFIter
-    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
         const amrex::Box& box = mfi.validbox(); // Get the valid box for this FAB
-        amrex::IArrayBox& fab = mf[mfi];       // Get the FArrayBox data (non-const ref)
+        amrex::IArrayBox& fab = mf[mfi];        // Get the FArrayBox data (non-const ref)
 
         // Loop over the cells in the box using amrex::LoopOnCpu (since m_raw_bytes is host memory)
-        amrex::LoopOnCpu(box, [&] (int i, int j, int k)
-        {
+        amrex::LoopOnCpu(box, [&](int i, int j, int k) {
             // --- Bounds Check for Raw Data Access ---
-            // Check if the current index (i,j,k) is within the bounds of the loaded raw data dimensions
-            if (i >= 0 && i < current_width && j >= 0 && j < current_height && k >= 0 && k < current_depth)
-            {
+            // Check if the current index (i,j,k) is within the bounds of the loaded raw data
+            // dimensions
+            if (i >= 0 && i < current_width && j >= 0 && j < current_height && k >= 0 &&
+                k < current_depth) {
                 // --- Calculate Offset ---
                 // Use size_t consistently for indexing calculations to prevent overflow
                 // Ensure dimensions are positive (checked in readFile)
-                size_t plane_size = static_cast<size_t>(current_width) * static_cast<size_t>(current_height);
+                size_t plane_size =
+                    static_cast<size_t>(current_width) * static_cast<size_t>(current_height);
                 size_t row_offset = static_cast<size_t>(j) * static_cast<size_t>(current_width);
-                size_t idx_1d = static_cast<size_t>(k) * plane_size + row_offset + static_cast<size_t>(i);
+                size_t idx_1d =
+                    static_cast<size_t>(k) * plane_size + row_offset + static_cast<size_t>(i);
                 size_t offset = idx_1d * bytes_per_voxel;
 
                 // --- Check Calculated Offset against raw buffer size ---
@@ -440,51 +509,82 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
                     bool comparison_result = false;
 
                     // Switch on type to reconstruct value and compare efficiently
-                    // This avoids calling the full getValue function (with its checks) for every voxel
+                    // This avoids calling the full getValue function (with its checks) for every
+                    // voxel
                     switch (current_data_type) {
-                        case RawDataType::UINT8: {
-                            uint8_t val = reconstructValue<uint8_t>(src_ptr, 1, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::INT8: {
-                            int8_t val = reconstructValue<int8_t>(src_ptr, 1, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::UINT16_LE: case RawDataType::UINT16_BE: {
-                            uint16_t val = reconstructValue<uint16_t>(src_ptr, 2, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::INT16_LE: case RawDataType::INT16_BE: {
-                            int16_t val = reconstructValue<int16_t>(src_ptr, 2, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::UINT32_LE: case RawDataType::UINT32_BE: {
-                            uint32_t val = reconstructValue<uint32_t>(src_ptr, 4, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::INT32_LE: case RawDataType::INT32_BE: {
-                            int32_t val = reconstructValue<int32_t>(src_ptr, 4, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::FLOAT32_LE: case RawDataType::FLOAT32_BE: {
-                            static_assert(std::numeric_limits<float>::is_iec559 && sizeof(float) == 4, "");
-                            float val = reconstructValue<float>(src_ptr, 4, needs_swap);
-                            comparison_result = (static_cast<double>(val) > threshold_value); break; }
-                        case RawDataType::FLOAT64_LE: case RawDataType::FLOAT64_BE: {
-                            static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == 8, "");
-                            double val = reconstructValue<double>(src_ptr, 8, needs_swap);
-                            comparison_result = (val > threshold_value); break; }
-                        case RawDataType::UNKNOWN: default:
-                            // This state should ideally be impossible if m_is_read is true
-                            amrex::Abort("[RawReader::threshold] Unsupported data type encountered in loop.");
+                    case RawDataType::UINT8: {
+                        uint8_t val = reconstructValue<uint8_t>(src_ptr, 1, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::INT8: {
+                        int8_t val = reconstructValue<int8_t>(src_ptr, 1, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::UINT16_LE:
+                    case RawDataType::UINT16_BE: {
+                        uint16_t val = reconstructValue<uint16_t>(src_ptr, 2, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::INT16_LE:
+                    case RawDataType::INT16_BE: {
+                        int16_t val = reconstructValue<int16_t>(src_ptr, 2, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::UINT32_LE:
+                    case RawDataType::UINT32_BE: {
+                        uint32_t val = reconstructValue<uint32_t>(src_ptr, 4, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::INT32_LE:
+                    case RawDataType::INT32_BE: {
+                        int32_t val = reconstructValue<int32_t>(src_ptr, 4, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::FLOAT32_LE:
+                    case RawDataType::FLOAT32_BE: {
+                        static_assert(std::numeric_limits<float>::is_iec559 && sizeof(float) == 4,
+                                      "");
+                        float val = reconstructValue<float>(src_ptr, 4, needs_swap);
+                        comparison_result = (static_cast<double>(val) > threshold_value);
+                        break;
+                    }
+                    case RawDataType::FLOAT64_LE:
+                    case RawDataType::FLOAT64_BE: {
+                        static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == 8,
+                                      "");
+                        double val = reconstructValue<double>(src_ptr, 8, needs_swap);
+                        comparison_result = (val > threshold_value);
+                        break;
+                    }
+                    case RawDataType::UNKNOWN:
+                    default:
+                        // This state should ideally be impossible if m_is_read is true
+                        amrex::Abort(
+                            "[RawReader::threshold] Unsupported data type encountered in loop.");
                     }
                     // Assign result to the iMultiFab using IntVect for indexing
-                    fab(amrex::IntVect(i, j, k), 0) = comparison_result ? value_if_true : value_if_false;
+                    fab(amrex::IntVect(i, j, k), 0) =
+                        comparison_result ? value_if_true : value_if_false;
 
                 } else {
-                    // Offset check failed - This indicates a logic error (e.g., in index calculation) or data corruption.
-                    // Abort is safer than potentially reading garbage or setting incorrect values silently.
-                    amrex::Abort("[RawReader::threshold] Internal error: Calculated offset exceeds bounds.");
-                    // If choosing to continue instead: fab(amrex::IntVect(i, j, k), 0) = value_if_false;
+                    // Offset check failed - This indicates a logic error (e.g., in index
+                    // calculation) or data corruption. Abort is safer than potentially reading
+                    // garbage or setting incorrect values silently.
+                    amrex::Abort(
+                        "[RawReader::threshold] Internal error: Calculated offset exceeds bounds.");
+                    // If choosing to continue instead: fab(amrex::IntVect(i, j, k), 0) =
+                    // value_if_false;
                 }
             } else {
-                 // Index (i,j,k) from the iMultiFab box is outside the raw data bounds.
-                 // Set to the 'false' value as per the function description.
-                 fab(amrex::IntVect(i, j, k), 0) = value_if_false;
+                // Index (i,j,k) from the iMultiFab box is outside the raw data bounds.
+                // Set to the 'false' value as per the function description.
+                fab(amrex::IntVect(i, j, k), 0) = value_if_false;
             }
         }); // End of amrex::LoopOnCpu lambda
     } // End of MFIter loop
@@ -492,8 +592,7 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
 
 
 // Original overload (output 1/0) - calls the flexible version
-void RawReader::threshold(double threshold_value, amrex::iMultiFab& mf) const
-{
+void RawReader::threshold(double threshold_value, amrex::iMultiFab& mf) const {
     threshold(threshold_value, 1, 0, mf); // Call the flexible version with 1/0
 }
 

--- a/src/io/TiffReader.H
+++ b/src/io/TiffReader.H
@@ -41,8 +41,7 @@ namespace OpenImpala {
  * the first sample is used during thresholding.
  * @warning Copy operations disabled.
  */
-class TiffReader
-{
+class TiffReader {
 public:
     /**
      * @brief Default constructor. Creates an empty reader. Use readFile() or readFileSequence().
@@ -50,7 +49,8 @@ public:
     TiffReader();
 
     /**
-     * @brief Constructs a TiffReader, reads metadata from a single (potentially multi-directory) TIFF file.
+     * @brief Constructs a TiffReader, reads metadata from a single (potentially multi-directory)
+     * TIFF file.
      *
      * Reads dimensions and data type info on rank 0 and broadcasts.
      * Does NOT read pixel data. Throws on error.
@@ -71,12 +71,8 @@ public:
      * @param suffix File extension including dot (e.g., ".tif").
      * @throws std::runtime_error on file open/metadata read errors or inconsistent metadata.
      */
-    TiffReader(
-        const std::string& base_pattern,
-        int num_files,
-        int start_index = 0,
-        int digits = 1,
-        const std::string& suffix = ".tif");
+    TiffReader(const std::string& base_pattern, int num_files, int start_index = 0, int digits = 1,
+               const std::string& suffix = ".tif");
 
     /**
      * @brief Virtual default destructor.
@@ -114,12 +110,8 @@ public:
      * @param suffix File extension including dot (e.g., ".tif").
      * @return true on success (metadata broadcast), false otherwise. Aborts on critical errors.
      */
-    bool readFileSequence(
-        const std::string& base_pattern,
-        int num_files,
-        int start_index = 0,
-        int digits = 1,
-        const std::string& suffix = ".tif");
+    bool readFileSequence(const std::string& base_pattern, int num_files, int start_index = 0,
+                          int digits = 1, const std::string& suffix = ".tif");
 
     /**
      * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding (output 1/0).
@@ -129,7 +121,8 @@ public:
      * from the TIFF file(s) and fills the patch's FArrayBox based on the threshold.
      * Sets output cells to 1 if `native_value > raw_threshold`, else 0.
      * Requires metadata to have been read successfully first via readFile() or readFileSequence().
-     * Handles conversion from native TIFF type to double for comparison. Uses first sample if SPP > 1.
+     * Handles conversion from native TIFF type to double for comparison. Uses first sample if SPP
+     * > 1.
      *
      * @param raw_threshold The threshold value (compared against data converted to double).
      * @param mf Output amrex::iMultiFab reference to fill (must be defined and distributed).
@@ -138,14 +131,16 @@ public:
     void threshold(double raw_threshold, amrex::iMultiFab& mf) const;
 
     /**
-     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding with custom output values.
+     * @brief Reads data chunk-by-chunk into an iMultiFab based on thresholding with custom output
+     * values.
      *
      * Performs distributed reading. Iterates through the patches (`MFIter`) of the output
      * iMultiFab `mf`. For each patch, reads the corresponding strips or tiles
      * from the TIFF file(s) and fills the patch's FArrayBox based on the threshold.
-     * Sets output cells to `value_if_true` if `native_value > raw_threshold`, else `value_if_false`.
-     * Requires metadata to have been read successfully first via readFile() or readFileSequence().
-     * Handles conversion from native TIFF type to double for comparison. Uses first sample if SPP > 1.
+     * Sets output cells to `value_if_true` if `native_value > raw_threshold`, else
+     * `value_if_false`. Requires metadata to have been read successfully first via readFile() or
+     * readFileSequence(). Handles conversion from native TIFF type to double for comparison. Uses
+     * first sample if SPP > 1.
      *
      * @param raw_threshold The threshold value (compared against data converted to double).
      * @param value_if_true Integer value if condition is true.
@@ -153,10 +148,12 @@ public:
      * @param mf Output amrex::iMultiFab reference to fill (must be defined and distributed).
      * @throws std::runtime_error on read errors or if metadata not ready.
      */
-    void threshold(double raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const;
+    void threshold(double raw_threshold, int value_if_true, int value_if_false,
+                   amrex::iMultiFab& mf) const;
 
     // --- Metadata Getters ---
-    /** @brief Returns the index space Box covering the entire image domain [0, w-1]x[0, h-1]x[0, d-1]. */
+    /** @brief Returns the index space Box covering the entire image domain [0, w-1]x[0, h-1]x[0,
+     * d-1]. */
     amrex::Box box() const;
 
     /** @brief Get width (X-dimension) in pixels/voxels. Requires metadata to be read. */
@@ -168,48 +165,52 @@ public:
 
     /** @brief Get bits per sample (e.g., 8, 16, 32). Requires metadata to be read. */
     int bitsPerSample() const;
-    /** @brief Get sample format (e.g., SAMPLEFORMAT_UINT, SAMPLEFORMAT_INT, SAMPLEFORMAT_IEEEFP from tiff.h). Requires metadata to be read. */
+    /** @brief Get sample format (e.g., SAMPLEFORMAT_UINT, SAMPLEFORMAT_INT, SAMPLEFORMAT_IEEEFP
+     * from tiff.h). Requires metadata to be read. */
     int sampleFormat() const;
-    /** @brief Get samples per pixel (e.g., 1 for grayscale, 3 for RGB). Requires metadata to be read. */
+    /** @brief Get samples per pixel (e.g., 1 for grayscale, 3 for RGB). Requires metadata to be
+     * read. */
     int samplesPerPixel() const;
 
-    /** @brief Get TIFF FillOrder tag value (e.g., 1=MSB->LSB, 2=LSB->MSB). Requires metadata to be read. */
-    uint16_t getFillOrder() const { return m_fill_order; } // <<< NEW GETTER ADDED HERE <<<
+    /** @brief Get TIFF FillOrder tag value (e.g., 1=MSB->LSB, 2=LSB->MSB). Requires metadata to be
+     * read. */
+    uint16_t getFillOrder() const {
+        return m_fill_order;
+    } // <<< NEW GETTER ADDED HERE <<<
 
     /** @brief Check if metadata has been successfully read and broadcast. */
-    bool isRead() const { return m_is_read; }
+    bool isRead() const {
+        return m_is_read;
+    }
 
 
 private:
     // --- Member Variables ---
     // Source Info
-    std::string m_filename;       /**< Filename (single stack) */
-    std::string m_base_pattern;   /**< Base pattern for sequence */
-    std::string m_suffix;         /**< Suffix for sequence */
-    int m_start_index = 0;        /**< Starting index for sequence */
-    int m_digits = 1;             /**< Number of digits for sequence padding */
-    bool m_is_sequence = false;   /**< Flag indicating if source is a sequence */
+    std::string m_filename;     /**< Filename (single stack) */
+    std::string m_base_pattern; /**< Base pattern for sequence */
+    std::string m_suffix;       /**< Suffix for sequence */
+    int m_start_index = 0;      /**< Starting index for sequence */
+    int m_digits = 1;           /**< Number of digits for sequence padding */
+    bool m_is_sequence = false; /**< Flag indicating if source is a sequence */
 
     // Domain/Metadata Info (Read by Rank 0, Broadcast to all)
-    int m_width = 0;              /**< Width of the domain (X) */
-    int m_height = 0;             /**< Height of the domain (Y) */
-    int m_depth = 0;              /**< Depth of the domain (Z) */
-    bool m_is_read = false;       /**< Flag indicating if metadata has been successfully read and broadcast */
+    int m_width = 0;  /**< Width of the domain (X) */
+    int m_height = 0; /**< Height of the domain (Y) */
+    int m_depth = 0;  /**< Depth of the domain (Z) */
+    bool m_is_read =
+        false; /**< Flag indicating if metadata has been successfully read and broadcast */
 
     // TIFF Format Info (Read by Rank 0, Broadcast to all)
-    uint16_t m_bits_per_sample = 0; /**< TIFFTAG_BITSPERSAMPLE */
-    uint16_t m_sample_format = 0;   /**< TIFFTAG_SAMPLEFORMAT */
-    uint16_t m_samples_per_pixel = 0;/**< TIFFTAG_SAMPLESPERPIXEL */
-    uint16_t m_fill_order; // Initialized in constructor(s)
+    uint16_t m_bits_per_sample = 0;   /**< TIFFTAG_BITSPERSAMPLE */
+    uint16_t m_sample_format = 0;     /**< TIFFTAG_SAMPLEFORMAT */
+    uint16_t m_samples_per_pixel = 0; /**< TIFFTAG_SAMPLESPERPIXEL */
+    uint16_t m_fill_order;            // Initialized in constructor(s)
 
     // Private helper function implementing the core distributed read logic
     // Called by the public threshold methods.
-    void readDistributedIntoFab(
-        amrex::iMultiFab& dest_mf,
-        int value_if_true,
-        int value_if_false,
-        double raw_threshold
-    ) const;
+    void readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_true, int value_if_false,
+                                double raw_threshold) const;
 
 
 }; // class TiffReader

--- a/src/io/TiffReader.cpp
+++ b/src/io/TiffReader.cpp
@@ -9,8 +9,8 @@
 
 // --- Other standard and library includes ---
 #include "TiffReader.H"
-#include <tiffio.h>  // libtiff C API Header
-#include <memory>    // For std::unique_ptr
+#include <tiffio.h> // libtiff C API Header
+#include <memory>   // For std::unique_ptr
 #include <vector>
 #include <string>
 #include <stdexcept>
@@ -47,45 +47,83 @@ namespace {
 // RAII wrapper for TIFF* handle
 struct TiffCloser {
     void operator()(TIFF* tif) const {
-        if (tif) TIFFClose(tif);
+        if (tif)
+            TIFFClose(tif);
     }
 };
 using TiffPtr = std::unique_ptr<TIFF, TiffCloser>;
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-double interpretBytesAsDouble(const unsigned char* byte_ptr,
-                              uint16_t bits_per_sample,
-                              uint16_t sample_format)
-{
-    if (bits_per_sample < 8 || (bits_per_sample % 8 != 0) ) return 0.0;
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE double
+interpretBytesAsDouble(const unsigned char* byte_ptr, uint16_t bits_per_sample,
+                       uint16_t sample_format) {
+    if (bits_per_sample < 8 || (bits_per_sample % 8 != 0))
+        return 0.0;
     size_t bytes_per_sample_val = bits_per_sample / 8;
     double value = 0.0;
     switch (sample_format) {
-        case SAMPLEFORMAT_UINT:
-            if (bytes_per_sample_val == 1) { uint8_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-            else if (bytes_per_sample_val == 2) { uint16_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-            else if (bytes_per_sample_val == 4) { uint32_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-            else if (bytes_per_sample_val == 8) { uint64_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-            break;
-        case SAMPLEFORMAT_INT:
-             if (bytes_per_sample_val == 1) { int8_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-             else if (bytes_per_sample_val == 2) { int16_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-             else if (bytes_per_sample_val == 4) { int32_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-             else if (bytes_per_sample_val == 8) { int64_t val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-            break;
-        case SAMPLEFORMAT_IEEEFP:
-             if (bytes_per_sample_val == 4) { static_assert(sizeof(float) == 4, "Float size mismatch"); float val; std::memcpy(&val, byte_ptr, sizeof(val)); value = static_cast<double>(val); }
-             else if (bytes_per_sample_val == 8) { static_assert(sizeof(double) == 8, "Double size mismatch"); double val_d; std::memcpy(&val_d, byte_ptr, sizeof(val_d)); value = val_d; }
-            break;
-        default: value = 0.0; break;
+    case SAMPLEFORMAT_UINT:
+        if (bytes_per_sample_val == 1) {
+            uint8_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 2) {
+            uint16_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 4) {
+            uint32_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 8) {
+            uint64_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        }
+        break;
+    case SAMPLEFORMAT_INT:
+        if (bytes_per_sample_val == 1) {
+            int8_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 2) {
+            int16_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 4) {
+            int32_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 8) {
+            int64_t val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        }
+        break;
+    case SAMPLEFORMAT_IEEEFP:
+        if (bytes_per_sample_val == 4) {
+            static_assert(sizeof(float) == 4, "Float size mismatch");
+            float val;
+            std::memcpy(&val, byte_ptr, sizeof(val));
+            value = static_cast<double>(val);
+        } else if (bytes_per_sample_val == 8) {
+            static_assert(sizeof(double) == 8, "Double size mismatch");
+            double val_d;
+            std::memcpy(&val_d, byte_ptr, sizeof(val_d));
+            value = val_d;
+        }
+        break;
+    default:
+        value = 0.0;
+        break;
     }
     return value;
 }
 
-std::string generateFilename(const std::string& base, int index, int digits, const std::string& suffix) {
-     std::ostringstream ss;
-     ss << base << std::setw(digits) << std::setfill('0') << index << suffix;
-     return ss.str();
+std::string generateFilename(const std::string& base, int index, int digits,
+                             const std::string& suffix) {
+    std::ostringstream ss;
+    ss << base << std::setw(digits) << std::setfill('0') << index << suffix;
+    return ss.str();
 }
 
 } // end anonymous namespace
@@ -93,42 +131,60 @@ std::string generateFilename(const std::string& base, int index, int digits, con
 //================================================================
 // Constructors
 //================================================================
-TiffReader::TiffReader() :
-    m_width(0), m_height(0), m_depth(0),
-    m_bits_per_sample(0), m_sample_format(SAMPLEFORMAT_UINT), m_samples_per_pixel(1),
-    m_fill_order(FILLORDER_MSB2LSB),
-    m_is_read(false), m_is_sequence(false), m_start_index(0), m_digits(1)
-{}
+TiffReader::TiffReader()
+    : m_width(0), m_height(0), m_depth(0), m_bits_per_sample(0), m_sample_format(SAMPLEFORMAT_UINT),
+      m_samples_per_pixel(1), m_fill_order(FILLORDER_MSB2LSB), m_is_read(false),
+      m_is_sequence(false), m_start_index(0), m_digits(1) {}
 
 TiffReader::TiffReader(const std::string& filename) : TiffReader() {
-    m_filename = filename; // Store filename before calling readFile, as readFile might use it (e.g. in error messages on rank 0)
+    m_filename = filename; // Store filename before calling readFile, as readFile might use it (e.g.
+                           // in error messages on rank 0)
     if (!readFile(filename)) {
-        throw std::runtime_error("TiffReader(filename): Failed to read metadata from file: " + filename);
+        throw std::runtime_error("TiffReader(filename): Failed to read metadata from file: " +
+                                 filename);
     }
 }
 
-TiffReader::TiffReader(
-    const std::string& base_pattern, int num_files,
-    int start_index, int digits, const std::string& suffix) : TiffReader() {
+TiffReader::TiffReader(const std::string& base_pattern, int num_files, int start_index, int digits,
+                       const std::string& suffix)
+    : TiffReader() {
     // Store these before calling readFileSequence, as it will use them
-    m_base_pattern = base_pattern; m_start_index = start_index; m_digits = digits; m_suffix = suffix;
+    m_base_pattern = base_pattern;
+    m_start_index = start_index;
+    m_digits = digits;
+    m_suffix = suffix;
     if (!readFileSequence(base_pattern, num_files, start_index, digits, suffix)) {
-         throw std::runtime_error("TiffReader(sequence): Failed to read metadata for sequence: " + base_pattern);
+        throw std::runtime_error("TiffReader(sequence): Failed to read metadata for sequence: " +
+                                 base_pattern);
     }
 }
 
 //================================================================
 // Metadata Getters
 //================================================================
-int TiffReader::width() const { return m_width; }
-int TiffReader::height() const { return m_height; }
-int TiffReader::depth() const { return m_depth; }
-int TiffReader::bitsPerSample() const { return m_bits_per_sample; }
-int TiffReader::sampleFormat() const { return m_sample_format; }
-int TiffReader::samplesPerPixel() const { return m_samples_per_pixel; }
+int TiffReader::width() const {
+    return m_width;
+}
+int TiffReader::height() const {
+    return m_height;
+}
+int TiffReader::depth() const {
+    return m_depth;
+}
+int TiffReader::bitsPerSample() const {
+    return m_bits_per_sample;
+}
+int TiffReader::sampleFormat() const {
+    return m_sample_format;
+}
+int TiffReader::samplesPerPixel() const {
+    return m_samples_per_pixel;
+}
 
 amrex::Box TiffReader::box() const {
-    if (!m_is_read) { return amrex::Box(); }
+    if (!m_is_read) {
+        return amrex::Box();
+    }
     return amrex::Box(amrex::IntVect::TheZeroVector(),
                       amrex::IntVect(m_width - 1, m_height - 1, m_depth - 1));
 }
@@ -137,19 +193,27 @@ amrex::Box TiffReader::box() const {
 // readFile Method (Single Stack File)
 //================================================================
 bool TiffReader::readFile(const std::string& filename) {
-    // Ensure member filename is set correctly before this method is called by constructor, or set it here.
-    // If called directly, update member variables.
-    m_is_sequence = false; m_filename = filename; m_base_pattern = "";
-    int width_r0=0, height_r0=0, depth_r0=0;
-    uint16_t bps_r0=0, fmt_r0=SAMPLEFORMAT_UINT, spp_r0=1, fill_order_r0 = FILLORDER_MSB2LSB;
+    // Ensure member filename is set correctly before this method is called by constructor, or set
+    // it here. If called directly, update member variables.
+    m_is_sequence = false;
+    m_filename = filename;
+    m_base_pattern = "";
+    int width_r0 = 0, height_r0 = 0, depth_r0 = 0;
+    uint16_t bps_r0 = 0, fmt_r0 = SAMPLEFORMAT_UINT, spp_r0 = 1, fill_order_r0 = FILLORDER_MSB2LSB;
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        if (filename.empty()) { amrex::Abort("[TiffReader::readFile] Filename cannot be empty."); }
+        if (filename.empty()) {
+            amrex::Abort("[TiffReader::readFile] Filename cannot be empty.");
+        }
         TiffPtr tif(TIFFOpen(filename.c_str(), "r"), TiffCloser());
-        if (!tif) { amrex::Abort("[TiffReader::readFile] Failed to open TIFF file: " + filename); }
+        if (!tif) {
+            amrex::Abort("[TiffReader::readFile] Failed to open TIFF file: " + filename);
+        }
 
-        uint32_t w32=0, h32=0; uint16_t planar = PLANARCONFIG_CONTIG;
-        if (!TIFFGetField(tif.get(), TIFFTAG_IMAGEWIDTH, &w32) || !TIFFGetField(tif.get(), TIFFTAG_IMAGELENGTH, &h32)) {
+        uint32_t w32 = 0, h32 = 0;
+        uint16_t planar = PLANARCONFIG_CONTIG;
+        if (!TIFFGetField(tif.get(), TIFFTAG_IMAGEWIDTH, &w32) ||
+            !TIFFGetField(tif.get(), TIFFTAG_IMAGELENGTH, &h32)) {
             amrex::Abort("[TiffReader::readFile] Failed to get image dimensions from: " + filename);
         }
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_BITSPERSAMPLE, &bps_r0);
@@ -157,41 +221,76 @@ bool TiffReader::readFile(const std::string& filename) {
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_SAMPLESPERPIXEL, &spp_r0);
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_PLANARCONFIG, &planar);
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_FILLORDER, &fill_order_r0);
-        
-        if (amrex::Verbose() >= 2 && amrex::ParallelDescriptor::IOProcessor()) { // Ensure IOProc check for safety if Verbose isn't global
-            amrex::Print() << "TiffReader DEBUG (readFile): FillOrder tag read from file '" << filename << "' is: " << fill_order_r0
-                           << " (1=MSB2LSB, 2=LSB2MSB, Standard TIFF Default=" << FILLORDER_MSB2LSB << ")\n";
+
+        if (amrex::Verbose() >= 2 &&
+            amrex::ParallelDescriptor::IOProcessor()) { // Ensure IOProc check for safety if Verbose
+                                                        // isn't global
+            amrex::Print() << "TiffReader DEBUG (readFile): FillOrder tag read from file '"
+                           << filename << "' is: " << fill_order_r0
+                           << " (1=MSB2LSB, 2=LSB2MSB, Standard TIFF Default=" << FILLORDER_MSB2LSB
+                           << ")\n";
         }
 
-        width_r0 = static_cast<int>(w32); height_r0 = static_cast<int>(h32);
-        bool valid_bps = (bps_r0 == 1 || bps_r0 == 8 || bps_r0 == 16 || bps_r0 == 32 || bps_r0 == 64);
-        if (width_r0 <= 0 || height_r0 <= 0 || !valid_bps || planar != PLANARCONFIG_CONTIG || spp_r0 != 1) {
+        width_r0 = static_cast<int>(w32);
+        height_r0 = static_cast<int>(h32);
+        bool valid_bps =
+            (bps_r0 == 1 || bps_r0 == 8 || bps_r0 == 16 || bps_r0 == 32 || bps_r0 == 64);
+        if (width_r0 <= 0 || height_r0 <= 0 || !valid_bps || planar != PLANARCONFIG_CONTIG ||
+            spp_r0 != 1) {
             std::stringstream ss;
-            ss << "[TiffReader::readFile] Invalid/unsupported TIFF: " << filename << " (W=" << width_r0 
-               << ", H=" << height_r0 << ", BPS=" << bps_r0 << ", Planar=" << planar << ", SPP=" << spp_r0 << ").";
+            ss << "[TiffReader::readFile] Invalid/unsupported TIFF: " << filename
+               << " (W=" << width_r0 << ", H=" << height_r0 << ", BPS=" << bps_r0
+               << ", Planar=" << planar << ", SPP=" << spp_r0 << ").";
             amrex::Abort(ss.str());
         }
         depth_r0 = 0;
-        if (!TIFFSetDirectory(tif.get(), 0)) { amrex::Abort("[TiffReader::readFile] Failed to set initial directory (0) in: " + filename); }
-        do { depth_r0++; } while (TIFFReadDirectory(tif.get()));
-        if (depth_r0 == 0) { amrex::Abort("[TiffReader::readFile] No directories (depth=0) in: " + filename); }
+        if (!TIFFSetDirectory(tif.get(), 0)) {
+            amrex::Abort("[TiffReader::readFile] Failed to set initial directory (0) in: " +
+                         filename);
+        }
+        do {
+            depth_r0++;
+        } while (TIFFReadDirectory(tif.get()));
+        if (depth_r0 == 0) {
+            amrex::Abort("[TiffReader::readFile] No directories (depth=0) in: " + filename);
+        }
     }
 
     int root = amrex::ParallelDescriptor::IOProcessorNumber();
-    std::vector<int> idata = {width_r0, height_r0, depth_r0, static_cast<int>(bps_r0), static_cast<int>(fmt_r0), static_cast<int>(spp_r0), 0 /*is_sequence=false*/, static_cast<int>(fill_order_r0)};
-    amrex::ParallelDescriptor::Bcast(idata.data(), idata.size(), root, amrex::ParallelDescriptor::Communicator());
-    m_width=idata[0]; m_height=idata[1]; m_depth=idata[2]; m_bits_per_sample=(uint16_t)idata[3]; m_sample_format=(uint16_t)idata[4]; m_samples_per_pixel=(uint16_t)idata[5]; m_is_sequence=(bool)idata[6]; m_fill_order=(uint16_t)idata[7];
+    std::vector<int> idata = {width_r0,
+                              height_r0,
+                              depth_r0,
+                              static_cast<int>(bps_r0),
+                              static_cast<int>(fmt_r0),
+                              static_cast<int>(spp_r0),
+                              0 /*is_sequence=false*/,
+                              static_cast<int>(fill_order_r0)};
+    amrex::ParallelDescriptor::Bcast(idata.data(), idata.size(), root,
+                                     amrex::ParallelDescriptor::Communicator());
+    m_width = idata[0];
+    m_height = idata[1];
+    m_depth = idata[2];
+    m_bits_per_sample = (uint16_t)idata[3];
+    m_sample_format = (uint16_t)idata[4];
+    m_samples_per_pixel = (uint16_t)idata[5];
+    m_is_sequence = (bool)idata[6];
+    m_fill_order = (uint16_t)idata[7];
 
     // Corrected string broadcast for m_filename
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        int string_len = static_cast<int>(m_filename.length()); // m_filename is already set on IOProc
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_filename.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        int string_len =
+            static_cast<int>(m_filename.length()); // m_filename is already set on IOProc
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_filename.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     } else {
         int string_len = 0;
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
         m_filename.resize(string_len);
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_filename.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_filename.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     }
 
     if (m_width <= 0 || m_height <= 0 || m_depth <= 0 || m_bits_per_sample == 0) {
@@ -204,25 +303,37 @@ bool TiffReader::readFile(const std::string& filename) {
 //================================================================
 // readFileSequence Method
 //================================================================
-bool TiffReader::readFileSequence(
-    const std::string& base_pattern, int num_files,
-    int start_index, int digits, const std::string& suffix) {
+bool TiffReader::readFileSequence(const std::string& base_pattern, int num_files, int start_index,
+                                  int digits, const std::string& suffix) {
     // Ensure member variables are set correctly if this is called directly
-    m_is_sequence = true; m_base_pattern = base_pattern; m_start_index = start_index; m_digits = digits; m_suffix = suffix; m_filename = "";
-    int width_r0=0, height_r0=0, depth_r0=0;
-    uint16_t bps_r0=0, fmt_r0=SAMPLEFORMAT_UINT, spp_r0=1, fill_order_r0 = FILLORDER_MSB2LSB;
+    m_is_sequence = true;
+    m_base_pattern = base_pattern;
+    m_start_index = start_index;
+    m_digits = digits;
+    m_suffix = suffix;
+    m_filename = "";
+    int width_r0 = 0, height_r0 = 0, depth_r0 = 0;
+    uint16_t bps_r0 = 0, fmt_r0 = SAMPLEFORMAT_UINT, spp_r0 = 1, fill_order_r0 = FILLORDER_MSB2LSB;
     std::string first_filename_r0 = "";
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        if (num_files <= 0 || digits <= 0 || base_pattern.empty()) { amrex::Abort("[TiffReader::readFileSequence] Invalid sequence params."); }
+        if (num_files <= 0 || digits <= 0 || base_pattern.empty()) {
+            amrex::Abort("[TiffReader::readFileSequence] Invalid sequence params.");
+        }
         depth_r0 = num_files; // For sequences, depth is num_files
         first_filename_r0 = generateFilename(base_pattern, start_index, digits, suffix);
         TiffPtr tif(TIFFOpen(first_filename_r0.c_str(), "r"), TiffCloser());
-        if (!tif) { amrex::Abort("[TiffReader::readFileSequence] Failed to open first sequence file: " + first_filename_r0); }
-        
-        uint32_t w32=0, h32=0; uint16_t planar = PLANARCONFIG_CONTIG;
-        if (!TIFFGetField(tif.get(), TIFFTAG_IMAGEWIDTH, &w32) || !TIFFGetField(tif.get(), TIFFTAG_IMAGELENGTH, &h32)) {
-             amrex::Abort("[TiffReader::readFileSequence] Failed to get image dimensions from: " + first_filename_r0);
+        if (!tif) {
+            amrex::Abort("[TiffReader::readFileSequence] Failed to open first sequence file: " +
+                         first_filename_r0);
+        }
+
+        uint32_t w32 = 0, h32 = 0;
+        uint16_t planar = PLANARCONFIG_CONTIG;
+        if (!TIFFGetField(tif.get(), TIFFTAG_IMAGEWIDTH, &w32) ||
+            !TIFFGetField(tif.get(), TIFFTAG_IMAGELENGTH, &h32)) {
+            amrex::Abort("[TiffReader::readFileSequence] Failed to get image dimensions from: " +
+                         first_filename_r0);
         }
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_BITSPERSAMPLE, &bps_r0);
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_SAMPLEFORMAT, &fmt_r0);
@@ -231,52 +342,91 @@ bool TiffReader::readFileSequence(
         TIFFGetFieldDefaulted(tif.get(), TIFFTAG_FILLORDER, &fill_order_r0);
 
         if (amrex::Verbose() >= 2 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "TiffReader DEBUG (readFileSequence): FillOrder tag read from file '" << first_filename_r0 << "' is: " << fill_order_r0
-                           << " (1=MSB2LSB, 2=LSB2MSB, Standard TIFF Default=" << FILLORDER_MSB2LSB << ")\n";
+            amrex::Print() << "TiffReader DEBUG (readFileSequence): FillOrder tag read from file '"
+                           << first_filename_r0 << "' is: " << fill_order_r0
+                           << " (1=MSB2LSB, 2=LSB2MSB, Standard TIFF Default=" << FILLORDER_MSB2LSB
+                           << ")\n";
         }
 
-        width_r0 = static_cast<int>(w32); height_r0 = static_cast<int>(h32);
-        bool valid_bps = (bps_r0 == 1 || bps_r0 == 8 || bps_r0 == 16 || bps_r0 == 32 || bps_r0 == 64);
-        if (width_r0 <= 0 || height_r0 <= 0 || !valid_bps || planar != PLANARCONFIG_CONTIG || spp_r0 != 1) {
-             std::stringstream ss;
-             ss << "[TiffReader::readFileSequence] Invalid/unsupported TIFF: " << first_filename_r0 << " (W=" << width_r0 
-                << ", H=" << height_r0 << ", BPS=" << bps_r0 << ", Planar=" << planar << ", SPP=" << spp_r0 << ").";
-             amrex::Abort(ss.str());
+        width_r0 = static_cast<int>(w32);
+        height_r0 = static_cast<int>(h32);
+        bool valid_bps =
+            (bps_r0 == 1 || bps_r0 == 8 || bps_r0 == 16 || bps_r0 == 32 || bps_r0 == 64);
+        if (width_r0 <= 0 || height_r0 <= 0 || !valid_bps || planar != PLANARCONFIG_CONTIG ||
+            spp_r0 != 1) {
+            std::stringstream ss;
+            ss << "[TiffReader::readFileSequence] Invalid/unsupported TIFF: " << first_filename_r0
+               << " (W=" << width_r0 << ", H=" << height_r0 << ", BPS=" << bps_r0
+               << ", Planar=" << planar << ", SPP=" << spp_r0 << ").";
+            amrex::Abort(ss.str());
         }
-        if (TIFFReadDirectory(tif.get())) { amrex::Warning("[TiffReader::readFileSequence] First sequence file has >1 directory. Using first only for metadata.");}
+        if (TIFFReadDirectory(tif.get())) {
+            amrex::Warning("[TiffReader::readFileSequence] First sequence file has >1 directory. "
+                           "Using first only for metadata.");
+        }
     }
-    
+
     int root = amrex::ParallelDescriptor::IOProcessorNumber();
-    // Broadcast m_start_index, m_digits separately or ensure they are set from constructor before this Bcast
-    std::vector<int> idata = {width_r0, height_r0, depth_r0, static_cast<int>(bps_r0), static_cast<int>(fmt_r0), static_cast<int>(spp_r0), 1 /*is_sequence=true*/, m_start_index, m_digits, static_cast<int>(fill_order_r0)};
-    amrex::ParallelDescriptor::Bcast(idata.data(), idata.size(), root, amrex::ParallelDescriptor::Communicator());
-    m_width=idata[0]; m_height=idata[1]; m_depth=idata[2]; m_bits_per_sample=(uint16_t)idata[3]; m_sample_format=(uint16_t)idata[4]; m_samples_per_pixel=(uint16_t)idata[5]; m_is_sequence=(bool)idata[6]; m_start_index=idata[7]; m_digits=idata[8]; m_fill_order=(uint16_t)idata[9];
-    
+    // Broadcast m_start_index, m_digits separately or ensure they are set from constructor before
+    // this Bcast
+    std::vector<int> idata = {width_r0,
+                              height_r0,
+                              depth_r0,
+                              static_cast<int>(bps_r0),
+                              static_cast<int>(fmt_r0),
+                              static_cast<int>(spp_r0),
+                              1 /*is_sequence=true*/,
+                              m_start_index,
+                              m_digits,
+                              static_cast<int>(fill_order_r0)};
+    amrex::ParallelDescriptor::Bcast(idata.data(), idata.size(), root,
+                                     amrex::ParallelDescriptor::Communicator());
+    m_width = idata[0];
+    m_height = idata[1];
+    m_depth = idata[2];
+    m_bits_per_sample = (uint16_t)idata[3];
+    m_sample_format = (uint16_t)idata[4];
+    m_samples_per_pixel = (uint16_t)idata[5];
+    m_is_sequence = (bool)idata[6];
+    m_start_index = idata[7];
+    m_digits = idata[8];
+    m_fill_order = (uint16_t)idata[9];
+
     // Corrected string broadcast for m_base_pattern
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        int string_len = static_cast<int>(m_base_pattern.length()); // m_base_pattern is set on IOProc
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_base_pattern.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        int string_len =
+            static_cast<int>(m_base_pattern.length()); // m_base_pattern is set on IOProc
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_base_pattern.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     } else {
         int string_len = 0;
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
         m_base_pattern.resize(string_len);
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_base_pattern.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_base_pattern.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     }
 
     // Corrected string broadcast for m_suffix
     if (amrex::ParallelDescriptor::IOProcessor()) {
         int string_len = static_cast<int>(m_suffix.length()); // m_suffix is set on IOProc
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_suffix.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_suffix.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     } else {
         int string_len = 0;
-        amrex::ParallelDescriptor::Bcast(&string_len, 1, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(&string_len, 1, root,
+                                         amrex::ParallelDescriptor::Communicator());
         m_suffix.resize(string_len);
-        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_suffix.data()), string_len, root, amrex::ParallelDescriptor::Communicator());
+        amrex::ParallelDescriptor::Bcast(const_cast<char*>(m_suffix.data()), string_len, root,
+                                         amrex::ParallelDescriptor::Communicator());
     }
 
-    if (m_width <= 0 || m_height <= 0 || m_depth <= 0 || m_bits_per_sample == 0 || (m_is_sequence && m_base_pattern.empty())) {
+    if (m_width <= 0 || m_height <= 0 || m_depth <= 0 || m_bits_per_sample == 0 ||
+        (m_is_sequence && m_base_pattern.empty())) {
         amrex::Abort("TiffReader::readFileSequence: Invalid metadata after broadcast.");
     }
     m_is_read = true;
@@ -286,20 +436,24 @@ bool TiffReader::readFileSequence(
 //================================================================
 // readDistributedIntoFab Method - Main Data Reading Logic
 //================================================================
-void TiffReader::readDistributedIntoFab(
-    amrex::iMultiFab& dest_mf, int value_if_true,
-    int value_if_false, double raw_threshold) const {
-    if (!m_is_read) { amrex::Abort("[TiffReader::readDistributedIntoFab] Metadata not processed."); }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.boxArray().minimalBox()==this->box(), "Dest MF BoxArray domain mismatch.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.nComp()==1, "Dest MF must have 1 component.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.nGrow()==0, "Dest MF must have 0 ghost cells.");
+void TiffReader::readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_true,
+                                        int value_if_false, double raw_threshold) const {
+    if (!m_is_read) {
+        amrex::Abort("[TiffReader::readDistributedIntoFab] Metadata not processed.");
+    }
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.boxArray().minimalBox() == this->box(),
+                                     "Dest MF BoxArray domain mismatch.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.nComp() == 1, "Dest MF must have 1 component.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dest_mf.nGrow() == 0, "Dest MF must have 0 ghost cells.");
 
     const int bits_per_sample_val = m_bits_per_sample;
     const size_t bytes_per_sample_calc = (bits_per_sample_val >= 8) ? (bits_per_sample_val / 8) : 1;
     const size_t bytes_per_pixel = bytes_per_sample_calc * m_samples_per_pixel; // Assumes SPP=1
-    if (bits_per_sample_val == 0 ) { amrex::Abort("[TiffReader] Bits per sample is zero!"); }
+    if (bits_per_sample_val == 0) {
+        amrex::Abort("[TiffReader] Bits per sample is zero!");
+    }
 
-    const int image_width_const = m_width; 
+    const int image_width_const = m_width;
     const int image_height_const = m_height;
     const int image_depth_const = m_depth;
     const uint16_t fill_order_local = m_fill_order;
@@ -309,7 +463,7 @@ void TiffReader::readDistributedIntoFab(
 #endif
     {
         std::vector<unsigned char> temp_buffer;
-        TiffPtr thread_local_tif_handle = nullptr; 
+        TiffPtr thread_local_tif_handle = nullptr;
 
         for (amrex::MFIter mfi(dest_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             amrex::Array4<int> fab_arr = dest_mf.array(mfi);
@@ -322,84 +476,160 @@ void TiffReader::readDistributedIntoFab(
                 TIFF* current_tif_ptr = nullptr;
 
                 if (m_is_sequence) {
-                    std::string current_filename = generateFilename(m_base_pattern, m_start_index + k_loop_idx, m_digits, m_suffix);
-                    thread_local_tif_handle = TiffPtr(TIFFOpen(current_filename.c_str(), "r"), TiffCloser());
-                    if (!thread_local_tif_handle) { amrex::Abort("[TiffReader] Seq: Failed to open: " + current_filename); }
+                    std::string current_filename = generateFilename(
+                        m_base_pattern, m_start_index + k_loop_idx, m_digits, m_suffix);
+                    thread_local_tif_handle =
+                        TiffPtr(TIFFOpen(current_filename.c_str(), "r"), TiffCloser());
+                    if (!thread_local_tif_handle) {
+                        amrex::Abort("[TiffReader] Seq: Failed to open: " + current_filename);
+                    }
                     current_tif_ptr = thread_local_tif_handle.get();
                 } else { // Stack file
-                    thread_local_tif_handle = TiffPtr(TIFFOpen(m_filename.c_str(), "r"), TiffCloser());
-                    if (!thread_local_tif_handle) { amrex::Abort("[TiffReader] Stack: Failed to open: " + m_filename + " in thread."); }
+                    thread_local_tif_handle =
+                        TiffPtr(TIFFOpen(m_filename.c_str(), "r"), TiffCloser());
+                    if (!thread_local_tif_handle) {
+                        amrex::Abort("[TiffReader] Stack: Failed to open: " + m_filename +
+                                     " in thread.");
+                    }
                     current_tif_ptr = thread_local_tif_handle.get();
                     if (TIFFCurrentDirectory(current_tif_ptr) != static_cast<tdir_t>(k_loop_idx)) {
                         if (!TIFFSetDirectory(current_tif_ptr, static_cast<tdir_t>(k_loop_idx))) {
-                            amrex::Abort("[TiffReader] Stack: Failed to set dir " + std::to_string(k_loop_idx));
+                            amrex::Abort("[TiffReader] Stack: Failed to set dir " +
+                                         std::to_string(k_loop_idx));
                         }
                     }
                 }
-                
+
                 if (bits_per_sample_val == 1) {
                     actual_bytes_per_scanline_for_1bit = TIFFScanlineSize(current_tif_ptr);
-                    if (amrex::Verbose() >= 2 && omp_get_thread_num() == 0 && mfi.LocalTileIndex() == 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                         amrex::Print() << "DEBUG_SCANLINE_SIZE: Z-slice " << k_loop_idx
-                                   << ", TIFFScanlineSize() reports: " << actual_bytes_per_scanline_for_1bit
-                                   << " bytes/scanline. (ImgWidth=" << image_width_const
-                                   << ", TheoryMinBytes: " << (image_width_const + 7) / 8 << ")\n";
+                    if (amrex::Verbose() >= 2 && omp_get_thread_num() == 0 &&
+                        mfi.LocalTileIndex() == 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print()
+                            << "DEBUG_SCANLINE_SIZE: Z-slice " << k_loop_idx
+                            << ", TIFFScanlineSize() reports: "
+                            << actual_bytes_per_scanline_for_1bit
+                            << " bytes/scanline. (ImgWidth=" << image_width_const
+                            << ", TheoryMinBytes: " << (image_width_const + 7) / 8 << ")\n";
                     }
-                     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(actual_bytes_per_scanline_for_1bit > 0 || image_width_const == 0, 
-                                                 "actual_bytes_per_scanline_for_1bit is zero for 1-bit image with non-zero width!");
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(actual_bytes_per_scanline_for_1bit > 0 ||
+                                                         image_width_const == 0,
+                                                     "actual_bytes_per_scanline_for_1bit is zero "
+                                                     "for 1-bit image with non-zero width!");
                 }
 
                 bool is_tiled = TIFFIsTiled(current_tif_ptr);
 
                 if (is_tiled) {
-                    uint32_t tile_w=0, tile_h=0; tsize_t tile_buf_size=0;
+                    uint32_t tile_w = 0, tile_h = 0;
+                    tsize_t tile_buf_size = 0;
                     TIFFGetField(current_tif_ptr, TIFFTAG_TILEWIDTH, &tile_w);
                     TIFFGetField(current_tif_ptr, TIFFTAG_TILELENGTH, &tile_h);
                     tile_buf_size = TIFFTileSize(current_tif_ptr);
-                    if(tile_w==0||tile_h==0||tile_buf_size<=0) amrex::Abort("Invalid tile params.");
-                    if(temp_buffer.size()< (size_t)tile_buf_size) temp_buffer.resize(tile_buf_size);
-                    const int tile_width_int = (int)tile_w; const int tile_height_int = (int)tile_h;
-                    int tx_min = tile_box.smallEnd(0)/tile_width_int; int tx_max = tile_box.bigEnd(0)/tile_width_int;
-                    int ty_min = tile_box.smallEnd(1)/tile_height_int; int ty_max = tile_box.bigEnd(1)/tile_height_int;
+                    if (tile_w == 0 || tile_h == 0 || tile_buf_size <= 0)
+                        amrex::Abort("Invalid tile params.");
+                    if (temp_buffer.size() < (size_t)tile_buf_size)
+                        temp_buffer.resize(tile_buf_size);
+                    const int tile_width_int = (int)tile_w;
+                    const int tile_height_int = (int)tile_h;
+                    int tx_min = tile_box.smallEnd(0) / tile_width_int;
+                    int tx_max = tile_box.bigEnd(0) / tile_width_int;
+                    int ty_min = tile_box.smallEnd(1) / tile_height_int;
+                    int ty_max = tile_box.bigEnd(1) / tile_height_int;
 
                     for (int ty = ty_min; ty <= ty_max; ++ty) {
                         for (int tx = tx_min; tx <= tx_max; ++tx) {
-                            int chk_ox = tx*tile_width_int; int chk_oy = ty*tile_height_int;
-                            amrex::Box chk_box(amrex::IntVect(chk_ox,chk_oy,k_loop_idx), amrex::IntVect(chk_ox+tile_width_int-1, chk_oy+tile_height_int-1, k_loop_idx));
+                            int chk_ox = tx * tile_width_int;
+                            int chk_oy = ty * tile_height_int;
+                            amrex::Box chk_box(amrex::IntVect(chk_ox, chk_oy, k_loop_idx),
+                                               amrex::IntVect(chk_ox + tile_width_int - 1,
+                                                              chk_oy + tile_height_int - 1,
+                                                              k_loop_idx));
                             amrex::Box insect = tile_box & chk_box;
                             if (insect.ok()) {
-                                ttile_t tile_idx = TIFFComputeTile(current_tif_ptr, chk_ox, chk_oy, 0, 0);
-                                tsize_t bytes_rd = TIFFReadEncodedTile(current_tif_ptr, tile_idx, temp_buffer.data(), tile_buf_size);
-                                if(bytes_rd < 0) amrex::Abort("Error reading tile " + std::to_string(tile_idx));
-                                amrex::LoopOnCpu(insect, [&](int i, int j, int k_fab){
-                                    double val_dbl=0.0; int bit_v=-1; unsigned char p_byte=0; size_t byte_i=0; int bit_i=0; size_t lin_i_chk=0;
-                                    if(bits_per_sample_val==1){
-                                        int i_chk=i-chk_ox; int j_chk=j-chk_oy;
-                                        lin_i_chk = (size_t)j_chk*tile_width_int + i_chk; // Use tile_width_int for tile calculations
-                                        byte_i=lin_i_chk/8; bit_i=lin_i_chk%8;
-                                        if(byte_i<(size_t)bytes_rd){ p_byte=temp_buffer[byte_i]; bit_v=(fill_order_local==FILLORDER_MSB2LSB)?(p_byte>>(7-bit_i))&1:(p_byte>>bit_i)&1; val_dbl=(double)bit_v; }
-                                        else { val_dbl=0.0; bit_v=-2; }
+                                ttile_t tile_idx =
+                                    TIFFComputeTile(current_tif_ptr, chk_ox, chk_oy, 0, 0);
+                                tsize_t bytes_rd = TIFFReadEncodedTile(
+                                    current_tif_ptr, tile_idx, temp_buffer.data(), tile_buf_size);
+                                if (bytes_rd < 0)
+                                    amrex::Abort("Error reading tile " + std::to_string(tile_idx));
+                                amrex::LoopOnCpu(insect, [&](int i, int j, int k_fab) {
+                                    double val_dbl = 0.0;
+                                    int bit_v = -1;
+                                    unsigned char p_byte = 0;
+                                    size_t byte_i = 0;
+                                    int bit_i = 0;
+                                    size_t lin_i_chk = 0;
+                                    if (bits_per_sample_val == 1) {
+                                        int i_chk = i - chk_ox;
+                                        int j_chk = j - chk_oy;
+                                        lin_i_chk =
+                                            (size_t)j_chk * tile_width_int +
+                                            i_chk; // Use tile_width_int for tile calculations
+                                        byte_i = lin_i_chk / 8;
+                                        bit_i = lin_i_chk % 8;
+                                        if (byte_i < (size_t)bytes_rd) {
+                                            p_byte = temp_buffer[byte_i];
+                                            bit_v = (fill_order_local == FILLORDER_MSB2LSB)
+                                                        ? (p_byte >> (7 - bit_i)) & 1
+                                                        : (p_byte >> bit_i) & 1;
+                                            val_dbl = (double)bit_v;
+                                        } else {
+                                            val_dbl = 0.0;
+                                            bit_v = -2;
+                                        }
                                     } else {
-                                        int i_chk=i-chk_ox; int j_chk=j-chk_oy;
-                                        size_t off = ((size_t)j_chk*tile_width_int + i_chk)*bytes_per_pixel; // Use tile_width_int
-                                        if(off+bytes_per_sample_calc <= (size_t)bytes_rd){ val_dbl=interpretBytesAsDouble(temp_buffer.data()+off, bits_per_sample_val, m_sample_format); }
-                                        else { val_dbl=0.0; }
+                                        int i_chk = i - chk_ox;
+                                        int j_chk = j - chk_oy;
+                                        size_t off = ((size_t)j_chk * tile_width_int + i_chk) *
+                                                     bytes_per_pixel; // Use tile_width_int
+                                        if (off + bytes_per_sample_calc <= (size_t)bytes_rd) {
+                                            val_dbl = interpretBytesAsDouble(
+                                                temp_buffer.data() + off, bits_per_sample_val,
+                                                m_sample_format);
+                                        } else {
+                                            val_dbl = 0.0;
+                                        }
                                     }
-                                    if (amrex::Verbose()>=3 && amrex::ParallelDescriptor::IOProcessor()){ bool bnd=(i==image_width_const-1||j==image_height_const-1||k_fab==image_depth_const-1||i==0||j==0||k_fab==0); if(bnd&&bits_per_sample_val==1) {amrex::Print().SetPrecision(0)<<"TIFF_DBG(Tile): V("<<i<<","<<j<<","<<k_fab<<") T("<<tx<<","<<ty<<") LinChkIdx("<<lin_i_chk<<") ByteIdx("<<byte_i<<") BitInByte("<<bit_i<<") PByte(0x"<<std::hex<<(int)p_byte<<std::dec<<") RawBit("<<bit_v<<") Thr("<<((val_dbl>raw_threshold)?value_if_true:value_if_false)<<")\n";}}
-                                    fab_arr(i,j,k_fab) = (val_dbl > raw_threshold) ? value_if_true : value_if_false;
+                                    if (amrex::Verbose() >= 3 &&
+                                        amrex::ParallelDescriptor::IOProcessor()) {
+                                        bool bnd = (i == image_width_const - 1 ||
+                                                    j == image_height_const - 1 ||
+                                                    k_fab == image_depth_const - 1 || i == 0 ||
+                                                    j == 0 || k_fab == 0);
+                                        if (bnd && bits_per_sample_val == 1) {
+                                            amrex::Print().SetPrecision(0)
+                                                << "TIFF_DBG(Tile): V(" << i << "," << j << ","
+                                                << k_fab << ") T(" << tx << "," << ty
+                                                << ") LinChkIdx(" << lin_i_chk << ") ByteIdx("
+                                                << byte_i << ") BitInByte(" << bit_i << ") PByte(0x"
+                                                << std::hex << (int)p_byte << std::dec
+                                                << ") RawBit(" << bit_v << ") Thr("
+                                                << ((val_dbl > raw_threshold) ? value_if_true
+                                                                              : value_if_false)
+                                                << ")\n";
+                                        }
+                                    }
+                                    fab_arr(i, j, k_fab) =
+                                        (val_dbl > raw_threshold) ? value_if_true : value_if_false;
                                 });
                             }
                         }
                     }
                 } else { // Striped Reading
-                    uint32_t rps=0; uint32_t cur_h32=(uint32_t)m_height; tsize_t strip_buf_size=0;
+                    uint32_t rps = 0;
+                    uint32_t cur_h32 = (uint32_t)m_height;
+                    tsize_t strip_buf_size = 0;
                     TIFFGetFieldDefaulted(current_tif_ptr, TIFFTAG_ROWSPERSTRIP, &rps);
                     strip_buf_size = TIFFStripSize(current_tif_ptr);
-                    if(rps==0||rps>cur_h32) rps=cur_h32;
-                    if(strip_buf_size<=0) amrex::Abort("Invalid strip buffer size.");
-                    if(temp_buffer.size()<(size_t)strip_buf_size) temp_buffer.resize(strip_buf_size);
+                    if (rps == 0 || rps > cur_h32)
+                        rps = cur_h32;
+                    if (strip_buf_size <= 0)
+                        amrex::Abort("Invalid strip buffer size.");
+                    if (temp_buffer.size() < (size_t)strip_buf_size)
+                        temp_buffer.resize(strip_buf_size);
 
-                    int fab_y_min = tile_box.smallEnd(1); int fab_y_max = tile_box.bigEnd(1);
+                    int fab_y_min = tile_box.smallEnd(1);
+                    int fab_y_max = tile_box.bigEnd(1);
                     tstrip_t first_strip = TIFFComputeStrip(current_tif_ptr, fab_y_min, 0);
                     tstrip_t last_strip = TIFFComputeStrip(current_tif_ptr, fab_y_max, 0);
 
@@ -407,36 +637,80 @@ void TiffReader::readDistributedIntoFab(
                         uint32_t strip_oy_uint = strip_num * rps;
                         int strip_oy_img = (int)strip_oy_uint;
                         uint32_t rows_this_strip = std::min(rps, cur_h32 - strip_oy_uint);
-                        if(rows_this_strip==0) continue;
+                        if (rows_this_strip == 0)
+                            continue;
                         int strip_h_px = (int)rows_this_strip;
-                        amrex::Box strip_box_img(amrex::IntVect(0,strip_oy_img,k_loop_idx), amrex::IntVect(image_width_const-1, strip_oy_img+strip_h_px-1, k_loop_idx));
+                        amrex::Box strip_box_img(amrex::IntVect(0, strip_oy_img, k_loop_idx),
+                                                 amrex::IntVect(image_width_const - 1,
+                                                                strip_oy_img + strip_h_px - 1,
+                                                                k_loop_idx));
                         amrex::Box insect = tile_box & strip_box_img;
-                        if(insect.ok()){
-                            tsize_t bytes_rd = TIFFReadEncodedStrip(current_tif_ptr, strip_num, temp_buffer.data(), strip_buf_size);
-                            if(bytes_rd<0) amrex::Abort("Error reading strip " + std::to_string(strip_num));
-                            amrex::LoopOnCpu(insect, [&](int i, int j, int k_fab){
-                                double val_dbl=0.0; int bit_v=-1; unsigned char p_byte=0; size_t byte_i=0; int bit_i=0;
-                                if(bits_per_sample_val==1){
-                                    int j_in_strip_buf = j - strip_oy_img; 
-                                    size_t scanline_start_off = (size_t)j_in_strip_buf * actual_bytes_per_scanline_for_1bit;
+                        if (insect.ok()) {
+                            tsize_t bytes_rd = TIFFReadEncodedStrip(
+                                current_tif_ptr, strip_num, temp_buffer.data(), strip_buf_size);
+                            if (bytes_rd < 0)
+                                amrex::Abort("Error reading strip " + std::to_string(strip_num));
+                            amrex::LoopOnCpu(insect, [&](int i, int j, int k_fab) {
+                                double val_dbl = 0.0;
+                                int bit_v = -1;
+                                unsigned char p_byte = 0;
+                                size_t byte_i = 0;
+                                int bit_i = 0;
+                                if (bits_per_sample_val == 1) {
+                                    int j_in_strip_buf = j - strip_oy_img;
+                                    size_t scanline_start_off =
+                                        (size_t)j_in_strip_buf * actual_bytes_per_scanline_for_1bit;
                                     size_t byte_off_in_scanline = (size_t)i / 8;
                                     bit_i = i % 8;
                                     byte_i = scanline_start_off + byte_off_in_scanline;
-                                    if(byte_i<(size_t)bytes_rd){ p_byte=temp_buffer[byte_i]; bit_v=(fill_order_local==FILLORDER_MSB2LSB)?(p_byte>>(7-bit_i))&1:(p_byte>>bit_i)&1; val_dbl=(double)bit_v; }
-                                    else { val_dbl=0.0; bit_v=-2; }
+                                    if (byte_i < (size_t)bytes_rd) {
+                                        p_byte = temp_buffer[byte_i];
+                                        bit_v = (fill_order_local == FILLORDER_MSB2LSB)
+                                                    ? (p_byte >> (7 - bit_i)) & 1
+                                                    : (p_byte >> bit_i) & 1;
+                                        val_dbl = (double)bit_v;
+                                    } else {
+                                        val_dbl = 0.0;
+                                        bit_v = -2;
+                                    }
                                 } else {
                                     int j_in_strip_buf = j - strip_oy_img;
-                                    size_t off = ((size_t)j_in_strip_buf * image_width_const + i) * bytes_per_pixel;
-                                    if(off+bytes_per_sample_calc <= (size_t)bytes_rd){ val_dbl=interpretBytesAsDouble(temp_buffer.data()+off, bits_per_sample_val, m_sample_format); }
-                                    else { val_dbl=0.0; }
+                                    size_t off = ((size_t)j_in_strip_buf * image_width_const + i) *
+                                                 bytes_per_pixel;
+                                    if (off + bytes_per_sample_calc <= (size_t)bytes_rd) {
+                                        val_dbl = interpretBytesAsDouble(temp_buffer.data() + off,
+                                                                         bits_per_sample_val,
+                                                                         m_sample_format);
+                                    } else {
+                                        val_dbl = 0.0;
+                                    }
                                 }
-                                if (amrex::Verbose()>=3 && amrex::ParallelDescriptor::IOProcessor()){ bool bnd=(i==image_width_const-1||j==image_height_const-1||k_fab==image_depth_const-1||i==0||j==0||k_fab==0); if(bnd&&bits_per_sample_val==1) {amrex::Print().SetPrecision(0)<<"TIFF_DBG(Strip): V("<<i<<","<<j<<","<<k_fab<<") Strp("<<strip_num<<") ByteIdxInBuf("<<byte_i<<") BitInByte("<<bit_i<<") PByte(0x"<<std::hex<<(int)p_byte<<std::dec<<") RawBit("<<bit_v<<") Thr("<<((val_dbl > raw_threshold) ? value_if_true : value_if_false)<<")\n";}}
-                                fab_arr(i,j,k_fab) = (val_dbl > raw_threshold) ? value_if_true : value_if_false;
+                                if (amrex::Verbose() >= 3 &&
+                                    amrex::ParallelDescriptor::IOProcessor()) {
+                                    bool bnd = (i == image_width_const - 1 ||
+                                                j == image_height_const - 1 ||
+                                                k_fab == image_depth_const - 1 || i == 0 ||
+                                                j == 0 || k_fab == 0);
+                                    if (bnd && bits_per_sample_val == 1) {
+                                        amrex::Print().SetPrecision(0)
+                                            << "TIFF_DBG(Strip): V(" << i << "," << j << ","
+                                            << k_fab << ") Strp(" << strip_num << ") ByteIdxInBuf("
+                                            << byte_i << ") BitInByte(" << bit_i << ") PByte(0x"
+                                            << std::hex << (int)p_byte << std::dec << ") RawBit("
+                                            << bit_v << ") Thr("
+                                            << ((val_dbl > raw_threshold) ? value_if_true
+                                                                          : value_if_false)
+                                            << ")\n";
+                                    }
+                                }
+                                fab_arr(i, j, k_fab) =
+                                    (val_dbl > raw_threshold) ? value_if_true : value_if_false;
                             });
                         }
                     }
                 }
-                // thread_local_tif_handle (and its TIFF*) will be closed when TiffPtr goes out of scope at the end of this k_loop_idx iteration
+                // thread_local_tif_handle (and its TIFF*) will be closed when TiffPtr goes out of
+                // scope at the end of this k_loop_idx iteration
             } // End k_loop_idx Z-slices
         } // End MFIter
     } // End OMP parallel region
@@ -446,7 +720,8 @@ void TiffReader::readDistributedIntoFab(
 //================================================================
 // Public threshold methods
 //================================================================
-void TiffReader::threshold(double raw_threshold, int value_if_true, int value_if_false, amrex::iMultiFab& mf) const {
+void TiffReader::threshold(double raw_threshold, int value_if_true, int value_if_false,
+                           amrex::iMultiFab& mf) const {
     readDistributedIntoFab(mf, value_if_true, value_if_false, raw_threshold);
 }
 

--- a/src/io/tHDF5Reader.cpp
+++ b/src/io/tHDF5Reader.cpp
@@ -7,8 +7,8 @@
 #include <fstream>   // For std::ifstream check
 #include <iomanip>   // For std::setw, std::setfill
 #include <ctime>
-#include <memory>    // For std::unique_ptr, std::make_unique
-#include <sstream>   // For std::stringstream
+#include <memory>  // For std::unique_ptr, std::make_unique
+#include <sstream> // For std::stringstream
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H> // For reading input files
@@ -23,10 +23,10 @@
 #include <AMReX_CoordSys.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_PlotFileUtil.H>
-#include <AMReX_Utility.H> // For amrex::UtilCreateDirectory, amrex::Concatenate
+#include <AMReX_Utility.H>            // For amrex::UtilCreateDirectory, amrex::Concatenate
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier, MyProc
-#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
-#include <AMReX_MFIter.H>    // Needed for MFIter
+#include <AMReX_GpuLaunch.H>          // Provides amrex::ParallelFor
+#include <AMReX_MFIter.H>             // Needed for MFIter
 
 
 // Output directory relative to executable location
@@ -34,8 +34,7 @@ const std::string test_output_dir = "tHDF5Reader_output";
 // Define Box size for breaking down domain (can also be read from inputs)
 const int BOX_SIZE = 32;
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
     amrex::Initialize(argc, argv);
 
     // Use a block for AMReX object lifetimes
@@ -49,7 +48,7 @@ int main (int argc, char* argv[])
 
 
         // --- ParmParse ---
-        { // Use ParmParse to query the database populated by Initialize
+        {                        // Use ParmParse to query the database populated by Initialize
             amrex::ParmParse pp; // No prefix - queries global database
 
             // These should now work if make test passes ./inputs argument
@@ -67,14 +66,16 @@ int main (int argc, char* argv[])
         {
             std::ifstream test_ifs(hdf5_filename);
             if (!test_ifs) {
-                amrex::Error("Error: Cannot open input HDF5 file specified by 'filename': " + hdf5_filename);
+                amrex::Error("Error: Cannot open input HDF5 file specified by 'filename': " +
+                             hdf5_filename);
             }
             // (Removed DEBUG print for successful open)
         }
 
         // --- Parameter Summary ---
         if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "Starting tHDF5Reader Test (Compiled: " << __DATE__ << " " << __TIME__ << ")\n";
+            amrex::Print() << "Starting tHDF5Reader Test (Compiled: " << __DATE__ << " " << __TIME__
+                           << ")\n";
             amrex::Print() << "Input HDF5 file (from inputs): " << hdf5_filename << "\n";
             amrex::Print() << "Input dataset path (from inputs): " << hdf5_dataset << "\n";
             amrex::Print() << "Threshold value: " << threshold_value << "\n";
@@ -112,14 +113,17 @@ int main (int argc, char* argv[])
         int actual_depth = reader_ptr->depth();
 
         if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x" << actual_depth << "\n";
+            amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x"
+                           << actual_depth << "\n";
             // (Removed skipping metadata checks message)
         }
 
-        if (actual_width != expected_width || actual_height != expected_height || actual_depth != expected_depth) {
+        if (actual_width != expected_width || actual_height != expected_height ||
+            actual_depth != expected_depth) {
             std::stringstream ss;
-            ss << "FAIL: Read dimensions (" << actual_width << "x" << actual_height << "x" << actual_depth
-               << ") do not match expected dimensions (" << expected_width << "x" << expected_height << "x" << expected_depth << ").";
+            ss << "FAIL: Read dimensions (" << actual_width << "x" << actual_height << "x"
+               << actual_depth << ") do not match expected dimensions (" << expected_width << "x"
+               << expected_height << "x" << expected_depth << ").";
             amrex::Error(ss.str());
         }
 
@@ -132,11 +136,11 @@ int main (int argc, char* argv[])
         amrex::Box domain_box = reader_ptr->box();
         // (Removed DEBUG print for geometry/boxarray setup)
         {
-            amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
-                              {AMREX_D_DECL(amrex::Real(domain_box.length(0)),
-                                            amrex::Real(domain_box.length(1)),
-                                            amrex::Real(domain_box.length(2)))});
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0};
+            amrex::RealBox rb(
+                {AMREX_D_DECL(0.0, 0.0, 0.0)},
+                {AMREX_D_DECL(amrex::Real(domain_box.length(0)), amrex::Real(domain_box.length(1)),
+                              amrex::Real(domain_box.length(2)))});
+            amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
             geom.define(domain_box, &rb, amrex::CoordSys::cartesian, is_periodic.data());
         }
         amrex::BoxArray ba(domain_box);
@@ -174,31 +178,31 @@ int main (int argc, char* argv[])
 
         // --- Optional: Write Plotfile ---
         if (write_plotfile) {
-             std::string plotfilename;
-             const std::string plotfile_prefix = "plt_thresh";
-             if (amrex::ParallelDescriptor::IOProcessor()) {
-                 if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
-                     amrex::CreateDirectoryFailed(test_output_dir);
-                 }
-             }
-             amrex::ParallelDescriptor::Barrier(); // Ensure directory exists before proceeding
+            std::string plotfilename;
+            const std::string plotfile_prefix = "plt_thresh";
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
+                    amrex::CreateDirectoryFailed(test_output_dir);
+                }
+            }
+            amrex::ParallelDescriptor::Barrier(); // Ensure directory exists before proceeding
 
-             // Construct filename (e.g., plt_thresh_00000) - simpler example
-             plotfilename = amrex::Concatenate(test_output_dir + "/" + plotfile_prefix, 5, '0');
+            // Construct filename (e.g., plt_thresh_00000) - simpler example
+            plotfilename = amrex::Concatenate(test_output_dir + "/" + plotfile_prefix, 5, '0');
 
-             if (amrex::ParallelDescriptor::IOProcessor()) {
-                  amrex::Print() << "Writing plotfile: " << plotfilename << "\n";
-             }
-             // Need to copy iMultiFab to MultiFab for plotting
-             amrex::MultiFab mfv(ba, dm, 1, 0);
-             amrex::Copy(mfv, mf, 0, 0, 1, 0); // Copy component 0 from mf to mfv
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "Writing plotfile: " << plotfilename << "\n";
+            }
+            // Need to copy iMultiFab to MultiFab for plotting
+            amrex::MultiFab mfv(ba, dm, 1, 0);
+            amrex::Copy(mfv, mf, 0, 0, 1, 0); // Copy component 0 from mf to mfv
 
-             amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0, 0);
+            amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0, 0);
 
-             if (amrex::ParallelDescriptor::IOProcessor()) {
-                 amrex::Print() << "Plotfile writing complete.\n";
-             }
-         }
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "Plotfile writing complete.\n";
+            }
+        }
 
         if (amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "tHDF5Reader Test Completed Successfully.\n";

--- a/src/io/tTiffReader.cpp
+++ b/src/io/tTiffReader.cpp
@@ -7,7 +7,7 @@
 #include <fstream>   // For std::ifstream check
 #include <iomanip>   // For std::setw, std::setfill
 #include <ctime>
-#include <memory>    // For std::unique_ptr
+#include <memory> // For std::unique_ptr
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H> // For reading command-line arguments
@@ -22,9 +22,9 @@
 #include <AMReX_CoordSys.H>
 #include <AMReX_DistributionMapping.H>
 #include <AMReX_PlotFileUtil.H>
-#include <AMReX_Utility.H>      // For amrex::UtilCreateDirectory
+#include <AMReX_Utility.H>            // For amrex::UtilCreateDirectory
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier
-#include <AMReX_GpuLaunch.H> // Provides amrex::ParallelFor
+#include <AMReX_GpuLaunch.H>          // Provides amrex::ParallelFor
 
 // Default relative path to the sample TIFF file
 // *** Make sure this points to a valid TIFF file (Striped or Tiled) ***
@@ -45,8 +45,7 @@ const int BOX_SIZE = 32;
 // const std::string default_sequence_suffix = ".tif";
 
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
     amrex::Initialize(argc, argv);
 
     // Use a block for AMReX object lifetimes
@@ -60,7 +59,7 @@ int main (int argc, char* argv[])
         // bool test_tiled = false;
 
         { // Use ParmParse to read parameters from command line
-         // Example: ./executable tifffile=path/to/stack.tif threshold=128 write_plotfile=1
+          // Example: ./executable tifffile=path/to/stack.tif threshold=128 write_plotfile=1
             amrex::ParmParse pp;
             pp.query("tifffile", tiff_filename);
             pp.query("threshold", threshold_val);
@@ -75,18 +74,22 @@ int main (int argc, char* argv[])
         // Note: For sequences, only check the first file
         std::string file_to_check = tiff_filename;
         // if (test_sequence) {
-        //     file_to_check = OpenImpala::generateFilename(default_sequence_pattern, default_start_index, default_sequence_digits, default_sequence_suffix);
+        //     file_to_check = OpenImpala::generateFilename(default_sequence_pattern,
+        //     default_start_index, default_sequence_digits, default_sequence_suffix);
         // }
         {
             std::ifstream test_ifs(file_to_check);
             if (!test_ifs) {
-                amrex::Abort("Error: Cannot open input file: " + file_to_check + "\n"
+                amrex::Abort("Error: Cannot open input file: " + file_to_check +
+                             "\n"
                              "       Specify path using 'tifffile=/path/to/file.tif'");
             }
         }
 
-        amrex::Print() << "Starting tTiffReader Test (Oxford, " << __DATE__ << " " << __TIME__ << ")\n";
-        amrex::Print() << "Input TIFF source: " << tiff_filename << "\n"; // Adjust message if testing sequences
+        amrex::Print() << "Starting tTiffReader Test (Oxford, " << __DATE__ << " " << __TIME__
+                       << ")\n";
+        amrex::Print() << "Input TIFF source: " << tiff_filename
+                       << "\n"; // Adjust message if testing sequences
         amrex::Print() << "Threshold value: " << threshold_val << "\n";
         amrex::Print() << "Write plot file: " << (write_plotfile ? "Yes" : "No") << "\n";
 
@@ -98,9 +101,9 @@ int main (int argc, char* argv[])
         int expected_width = 100;
         int expected_height = 100;
         int expected_depth = 100;
-        int expected_bps = 1;       // e.g., 8-bit
-        int expected_format = 1;    // e.g., SAMPLEFORMAT_UINT from tiff.h
-        int expected_spp = 1;       // e.g., grayscale
+        int expected_bps = 1;    // e.g., 8-bit
+        int expected_format = 1; // e.g., SAMPLEFORMAT_UINT from tiff.h
+        int expected_spp = 1;    // e.g., grayscale
 
         try {
             // *** BEHAVIOR CHANGE ***
@@ -116,11 +119,11 @@ int main (int argc, char* argv[])
             //     expected_depth = default_sequence_num_files; // Update expected depth
             //     // Update other expected values if sequence differs from single file
             // } else {
-                 reader_ptr = std::make_unique<OpenImpala::TiffReader>(tiff_filename);
+            reader_ptr = std::make_unique<OpenImpala::TiffReader>(tiff_filename);
             // }
 
             if (!reader_ptr->isRead()) { // Check if metadata read was successful
-                 throw std::runtime_error("Reader failed to read metadata (isRead() is false).");
+                throw std::runtime_error("Reader failed to read metadata (isRead() is false).");
             }
 
         } catch (const std::exception& e) {
@@ -136,24 +139,30 @@ int main (int argc, char* argv[])
         int actual_format = reader_ptr->sampleFormat();
         int actual_spp = reader_ptr->samplesPerPixel();
 
-        amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x" << actual_depth << "\n";
-        amrex::Print() << "  Read metadata: BPS=" << actual_bps << ", Format=" << actual_format << ", SPP=" << actual_spp << "\n";
+        amrex::Print() << "  Read dimensions: " << actual_width << "x" << actual_height << "x"
+                       << actual_depth << "\n";
+        amrex::Print() << "  Read metadata: BPS=" << actual_bps << ", Format=" << actual_format
+                       << ", SPP=" << actual_spp << "\n";
 
         // Use if/Abort instead of assert for checks active in all builds
-        if (actual_width != expected_width || actual_height != expected_height || actual_depth != expected_depth) {
-            amrex::Abort("FAIL: Read dimensions do not match expected dimensions (" + std::to_string(expected_width) + "x" + std::to_string(expected_height) + "x" + std::to_string(expected_depth) +").");
+        if (actual_width != expected_width || actual_height != expected_height ||
+            actual_depth != expected_depth) {
+            amrex::Abort("FAIL: Read dimensions do not match expected dimensions (" +
+                         std::to_string(expected_width) + "x" + std::to_string(expected_height) +
+                         "x" + std::to_string(expected_depth) + ").");
         }
         if (actual_bps != expected_bps) {
-             amrex::Abort("FAIL: Read BitsPerSample (" + std::to_string(actual_bps) +
-                          ") does not match expected value (" + std::to_string(expected_bps) + ").");
+            amrex::Abort("FAIL: Read BitsPerSample (" + std::to_string(actual_bps) +
+                         ") does not match expected value (" + std::to_string(expected_bps) + ").");
         }
         if (actual_format != expected_format) {
-             amrex::Abort("FAIL: Read SampleFormat (" + std::to_string(actual_format) +
-                          ") does not match expected value (" + std::to_string(expected_format) + ").");
+            amrex::Abort("FAIL: Read SampleFormat (" + std::to_string(actual_format) +
+                         ") does not match expected value (" + std::to_string(expected_format) +
+                         ").");
         }
         if (actual_spp != expected_spp) {
-             amrex::Abort("FAIL: Read SamplesPerPixel (" + std::to_string(actual_spp) +
-                          ") does not match expected value (" + std::to_string(expected_spp) + ").");
+            amrex::Abort("FAIL: Read SamplesPerPixel (" + std::to_string(actual_spp) +
+                         ") does not match expected value (" + std::to_string(expected_spp) + ").");
         }
         amrex::Print() << "  Dimensions and basic metadata match expected values.\n";
         // TODO: Add tests for TiffReader attribute reading if implemented and needed.
@@ -163,11 +172,13 @@ int main (int argc, char* argv[])
         amrex::Geometry geom;
         amrex::Box domain_box = reader_ptr->box();
         if (domain_box.isEmpty()) {
-             amrex::Abort("FAIL: Reader returned an empty box after metadata read.");
+            amrex::Abort("FAIL: Reader returned an empty box after metadata read.");
         }
         {
-            amrex::RealBox rb({0.0, 0.0, 0.0}, {(amrex::Real)actual_width, (amrex::Real)actual_height, (amrex::Real)actual_depth}); // Physical domain matching pixel size
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0};
+            amrex::RealBox rb({0.0, 0.0, 0.0},
+                              {(amrex::Real)actual_width, (amrex::Real)actual_height,
+                               (amrex::Real)actual_depth}); // Physical domain matching pixel size
+            amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
             // Note: Using default CoodSys = 0 (Cartesian)
             amrex::Geometry::Setup(&rb, 0, is_periodic.data());
             geom.define(domain_box);
@@ -180,7 +191,8 @@ int main (int argc, char* argv[])
         mf.setVal(-1); // Initialize to a sentinel value (e.g., -1) to ensure threshold modifies it
 
         // --- Test Thresholding (Now performs distributed I/O + threshold) ---
-        amrex::Print() << "Performing threshold > " << threshold_val << " (This now reads data chunk-by-chunk)...\n";
+        amrex::Print() << "Performing threshold > " << threshold_val
+                       << " (This now reads data chunk-by-chunk)...\n";
         try {
             // *** BEHAVIOR CHANGE ***
             // This call now triggers the parallel, distributed reading of TIFF strips/tiles
@@ -193,7 +205,8 @@ int main (int argc, char* argv[])
             // Check min/max against 50/100
 
         } catch (const std::exception& e) {
-            amrex::Abort("Error during threshold operation (read + process): " + std::string(e.what()));
+            amrex::Abort("Error during threshold operation (read + process): " +
+                         std::string(e.what()));
         }
 
         // Check results (min/max across all processors)
@@ -204,20 +217,24 @@ int main (int argc, char* argv[])
         amrex::Print() << "  Threshold result max value: " << max_val << "\n";
 
         // Check if result is binary (0 or 1) - Adjust if testing custom values
-        // This check is valid only if the threshold value is expected to segment the data into 0 and 1
-        if (min_val < 0 || max_val > 1 || (min_val == 0 && max_val == 0) || (min_val == 1 && max_val == 1) ) {
-             amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
-                           << ") is not {0, 1}. Check threshold value ("<< threshold_val
+        // This check is valid only if the threshold value is expected to segment the data into 0
+        // and 1
+        if (min_val < 0 || max_val > 1 || (min_val == 0 && max_val == 0) ||
+            (min_val == 1 && max_val == 1)) {
+            amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
+                           << ") is not {0, 1}. Check threshold value (" << threshold_val
                            << ") or sample data range.\n";
-             // If min==max==0 or min==max==1, threshold didn't separate phases.
-             // Decide if this is a fatal error for the test.
-             // amrex::Abort("FAIL: Threshold result unexpected.");
+            // If min==max==0 or min==max==1, threshold didn't separate phases.
+            // Decide if this is a fatal error for the test.
+            // amrex::Abort("FAIL: Threshold result unexpected.");
         } else if (min_val == 0 && max_val == 1) {
-             amrex::Print() << "  Threshold value range looks plausible (0 and 1 found).\n";
+            amrex::Print() << "  Threshold value range looks plausible (0 and 1 found).\n";
         } else {
-             amrex::Print() << "  Threshold value range is [" << min_val << ", " << max_val << "]. Check threshold logic if 0/1 expected.\n";
+            amrex::Print() << "  Threshold value range is [" << min_val << ", " << max_val
+                           << "]. Check threshold logic if 0/1 expected.\n";
         }
-        // TODO: Add separate tests for error conditions (bad file path handled, but test unsupported TIFF format if possible).
+        // TODO: Add separate tests for error conditions (bad file path handled, but test
+        // unsupported TIFF format if possible).
 
         // --- Optional: Write Plotfile (Remains the same) ---
         if (write_plotfile) {
@@ -227,7 +244,8 @@ int main (int argc, char* argv[])
             if (amrex::ParallelDescriptor::IOProcessor()) {
                 if (!amrex::UtilCreateDirectory(test_output_dir, 0755)) {
                     // Don't abort test, just warn that plotfile won't be written
-                    amrex::Warning("Could not create output directory: " + test_output_dir + ". Skipping plotfile write.");
+                    amrex::Warning("Could not create output directory: " + test_output_dir +
+                                   ". Skipping plotfile write.");
                     write_plotfile = false; // Disable writing
                 }
             }
@@ -239,10 +257,13 @@ int main (int argc, char* argv[])
                 // Get datetime string (same as before)
                 std::string datetime_str;
                 {
-                    std::time_t strt_time; std::tm* timeinfo; char datetime_buf[80];
-                    std::time(&strt_time); timeinfo = std::localtime(&strt_time);
+                    std::time_t strt_time;
+                    std::tm* timeinfo;
+                    char datetime_buf[80];
+                    std::time(&strt_time);
+                    timeinfo = std::localtime(&strt_time);
                     // Use ISO 8601 format for better sorting/clarity
-                    std::strftime(datetime_buf, sizeof(datetime_buf),"%Y%m%dT%H%M%S",timeinfo);
+                    std::strftime(datetime_buf, sizeof(datetime_buf), "%Y%m%dT%H%M%S", timeinfo);
                     datetime_str = datetime_buf;
                 }
                 // Construct filename
@@ -251,19 +272,18 @@ int main (int argc, char* argv[])
                 // Copy integer data to float MultiFab for plotting (same as before)
                 amrex::MultiFab mfv(ba, dm, 1, 0);
                 // Use ParallelFor for the copy
-                for (amrex::MFIter mfi(mfv, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
+                for (amrex::MFIter mfi(mfv, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
                     const amrex::Box& box = mfi.tilebox();
                     auto const& int_fab_arr = mf.const_array(mfi);
-                    auto        real_fab_arr = mfv.array(mfi);
-                    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                    {
+                    auto real_fab_arr = mfv.array(mfi);
+                    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         real_fab_arr(i, j, k) = static_cast<amrex::Real>(int_fab_arr(i, j, k));
                     });
                 }
 
                 // Write plot file (same as before)
-                amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0, 0);
+                amrex::WriteSingleLevelPlotfile(plotfilename, mfv, {"phase_threshold"}, geom, 0.0,
+                                                0);
                 amrex::Print() << "  Plot file written to: " << plotfilename << "\n";
             }
         }

--- a/src/props/Diffusion.cpp
+++ b/src/props/Diffusion.cpp
@@ -42,46 +42,51 @@
 
 // Anonymous namespace for helpers
 namespace {
-    OpenImpala::EffectiveDiffusivityHypre::SolverType stringToSolverType(const std::string& solver_str) {
-        std::string lower_solver_str = solver_str;
-        std::transform(lower_solver_str.begin(), lower_solver_str.end(), lower_solver_str.begin(),
-                       [](unsigned char c){ return std::tolower(c); });
-        if (lower_solver_str == "jacobi") return OpenImpala::EffectiveDiffusivityHypre::SolverType::Jacobi;
-        if (lower_solver_str == "gmres") return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES;
-        if (lower_solver_str == "flexgmres") return OpenImpala::EffectiveDiffusivityHypre::SolverType::FlexGMRES;
-        if (lower_solver_str == "pcg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::PCG;
-        if (lower_solver_str == "bicgstab") return OpenImpala::EffectiveDiffusivityHypre::SolverType::BiCGSTAB;
-        if (lower_solver_str == "smg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::SMG;
-        if (lower_solver_str == "pfmg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::PFMG;
-        amrex::Abort("Invalid solver string: '" + solver_str + "'.");
-        return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES; // Should not reach
-    }
+OpenImpala::EffectiveDiffusivityHypre::SolverType
+stringToSolverType(const std::string& solver_str) {
+    std::string lower_solver_str = solver_str;
+    std::transform(lower_solver_str.begin(), lower_solver_str.end(), lower_solver_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_solver_str == "jacobi")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::Jacobi;
+    if (lower_solver_str == "gmres")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES;
+    if (lower_solver_str == "flexgmres")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::FlexGMRES;
+    if (lower_solver_str == "pcg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::PCG;
+    if (lower_solver_str == "bicgstab")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::BiCGSTAB;
+    if (lower_solver_str == "smg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::SMG;
+    if (lower_solver_str == "pfmg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::PFMG;
+    amrex::Abort("Invalid solver string: '" + solver_str + "'.");
+    return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES; // Should not reach
+}
 
-void calculate_Deff_tensor_homogenization(
-    amrex::Real Deff_tensor[AMREX_SPACEDIM][AMREX_SPACEDIM],
-    const amrex::MultiFab& mf_chi_x_in,
-    const amrex::MultiFab& mf_chi_y_in,
-    const amrex::MultiFab& mf_chi_z_in,
-    const amrex::iMultiFab& active_mask, 
-    const amrex::Geometry& geom,
-    int verbose_level)
-{
-    BL_PROFILE("calculate_Deff_tensor_homogenization_main_driver"); 
+void calculate_Deff_tensor_homogenization(amrex::Real Deff_tensor[AMREX_SPACEDIM][AMREX_SPACEDIM],
+                                          const amrex::MultiFab& mf_chi_x_in,
+                                          const amrex::MultiFab& mf_chi_y_in,
+                                          const amrex::MultiFab& mf_chi_z_in,
+                                          const amrex::iMultiFab& active_mask,
+                                          const amrex::Geometry& geom, int verbose_level) {
+    BL_PROFILE("calculate_Deff_tensor_homogenization_main_driver");
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         for (int j = 0; j < AMREX_SPACEDIM; ++j) {
             Deff_tensor[i][j] = 0.0;
         }
     }
-    AMREX_ASSERT(mf_chi_x_in.nGrow() >= 1); 
+    AMREX_ASSERT(mf_chi_x_in.nGrow() >= 1);
     AMREX_ASSERT(mf_chi_y_in.nGrow() >= 1);
     if (AMREX_SPACEDIM == 3) {
-        AMREX_ASSERT(mf_chi_z_in.isDefined() && mf_chi_z_in.nGrow() >= 1); 
+        AMREX_ASSERT(mf_chi_z_in.isDefined() && mf_chi_z_in.nGrow() >= 1);
     }
-    AMREX_ASSERT(active_mask.nGrow() == 0); 
+    AMREX_ASSERT(active_mask.nGrow() == 0);
 
     const amrex::Real* dx_arr = geom.CellSize();
     amrex::Real inv_2dx[AMREX_SPACEDIM];
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         inv_2dx[i] = 1.0 / (2.0 * dx_arr[i]);
     }
 
@@ -93,130 +98,140 @@ void calculate_Deff_tensor_homogenization(
     }
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:sum_integrand_tensor_comp_local)
+#pragma omp parallel reduction(+ : sum_integrand_tensor_comp_local)
 #endif
-    for (amrex::MFIter mfi(active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const amrex::Box& bx = mfi.tilebox(); 
+    for (amrex::MFIter mfi(active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
         amrex::Array4<const int> const mask_arr = active_mask.const_array(mfi);
         amrex::Array4<const amrex::Real> const chi_x_arr = mf_chi_x_in.const_array(mfi);
         amrex::Array4<const amrex::Real> const chi_y_arr = mf_chi_y_in.const_array(mfi);
-        amrex::Array4<const amrex::Real> const chi_z_arr = (AMREX_SPACEDIM == 3 && mf_chi_z_in.isDefined()) ? 
-                                                           mf_chi_z_in.const_array(mfi) :
-                                                           mf_chi_x_in.const_array(mfi); 
+        amrex::Array4<const amrex::Real> const chi_z_arr =
+            (AMREX_SPACEDIM == 3 && mf_chi_z_in.isDefined()) ? mf_chi_z_in.const_array(mfi)
+                                                             : mf_chi_x_in.const_array(mfi);
 
-        amrex::LoopOnCpu(bx, [=, &sum_integrand_tensor_comp_local] (int i, int j, int k) noexcept
-        {
-            if (mask_arr(i,j,k,0) == 1) { 
+        amrex::LoopOnCpu(bx, [=, &sum_integrand_tensor_comp_local](int i, int j, int k) noexcept {
+            if (mask_arr(i, j, k, 0) == 1) {
                 amrex::Real grad_chi_x[AMREX_SPACEDIM] = {0.0};
                 amrex::Real grad_chi_y[AMREX_SPACEDIM] = {0.0};
                 amrex::Real grad_chi_z[AMREX_SPACEDIM] = {0.0};
 
-                grad_chi_x[0] = (chi_x_arr(i+1,j,k,0) - chi_x_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                grad_chi_x[1] = (chi_x_arr(i,j+1,k,0) - chi_x_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                if (AMREX_SPACEDIM == 3) grad_chi_x[2] = (chi_x_arr(i,j,k+1,0) - chi_x_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                grad_chi_x[0] =
+                    (chi_x_arr(i + 1, j, k, 0) - chi_x_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                grad_chi_x[1] =
+                    (chi_x_arr(i, j + 1, k, 0) - chi_x_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                if (AMREX_SPACEDIM == 3)
+                    grad_chi_x[2] =
+                        (chi_x_arr(i, j, k + 1, 0) - chi_x_arr(i, j, k - 1, 0)) * inv_2dx[2];
 
-                grad_chi_y[0] = (chi_y_arr(i+1,j,k,0) - chi_y_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                grad_chi_y[1] = (chi_y_arr(i,j+1,k,0) - chi_y_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                if (AMREX_SPACEDIM == 3) grad_chi_y[2] = (chi_y_arr(i,j,k+1,0) - chi_y_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                grad_chi_y[0] =
+                    (chi_y_arr(i + 1, j, k, 0) - chi_y_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                grad_chi_y[1] =
+                    (chi_y_arr(i, j + 1, k, 0) - chi_y_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                if (AMREX_SPACEDIM == 3)
+                    grad_chi_y[2] =
+                        (chi_y_arr(i, j, k + 1, 0) - chi_y_arr(i, j, k - 1, 0)) * inv_2dx[2];
 
                 if (AMREX_SPACEDIM == 3) {
-                    grad_chi_z[0] = (chi_z_arr(i+1,j,k,0) - chi_z_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                    grad_chi_z[1] = (chi_z_arr(i,j+1,k,0) - chi_z_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                    grad_chi_z[2] = (chi_z_arr(i,j,k+1,0) - chi_z_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                    grad_chi_z[0] =
+                        (chi_z_arr(i + 1, j, k, 0) - chi_z_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                    grad_chi_z[1] =
+                        (chi_z_arr(i, j + 1, k, 0) - chi_z_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                    grad_chi_z[2] =
+                        (chi_z_arr(i, j, k + 1, 0) - chi_z_arr(i, j, k - 1, 0)) * inv_2dx[2];
                 }
-                sum_integrand_tensor_comp_local[0][0] += (1.0 - grad_chi_x[0]); 
-                sum_integrand_tensor_comp_local[0][1] += (    - grad_chi_y[0]); 
-                sum_integrand_tensor_comp_local[1][0] += (    - grad_chi_x[1]); 
-                sum_integrand_tensor_comp_local[1][1] += (1.0 - grad_chi_y[1]); 
+                sum_integrand_tensor_comp_local[0][0] += (1.0 - grad_chi_x[0]);
+                sum_integrand_tensor_comp_local[0][1] += (-grad_chi_y[0]);
+                sum_integrand_tensor_comp_local[1][0] += (-grad_chi_x[1]);
+                sum_integrand_tensor_comp_local[1][1] += (1.0 - grad_chi_y[1]);
 
                 if (AMREX_SPACEDIM == 3) {
-                    sum_integrand_tensor_comp_local[0][2] += (    - grad_chi_z[0]); 
-                    sum_integrand_tensor_comp_local[2][0] += (    - grad_chi_x[2]); 
-                    sum_integrand_tensor_comp_local[1][2] += (    - grad_chi_z[1]); 
-                    sum_integrand_tensor_comp_local[2][1] += (    - grad_chi_y[2]); 
-                    sum_integrand_tensor_comp_local[2][2] += (1.0 - grad_chi_z[2]); 
+                    sum_integrand_tensor_comp_local[0][2] += (-grad_chi_z[0]);
+                    sum_integrand_tensor_comp_local[2][0] += (-grad_chi_x[2]);
+                    sum_integrand_tensor_comp_local[1][2] += (-grad_chi_z[1]);
+                    sum_integrand_tensor_comp_local[2][1] += (-grad_chi_y[2]);
+                    sum_integrand_tensor_comp_local[2][2] += (1.0 - grad_chi_z[2]);
                 }
             }
         });
     }
-    
+
     for (int r = 0; r < AMREX_SPACEDIM; ++r) {
         for (int c = 0; c < AMREX_SPACEDIM; ++c) {
             amrex::ParallelDescriptor::ReduceRealSum(sum_integrand_tensor_comp_local[r][c]);
         }
     }
 
-    amrex::Long N_total_cells_in_domain = geom.Domain().numPts(); 
+    amrex::Long N_total_cells_in_domain = geom.Domain().numPts();
     if (N_total_cells_in_domain > 0) {
         for (int l_idx = 0; l_idx < AMREX_SPACEDIM; ++l_idx) {
             for (int m_idx = 0; m_idx < AMREX_SPACEDIM; ++m_idx) {
-                Deff_tensor[l_idx][m_idx] = sum_integrand_tensor_comp_local[l_idx][m_idx] / static_cast<amrex::Real>(N_total_cells_in_domain);
+                Deff_tensor[l_idx][m_idx] = sum_integrand_tensor_comp_local[l_idx][m_idx] /
+                                            static_cast<amrex::Real>(N_total_cells_in_domain);
             }
         }
     } else {
-         if (amrex::ParallelDescriptor::IOProcessor() && verbose_level > 0) {
+        if (amrex::ParallelDescriptor::IOProcessor() && verbose_level > 0) {
             amrex::Warning("Total cells in domain/REV is zero, D_eff cannot be calculated.");
-         }
+        }
     }
 
-     if (verbose_level > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-         amrex::Print() << "  [calc_Deff] Raw summed (1-dchi_x_dx): " << sum_integrand_tensor_comp_local[0][0]
-                        << ", N_total_cells_in_domain: " << N_total_cells_in_domain << std::endl;
-     }
+    if (verbose_level > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  [calc_Deff] Raw summed (1-dchi_x_dx): "
+                       << sum_integrand_tensor_comp_local[0][0]
+                       << ", N_total_cells_in_domain: " << N_total_cells_in_domain << std::endl;
+    }
 }
 } // end anonymous namespace
 
 
-int main (int argc, char* argv[])
-{
-    HYPRE_Init(); 
+int main(int argc, char* argv[]) {
+    HYPRE_Init();
     amrex::Initialize(argc, argv);
     {
         amrex::Real master_strt_time = amrex::second();
 
         std::string main_filename;
-        std::string main_data_path_str = "./data/";    
-        std::string main_results_path_str = "./results_diffusion/"; 
-        std::string main_hdf5_dataset = "image";      
+        std::string main_data_path_str = "./data/";
+        std::string main_results_path_str = "./results_diffusion/";
+        std::string main_hdf5_dataset = "image";
         amrex::Real main_threshold_val = 0.5;
-        int main_phase_id_analysis = 1; 
+        int main_phase_id_analysis = 1;
         std::string main_solver_str = "FlexGMRES";
         int main_box_size = 32;
         int main_verbose = 1;
-        int main_write_plotfile_full = 0; 
-        std::string main_calculation_method = "homogenization"; 
+        int main_write_plotfile_full = 0;
+        std::string main_calculation_method = "homogenization";
         std::string output_filename = "results.txt"; // Added this line
 
 
         bool rev_do_study = false;
         int rev_num_samples = 3;
-        std::string rev_sizes_str = "32 64 96"; 
+        std::string rev_sizes_str = "32 64 96";
         std::string rev_solver_str = "FlexGMRES";
         std::string rev_results_filename = "rev_study_Deff.csv";
-        int rev_write_plotfiles = 0; 
-        int rev_verbose_level = 1;   
+        int rev_write_plotfiles = 0;
+        int rev_verbose_level = 1;
 
-        { 
-            amrex::ParmParse pp; 
+        {
+            amrex::ParmParse pp;
             pp.get("filename", main_filename);
             pp.query("data_path", main_data_path_str);
             pp.query("results_path", main_results_path_str);
             pp.query("hdf5_dataset", main_hdf5_dataset);
             pp.query("threshold_val", main_threshold_val);
-            pp.query("phase_id", main_phase_id_analysis); 
-            pp.query("solver_type", main_solver_str); 
+            pp.query("phase_id", main_phase_id_analysis);
+            pp.query("solver_type", main_solver_str);
             pp.query("box_size", main_box_size);
             pp.query("verbose", main_verbose);
             pp.query("write_plotfile", main_write_plotfile_full);
             pp.query("calculation_method", main_calculation_method);
             pp.query("output_filename", output_filename); // Added this line
 
-            amrex::ParmParse ppr("rev"); 
+            amrex::ParmParse ppr("rev");
             ppr.query("do_study", rev_do_study);
             ppr.query("num_samples", rev_num_samples);
             ppr.query("sizes", rev_sizes_str);
-            ppr.query("solver_type", rev_solver_str); 
+            ppr.query("solver_type", rev_solver_str);
             ppr.query("results_file", rev_results_filename);
             ppr.query("write_plotfiles", rev_write_plotfiles);
             ppr.query("verbose", rev_verbose_level);
@@ -224,35 +239,38 @@ int main (int argc, char* argv[])
 
         std::filesystem::path main_data_path(main_data_path_str);
         std::filesystem::path main_results_path(main_results_path_str);
-        
+
         if (amrex::ParallelDescriptor::IOProcessor()) {
             if (!std::filesystem::exists(main_results_path)) {
                 std::filesystem::create_directories(main_results_path);
-                 if (main_verbose >=1 ) amrex::Print() << "Created results directory: " << main_results_path.string() << std::endl;
+                if (main_verbose >= 1)
+                    amrex::Print()
+                        << "Created results directory: " << main_results_path.string() << std::endl;
             }
         }
-        amrex::ParallelDescriptor::Barrier(); 
+        amrex::ParallelDescriptor::Barrier();
         std::filesystem::path full_input_path = main_data_path / main_filename;
 
 
         amrex::Geometry geom_full;
         amrex::BoxArray ba_full;
         amrex::DistributionMapping dm_full;
-        amrex::iMultiFab mf_phase_full; 
+        amrex::iMultiFab mf_phase_full;
         amrex::Box domain_box_full;
 
         try {
             if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
-                amrex::Print() << "Reading full domain data from: " << full_input_path.string() << std::endl;
+                amrex::Print() << "Reading full domain data from: " << full_input_path.string()
+                               << std::endl;
 
             std::string ext;
             if (full_input_path.has_extension()) {
                 ext = full_input_path.extension().string();
                 std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
             } else {
-                 throw std::runtime_error("File has no extension: " + full_input_path.string());
+                throw std::runtime_error("File has no extension: " + full_input_path.string());
             }
-            
+
             // Always map voxels > threshold to 1 and <= threshold to 0.
             // This creates a consistent binary map. The phase_id variable will be
             // used later to tell the solver which number (0 or 1) to analyze.
@@ -261,50 +279,55 @@ int main (int argc, char* argv[])
 
             if (ext == ".tif" || ext == ".tiff") {
                 OpenImpala::TiffReader reader(full_input_path.string());
-                if (!reader.isRead()) throw std::runtime_error("TiffReader failed to read metadata.");
+                if (!reader.isRead())
+                    throw std::runtime_error("TiffReader failed to read metadata.");
                 domain_box_full = reader.box();
                 ba_full.define(domain_box_full);
                 ba_full.maxSize(main_box_size);
                 dm_full.define(ba_full);
-                mf_phase_full.define(ba_full, dm_full, 1, 1); 
+                mf_phase_full.define(ba_full, dm_full, 1, 1);
                 amrex::iMultiFab mf_temp_no_ghost(ba_full, dm_full, 1, 0);
-                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive, mf_temp_no_ghost);
-                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0,0,1,0);
+                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive,
+                                 mf_temp_no_ghost);
+                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0, 0, 1, 0);
 
             } else if (ext == ".dat") {
                 OpenImpala::DatReader reader(full_input_path.string());
-                 if (!reader.isRead()) throw std::runtime_error("DatReader failed to read metadata.");
+                if (!reader.isRead())
+                    throw std::runtime_error("DatReader failed to read metadata.");
                 domain_box_full = reader.box();
                 ba_full.define(domain_box_full);
                 ba_full.maxSize(main_box_size);
                 dm_full.define(ba_full);
                 mf_phase_full.define(ba_full, dm_full, 1, 1);
                 amrex::iMultiFab mf_temp_no_ghost(ba_full, dm_full, 1, 0);
-                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive, mf_temp_no_ghost);
-                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0,0,1,0);
+                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive,
+                                 mf_temp_no_ghost);
+                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0, 0, 1, 0);
 
             } else if (ext == ".h5" || ext == ".hdf5") {
                 OpenImpala::HDF5Reader reader(full_input_path.string(), main_hdf5_dataset);
-                if (!reader.isRead()) throw std::runtime_error("HDF5Reader failed to read metadata.");
+                if (!reader.isRead())
+                    throw std::runtime_error("HDF5Reader failed to read metadata.");
                 domain_box_full = reader.box();
                 ba_full.define(domain_box_full);
                 ba_full.maxSize(main_box_size);
                 dm_full.define(ba_full);
                 mf_phase_full.define(ba_full, dm_full, 1, 1);
                 amrex::iMultiFab mf_temp_no_ghost(ba_full, dm_full, 1, 0);
-                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive, mf_temp_no_ghost);
-                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0,0,1,0);
-            }
-            else {
+                reader.threshold(main_threshold_val, reader_phase_active, reader_phase_inactive,
+                                 mf_temp_no_ghost);
+                amrex::Copy(mf_phase_full, mf_temp_no_ghost, 0, 0, 1, 0);
+            } else {
                 throw std::runtime_error("Unsupported file extension for full domain load: " + ext);
             }
 
-            amrex::RealBox rb_full({AMREX_D_DECL(0.0,0.0,0.0)},
+            amrex::RealBox rb_full({AMREX_D_DECL(0.0, 0.0, 0.0)},
                                    {AMREX_D_DECL(amrex::Real(domain_box_full.length(0)),
                                                  amrex::Real(domain_box_full.length(1)),
                                                  amrex::Real(domain_box_full.length(2)))});
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic_full;
-            is_periodic_full = {AMREX_D_DECL(1,1,1)}; 
+            amrex::Array<int, AMREX_SPACEDIM> is_periodic_full;
+            is_periodic_full = {AMREX_D_DECL(1, 1, 1)};
             geom_full.define(domain_box_full, &rb_full, 0, is_periodic_full.data());
             mf_phase_full.FillBoundary(geom_full.periodicity());
 
@@ -315,18 +338,21 @@ int main (int argc, char* argv[])
 
 
         if (rev_do_study) {
-            if (main_verbose >=1 && amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "\n--- Starting REV Study (Homogenization Method) for Phase ID " << main_phase_id_analysis << " ---\n";
+            if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "\n--- Starting REV Study (Homogenization Method) for Phase ID "
+                               << main_phase_id_analysis << " ---\n";
                 amrex::Print() << "  Number of samples per size: " << rev_num_samples << std::endl;
                 amrex::Print() << "  Target REV sizes: " << rev_sizes_str << std::endl;
                 amrex::Print() << "  REV Solver: " << rev_solver_str << std::endl;
-                amrex::Print() << "  REV Plotfiles: " << (rev_write_plotfiles ? "Yes" : "No") << std::endl;
+                amrex::Print() << "  REV Plotfiles: " << (rev_write_plotfiles ? "Yes" : "No")
+                               << std::endl;
             }
 
-            std::vector<int> rev_actual_sizes_vec; 
+            std::vector<int> rev_actual_sizes_vec;
             std::stringstream ss_rev_sizes(rev_sizes_str);
-            int size_val_loop; 
-            while (ss_rev_sizes >> size_val_loop) rev_actual_sizes_vec.push_back(size_val_loop);
+            int size_val_loop;
+            while (ss_rev_sizes >> size_val_loop)
+                rev_actual_sizes_vec.push_back(size_val_loop);
 
             if (rev_actual_sizes_vec.empty()) {
                 amrex::Warning("REV sizes string is empty or invalid. Skipping REV study.");
@@ -335,418 +361,510 @@ int main (int argc, char* argv[])
                 std::filesystem::path full_rev_csv_path = main_results_path / rev_results_filename;
                 if (amrex::ParallelDescriptor::IOProcessor()) {
                     rev_csv_file.open(full_rev_csv_path.string());
-                    rev_csv_file << "SampleNo,SeedX,SeedY,SeedZ,REV_Size_Target,ActualSizeX,ActualSizeY,ActualSizeZ,D_xx,D_yy,D_zz,D_xy,D_xz,D_yz\n";
+                    rev_csv_file << "SampleNo,SeedX,SeedY,SeedZ,REV_Size_Target,ActualSizeX,"
+                                    "ActualSizeY,ActualSizeZ,D_xx,D_yy,D_zz,D_xy,D_xz,D_yz\n";
                 }
 
-                std::mt19937 gen(amrex::ParallelDescriptor::MyProc() + 12345 + rev_num_samples); 
+                std::mt19937 gen(amrex::ParallelDescriptor::MyProc() + 12345 + rev_num_samples);
 
                 for (int s_idx = 0; s_idx < rev_num_samples; ++s_idx) {
                     for (int current_rev_size_target : rev_actual_sizes_vec) {
-                        amrex::IntVect seed_lo_global; 
-                        for(int d=0; d<AMREX_SPACEDIM; ++d) {
+                        amrex::IntVect seed_lo_global;
+                        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
                             int min_coord = domain_box_full.smallEnd(d);
-                            int max_coord = domain_box_full.bigEnd(d) - (current_rev_size_target -1) ;
-                            if (min_coord > max_coord || current_rev_size_target > domain_box_full.length(d)) { 
-                                seed_lo_global[d] = domain_box_full.smallEnd(d); 
+                            int max_coord =
+                                domain_box_full.bigEnd(d) - (current_rev_size_target - 1);
+                            if (min_coord > max_coord ||
+                                current_rev_size_target > domain_box_full.length(d)) {
+                                seed_lo_global[d] = domain_box_full.smallEnd(d);
                             } else {
                                 std::uniform_int_distribution<> distr(min_coord, max_coord);
                                 seed_lo_global[d] = distr(gen);
                             }
                         }
-                        
-                        amrex::Box bx_rev_global_const = amrex::Box(seed_lo_global, seed_lo_global + amrex::IntVect(current_rev_size_target - 1));
-                        amrex::Box bx_rev_global = bx_rev_global_const; 
-                        bx_rev_global &= domain_box_full; 
 
-                        if (bx_rev_global.isEmpty() || bx_rev_global.longside() < 8) { 
-                            if (rev_verbose_level >=1 && amrex::ParallelDescriptor::IOProcessor()) {
-                                std::stringstream ss; ss << bx_rev_global;
-                                amrex::Warning("Skipping REV for sample " + std::to_string(s_idx+1) + 
-                                               " target size " + std::to_string(current_rev_size_target) + 
-                                               " due to small/empty box after intersection: " + ss.str());
+                        amrex::Box bx_rev_global_const = amrex::Box(
+                            seed_lo_global,
+                            seed_lo_global + amrex::IntVect(current_rev_size_target - 1));
+                        amrex::Box bx_rev_global = bx_rev_global_const;
+                        bx_rev_global &= domain_box_full;
+
+                        if (bx_rev_global.isEmpty() || bx_rev_global.longside() < 8) {
+                            if (rev_verbose_level >= 1 &&
+                                amrex::ParallelDescriptor::IOProcessor()) {
+                                std::stringstream ss;
+                                ss << bx_rev_global;
+                                amrex::Warning(
+                                    "Skipping REV for sample " + std::to_string(s_idx + 1) +
+                                    " target size " + std::to_string(current_rev_size_target) +
+                                    " due to small/empty box after intersection: " + ss.str());
                             }
                             continue;
                         }
-                         if (rev_verbose_level >=1 && amrex::ParallelDescriptor::IOProcessor()) {
-                            amrex::Print() << " REV Sample " << s_idx + 1 << ", Target Size " << current_rev_size_target 
-                                           << ", Seed Lo (global): " << seed_lo_global 
-                                           << ", Actual REV Box (global): " << bx_rev_global << std::endl;
+                        if (rev_verbose_level >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                            amrex::Print()
+                                << " REV Sample " << s_idx + 1 << ", Target Size "
+                                << current_rev_size_target
+                                << ", Seed Lo (global): " << seed_lo_global
+                                << ", Actual REV Box (global): " << bx_rev_global << std::endl;
                         }
-                        
-                        amrex::Box domain_rev_relative_temp = bx_rev_global; 
-                        amrex::Box domain_rev_relative = domain_rev_relative_temp; // Make a copy
-                        domain_rev_relative.shift(-bx_rev_global.smallEnd()); // Shift the copy
-                        
-                        amrex::Geometry geom_rev;
-                        amrex::RealBox rb_rev({AMREX_D_DECL(0.0,0.0,0.0)},
-                                              {AMREX_D_DECL(amrex::Real(domain_rev_relative.length(0)), 
-                                                            amrex::Real(domain_rev_relative.length(1)), 
-                                                            amrex::Real(domain_rev_relative.length(2)))});
-                        amrex::Array<int,AMREX_SPACEDIM> is_periodic_rev = {AMREX_D_DECL(1,1,1)}; 
-                        geom_rev.define(domain_rev_relative, &rb_rev, 0, is_periodic_rev.data()); 
 
-                        amrex::BoxArray ba_rev_relative(domain_rev_relative); 
-                        ba_rev_relative.maxSize(main_box_size); 
+                        amrex::Box domain_rev_relative_temp = bx_rev_global;
+                        amrex::Box domain_rev_relative = domain_rev_relative_temp; // Make a copy
+                        domain_rev_relative.shift(-bx_rev_global.smallEnd());      // Shift the copy
+
+                        amrex::Geometry geom_rev;
+                        amrex::RealBox rb_rev(
+                            {AMREX_D_DECL(0.0, 0.0, 0.0)},
+                            {AMREX_D_DECL(amrex::Real(domain_rev_relative.length(0)),
+                                          amrex::Real(domain_rev_relative.length(1)),
+                                          amrex::Real(domain_rev_relative.length(2)))});
+                        amrex::Array<int, AMREX_SPACEDIM> is_periodic_rev = {AMREX_D_DECL(1, 1, 1)};
+                        geom_rev.define(domain_rev_relative, &rb_rev, 0, is_periodic_rev.data());
+
+                        amrex::BoxArray ba_rev_relative(domain_rev_relative);
+                        ba_rev_relative.maxSize(main_box_size);
                         amrex::DistributionMapping dm_rev_relative(ba_rev_relative);
-                        amrex::iMultiFab mf_phase_rev(ba_rev_relative, dm_rev_relative, 1, 1); 
-                        
+                        amrex::iMultiFab mf_phase_rev(ba_rev_relative, dm_rev_relative, 1, 1);
+
                         amrex::BoxArray ba_temp_global(bx_rev_global);
-                        amrex::DistributionMapping dm_temp_global(ba_temp_global); 
-                        amrex::iMultiFab mf_temp_global(ba_temp_global, dm_temp_global, 1, 0); 
-                        mf_temp_global.ParallelCopy(mf_phase_full, 0, 0, 1, amrex::IntVect::TheZeroVector(), amrex::IntVect::TheZeroVector(), geom_full.periodicity());
-                        
-                        mf_phase_rev.setVal(0); 
-                        for(amrex::MFIter mfi_dest(mf_phase_rev); mfi_dest.isValid(); ++mfi_dest) {
+                        amrex::DistributionMapping dm_temp_global(ba_temp_global);
+                        amrex::iMultiFab mf_temp_global(ba_temp_global, dm_temp_global, 1, 0);
+                        mf_temp_global.ParallelCopy(
+                            mf_phase_full, 0, 0, 1, amrex::IntVect::TheZeroVector(),
+                            amrex::IntVect::TheZeroVector(), geom_full.periodicity());
+
+                        mf_phase_rev.setVal(0);
+                        for (amrex::MFIter mfi_dest(mf_phase_rev); mfi_dest.isValid(); ++mfi_dest) {
                             amrex::IArrayBox& dest_fab = mf_phase_rev[mfi_dest];
-                            const amrex::Box& dest_fab_box_local = dest_fab.box(); 
+                            const amrex::Box& dest_fab_box_local = dest_fab.box();
 
                             amrex::Box temp_dest_box_global = dest_fab_box_local; // Non-const copy
-                            amrex::Box required_src_box_global = temp_dest_box_global.shift(bx_rev_global.smallEnd());
-                            
-                            for (amrex::MFIter mfi_src(mf_temp_global); mfi_src.isValid(); ++mfi_src) { // Should be 1 FAB for np=1
+                            amrex::Box required_src_box_global =
+                                temp_dest_box_global.shift(bx_rev_global.smallEnd());
+
+                            for (amrex::MFIter mfi_src(mf_temp_global); mfi_src.isValid();
+                                 ++mfi_src) { // Should be 1 FAB for np=1
                                 const amrex::IArrayBox& src_fab = mf_temp_global[mfi_src];
-                                const amrex::Box& src_fab_box_global_const = src_fab.box(); 
-                                amrex::Box src_fab_box_global = src_fab_box_global_const; // Non-const copy
-                                
-                                amrex::Box copy_region_global = required_src_box_global & src_fab_box_global;
+                                const amrex::Box& src_fab_box_global_const = src_fab.box();
+                                amrex::Box src_fab_box_global =
+                                    src_fab_box_global_const; // Non-const copy
+
+                                amrex::Box copy_region_global =
+                                    required_src_box_global & src_fab_box_global;
 
                                 if (!copy_region_global.isEmpty()) {
-                                    amrex::Box temp_copy_region_dest_local = copy_region_global; // Non-const copy
-                                    amrex::Box copy_region_dest_local = temp_copy_region_dest_local.shift(-bx_rev_global.smallEnd());
-                                    dest_fab.copy(src_fab, copy_region_global, 0, copy_region_dest_local, 0, 1);
+                                    amrex::Box temp_copy_region_dest_local =
+                                        copy_region_global; // Non-const copy
+                                    amrex::Box copy_region_dest_local =
+                                        temp_copy_region_dest_local.shift(
+                                            -bx_rev_global.smallEnd());
+                                    dest_fab.copy(src_fab, copy_region_global, 0,
+                                                  copy_region_dest_local, 0, 1);
                                 }
                             }
                         }
-                        mf_phase_rev.FillBoundary(geom_rev.periodicity()); 
+                        mf_phase_rev.FillBoundary(geom_rev.periodicity());
 
 
                         amrex::MultiFab mf_chi_x_rev(ba_rev_relative, dm_rev_relative, 1, 1);
                         amrex::MultiFab mf_chi_y_rev(ba_rev_relative, dm_rev_relative, 1, 1);
                         amrex::MultiFab mf_chi_z_rev;
-                        if (AMREX_SPACEDIM==3) mf_chi_z_rev.define(ba_rev_relative, dm_rev_relative, 1, 1);
+                        if (AMREX_SPACEDIM == 3)
+                            mf_chi_z_rev.define(ba_rev_relative, dm_rev_relative, 1, 1);
 
                         bool all_chi_rev_converged = true;
-                        std::vector<OpenImpala::Direction> rev_solve_dirs = {OpenImpala::Direction::X, OpenImpala::Direction::Y};
-                        if (AMREX_SPACEDIM == 3) rev_solve_dirs.push_back(OpenImpala::Direction::Z);
-                        OpenImpala::EffectiveDiffusivityHypre::SolverType rev_solver_type_enum = stringToSolverType(rev_solver_str);
+                        std::vector<OpenImpala::Direction> rev_solve_dirs = {
+                            OpenImpala::Direction::X, OpenImpala::Direction::Y};
+                        if (AMREX_SPACEDIM == 3)
+                            rev_solve_dirs.push_back(OpenImpala::Direction::Z);
+                        OpenImpala::EffectiveDiffusivityHypre::SolverType rev_solver_type_enum =
+                            stringToSolverType(rev_solver_str);
 
                         for (const auto& dir_k_solve : rev_solve_dirs) {
-                            std::string chi_plot_rev_subdir_str = "REV_Sample" + std::to_string(s_idx+1) + 
-                                                                  "_Size" + std::to_string(bx_rev_global.length(0)) + 
-                                                                  "_Dir" + std::to_string(static_cast<int>(dir_k_solve));
-                            std::filesystem::path chi_plot_rev_full_path = main_results_path / chi_plot_rev_subdir_str;
-                            
-                            if (rev_write_plotfiles != 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                                 amrex::UtilCreateDirectory(chi_plot_rev_full_path.string(), 0755);
+                            std::string chi_plot_rev_subdir_str =
+                                "REV_Sample" + std::to_string(s_idx + 1) + "_Size" +
+                                std::to_string(bx_rev_global.length(0)) + "_Dir" +
+                                std::to_string(static_cast<int>(dir_k_solve));
+                            std::filesystem::path chi_plot_rev_full_path =
+                                main_results_path / chi_plot_rev_subdir_str;
+
+                            if (rev_write_plotfiles != 0 &&
+                                amrex::ParallelDescriptor::IOProcessor()) {
+                                amrex::UtilCreateDirectory(chi_plot_rev_full_path.string(), 0755);
                             }
-                             amrex::ParallelDescriptor::Barrier(); 
+                            amrex::ParallelDescriptor::Barrier();
 
                             std::unique_ptr<OpenImpala::EffectiveDiffusivityHypre> rev_chi_solver;
                             try {
-                                 rev_chi_solver = std::make_unique<OpenImpala::EffectiveDiffusivityHypre>(
-                                    geom_rev, ba_rev_relative, dm_rev_relative, mf_phase_rev, // use ba_rev_relative and dm_rev_relative
-                                    main_phase_id_analysis, dir_k_solve, rev_solver_type_enum,
-                                    chi_plot_rev_full_path.string(), rev_verbose_level, (rev_write_plotfiles !=0)
-                                );
+                                rev_chi_solver =
+                                    std::make_unique<OpenImpala::EffectiveDiffusivityHypre>(
+                                        geom_rev, ba_rev_relative, dm_rev_relative,
+                                        mf_phase_rev, // use ba_rev_relative and dm_rev_relative
+                                        main_phase_id_analysis, dir_k_solve, rev_solver_type_enum,
+                                        chi_plot_rev_full_path.string(), rev_verbose_level,
+                                        (rev_write_plotfiles != 0));
                                 if (!rev_chi_solver->solve()) {
-                                    all_chi_rev_converged = false; 
-                                    if(rev_verbose_level >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    REV Chi solve FAILED for dir " << static_cast<int>(dir_k_solve) << std::endl;
+                                    all_chi_rev_converged = false;
+                                    if (rev_verbose_level >= 1 &&
+                                        amrex::ParallelDescriptor::IOProcessor())
+                                        amrex::Print()
+                                            << "    REV Chi solve FAILED for dir "
+                                            << static_cast<int>(dir_k_solve) << std::endl;
                                     break;
                                 }
-                                if (dir_k_solve == OpenImpala::Direction::X) rev_chi_solver->getChiSolution(mf_chi_x_rev);
-                                else if (dir_k_solve == OpenImpala::Direction::Y) rev_chi_solver->getChiSolution(mf_chi_y_rev);
-                                else if (AMREX_SPACEDIM==3 && dir_k_solve == OpenImpala::Direction::Z) rev_chi_solver->getChiSolution(mf_chi_z_rev);
+                                if (dir_k_solve == OpenImpala::Direction::X)
+                                    rev_chi_solver->getChiSolution(mf_chi_x_rev);
+                                else if (dir_k_solve == OpenImpala::Direction::Y)
+                                    rev_chi_solver->getChiSolution(mf_chi_y_rev);
+                                else if (AMREX_SPACEDIM == 3 &&
+                                         dir_k_solve == OpenImpala::Direction::Z)
+                                    rev_chi_solver->getChiSolution(mf_chi_z_rev);
                             } catch (const std::exception& e) {
-                                if(rev_verbose_level >= 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    REV Chi solve EXCEPTION for dir " << static_cast<int>(dir_k_solve) << ": " << e.what() << std::endl;
-                                all_chi_rev_converged = false; break;
+                                if (rev_verbose_level >= 0 &&
+                                    amrex::ParallelDescriptor::IOProcessor())
+                                    amrex::Print() << "    REV Chi solve EXCEPTION for dir "
+                                                   << static_cast<int>(dir_k_solve) << ": "
+                                                   << e.what() << std::endl;
+                                all_chi_rev_converged = false;
+                                break;
                             }
                         }
 
                         amrex::Real Deff_tensor_rev[AMREX_SPACEDIM][AMREX_SPACEDIM];
-                        for(int r=0; r<AMREX_SPACEDIM; ++r) for(int c=0; c<AMREX_SPACEDIM; ++c) Deff_tensor_rev[r][c] = std::numeric_limits<amrex::Real>::quiet_NaN();
+                        for (int r = 0; r < AMREX_SPACEDIM; ++r)
+                            for (int c = 0; c < AMREX_SPACEDIM; ++c)
+                                Deff_tensor_rev[r][c] =
+                                    std::numeric_limits<amrex::Real>::quiet_NaN();
 
                         if (all_chi_rev_converged) {
-                            amrex::iMultiFab active_mask_rev(ba_rev_relative, dm_rev_relative, 1, 0); // use ba_rev_relative
-                            #ifdef AMREX_USE_OMP
-                            #pragma omp parallel if(amrex::Gpu::notInLaunchRegion())
-                            #endif
-                            for (amrex::MFIter mfi(active_mask_rev, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
-                                const amrex::Box& tb = mfi.tilebox(); 
+                            amrex::iMultiFab active_mask_rev(ba_rev_relative, dm_rev_relative, 1,
+                                                             0); // use ba_rev_relative
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+                            for (amrex::MFIter mfi(active_mask_rev, amrex::TilingIfNotGPU());
+                                 mfi.isValid(); ++mfi) {
+                                const amrex::Box& tb = mfi.tilebox();
                                 auto const& mask_arr = active_mask_rev.array(mfi);
-                                auto const& phase_arr = mf_phase_rev.const_array(mfi); 
-                                amrex::LoopOnCpu(tb, [=] (int i, int j, int k) { 
-                                    mask_arr(i,j,k,0) = (phase_arr(i,j,k,0) == main_phase_id_analysis) ? 1 : 0;
+                                auto const& phase_arr = mf_phase_rev.const_array(mfi);
+                                amrex::LoopOnCpu(tb, [=](int i, int j, int k) {
+                                    mask_arr(i, j, k, 0) =
+                                        (phase_arr(i, j, k, 0) == main_phase_id_analysis) ? 1 : 0;
                                 });
                             }
-                            calculate_Deff_tensor_homogenization(Deff_tensor_rev,
-                                                                 mf_chi_x_rev, mf_chi_y_rev, mf_chi_z_rev,
-                                                                 active_mask_rev, geom_rev, rev_verbose_level);
+                            calculate_Deff_tensor_homogenization(
+                                Deff_tensor_rev, mf_chi_x_rev, mf_chi_y_rev, mf_chi_z_rev,
+                                active_mask_rev, geom_rev, rev_verbose_level);
                         }
                         if (amrex::ParallelDescriptor::IOProcessor()) {
-                            rev_csv_file << s_idx+1 << ","
-                                         << seed_lo_global[0] << "," << seed_lo_global[1] << "," 
-                                         << (AMREX_SPACEDIM == 3 ? seed_lo_global[2] : 0) << ","
-                                         << current_rev_size_target << "," 
-                                         << bx_rev_global.length(0) << "," << bx_rev_global.length(1) << "," 
-                                         << (AMREX_SPACEDIM == 3 ? bx_rev_global.length(2) : 1) << "," 
-                                         << std::fixed << std::setprecision(8)
-                                         << Deff_tensor_rev[0][0] << "," << Deff_tensor_rev[1][1] << ","
-                                         << (AMREX_SPACEDIM == 3 ? Deff_tensor_rev[2][2] : std::numeric_limits<amrex::Real>::quiet_NaN()) << ","
-                                         << Deff_tensor_rev[0][1] << ","
-                                         << (AMREX_SPACEDIM == 3 ? Deff_tensor_rev[0][2] : std::numeric_limits<amrex::Real>::quiet_NaN()) << ","
-                                         << (AMREX_SPACEDIM == 3 ? Deff_tensor_rev[1][2] : std::numeric_limits<amrex::Real>::quiet_NaN()) << "\n";
-                            rev_csv_file.flush(); 
+                            rev_csv_file
+                                << s_idx + 1 << "," << seed_lo_global[0] << "," << seed_lo_global[1]
+                                << "," << (AMREX_SPACEDIM == 3 ? seed_lo_global[2] : 0) << ","
+                                << current_rev_size_target << "," << bx_rev_global.length(0) << ","
+                                << bx_rev_global.length(1) << ","
+                                << (AMREX_SPACEDIM == 3 ? bx_rev_global.length(2) : 1) << ","
+                                << std::fixed << std::setprecision(8) << Deff_tensor_rev[0][0]
+                                << "," << Deff_tensor_rev[1][1] << ","
+                                << (AMREX_SPACEDIM == 3
+                                        ? Deff_tensor_rev[2][2]
+                                        : std::numeric_limits<amrex::Real>::quiet_NaN())
+                                << "," << Deff_tensor_rev[0][1] << ","
+                                << (AMREX_SPACEDIM == 3
+                                        ? Deff_tensor_rev[0][2]
+                                        : std::numeric_limits<amrex::Real>::quiet_NaN())
+                                << ","
+                                << (AMREX_SPACEDIM == 3
+                                        ? Deff_tensor_rev[1][2]
+                                        : std::numeric_limits<amrex::Real>::quiet_NaN())
+                                << "\n";
+                            rev_csv_file.flush();
                         }
-                    } 
-                } 
-                if (amrex::ParallelDescriptor::IOProcessor()) rev_csv_file.close();
-            } 
-        } 
+                    }
+                }
+                if (amrex::ParallelDescriptor::IOProcessor())
+                    rev_csv_file.close();
+            }
+        }
 
 
-        if (!rev_do_study || main_calculation_method != "skip_if_rev") { 
-            if (main_verbose >=1 && amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "\n--- Full Domain Calculation (" << main_calculation_method << ") using phase " << main_phase_id_analysis << " ---\n";
+        if (!rev_do_study || main_calculation_method != "skip_if_rev") {
+            if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "\n--- Full Domain Calculation (" << main_calculation_method
+                               << ") using phase " << main_phase_id_analysis << " ---\n";
             }
             if (main_calculation_method == "homogenization") {
                 if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
-                    amrex::Print() << "\n--- Effective Diffusivity via Homogenization (Full Domain) ---\n";
+                    amrex::Print()
+                        << "\n--- Effective Diffusivity via Homogenization (Full Domain) ---\n";
 
                 amrex::MultiFab mf_chi_x_full(ba_full, dm_full, 1, 1);
                 amrex::MultiFab mf_chi_y_full(ba_full, dm_full, 1, 1);
-                amrex::MultiFab mf_chi_z_full; 
-                if (AMREX_SPACEDIM == 3) mf_chi_z_full.define(ba_full, dm_full, 1, 1);
+                amrex::MultiFab mf_chi_z_full;
+                if (AMREX_SPACEDIM == 3)
+                    mf_chi_z_full.define(ba_full, dm_full, 1, 1);
                 bool all_chi_full_converged = true;
 
-                std::vector<OpenImpala::Direction> dirs_to_solve_chi_full = {OpenImpala::Direction::X, OpenImpala::Direction::Y};
-                if (AMREX_SPACEDIM == 3) dirs_to_solve_chi_full.push_back(OpenImpala::Direction::Z);
+                std::vector<OpenImpala::Direction> dirs_to_solve_chi_full = {
+                    OpenImpala::Direction::X, OpenImpala::Direction::Y};
+                if (AMREX_SPACEDIM == 3)
+                    dirs_to_solve_chi_full.push_back(OpenImpala::Direction::Z);
 
                 auto solver_type_effdiff_full = stringToSolverType(main_solver_str);
 
                 for (const auto& dir_k : dirs_to_solve_chi_full) {
-                    std::string dir_k_str = (dir_k == OpenImpala::Direction::X) ? "X" : (dir_k == OpenImpala::Direction::Y) ? "Y" : "Z";
+                    std::string dir_k_str = (dir_k == OpenImpala::Direction::X)   ? "X"
+                                            : (dir_k == OpenImpala::Direction::Y) ? "Y"
+                                                                                  : "Z";
                     if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
-                        amrex::Print() << "\n--- Solving for Full Domain chi_" << dir_k_str << " ---\n";
-                    
-                    std::filesystem::path full_chi_plot_dir_path = main_results_path / ("FullDomain_chi_" + dir_k_str);
-                    if (main_write_plotfile_full !=0 && amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print()
+                            << "\n--- Solving for Full Domain chi_" << dir_k_str << " ---\n";
+
+                    std::filesystem::path full_chi_plot_dir_path =
+                        main_results_path / ("FullDomain_chi_" + dir_k_str);
+                    if (main_write_plotfile_full != 0 && amrex::ParallelDescriptor::IOProcessor()) {
                         amrex::UtilCreateDirectory(full_chi_plot_dir_path.string(), 0755);
                     }
                     amrex::ParallelDescriptor::Barrier();
 
                     std::unique_ptr<OpenImpala::EffectiveDiffusivityHypre> solver_chi_k_full;
-                     try {
+                    try {
                         solver_chi_k_full = std::make_unique<OpenImpala::EffectiveDiffusivityHypre>(
-                            geom_full, ba_full, dm_full, mf_phase_full, 
-                            main_phase_id_analysis, dir_k, solver_type_effdiff_full, 
-                            full_chi_plot_dir_path.string(), 
-                            main_verbose, (main_write_plotfile_full != 0)
-                        );
+                            geom_full, ba_full, dm_full, mf_phase_full, main_phase_id_analysis,
+                            dir_k, solver_type_effdiff_full, full_chi_plot_dir_path.string(),
+                            main_verbose, (main_write_plotfile_full != 0));
                         if (!solver_chi_k_full->solve()) {
                             all_chi_full_converged = false;
-                            break; 
+                            break;
                         }
-                        if (dir_k == OpenImpala::Direction::X) solver_chi_k_full->getChiSolution(mf_chi_x_full);
-                        else if (dir_k == OpenImpala::Direction::Y) solver_chi_k_full->getChiSolution(mf_chi_y_full);
-                        else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z) solver_chi_k_full->getChiSolution(mf_chi_z_full);
+                        if (dir_k == OpenImpala::Direction::X)
+                            solver_chi_k_full->getChiSolution(mf_chi_x_full);
+                        else if (dir_k == OpenImpala::Direction::Y)
+                            solver_chi_k_full->getChiSolution(mf_chi_y_full);
+                        else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z)
+                            solver_chi_k_full->getChiSolution(mf_chi_z_full);
                     } catch (const std::exception& e_full) {
-                         if(main_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    Full Domain Chi solve EXCEPTION for dir " << static_cast<int>(dir_k) << ": " << e_full.what() << std::endl;
-                        all_chi_full_converged = false; break;
+                        if (main_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor())
+                            amrex::Print()
+                                << "    Full Domain Chi solve EXCEPTION for dir "
+                                << static_cast<int>(dir_k) << ": " << e_full.what() << std::endl;
+                        all_chi_full_converged = false;
+                        break;
                     }
                 }
 
                 if (all_chi_full_converged) {
                     amrex::Real Deff_tensor_full[AMREX_SPACEDIM][AMREX_SPACEDIM];
-                    amrex::iMultiFab active_mask_full(ba_full, dm_full, 1, 0); 
-                    #ifdef AMREX_USE_OMP
-                    #pragma omp parallel if(amrex::Gpu::notInLaunchRegion())
-                    #endif
-                    for (amrex::MFIter mfi(active_mask_full, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi){
+                    amrex::iMultiFab active_mask_full(ba_full, dm_full, 1, 0);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+                    for (amrex::MFIter mfi(active_mask_full, amrex::TilingIfNotGPU());
+                         mfi.isValid(); ++mfi) {
                         const amrex::Box& tb = mfi.tilebox();
                         auto const& mask_arr = active_mask_full.array(mfi);
                         auto const& phase_arr = mf_phase_full.const_array(mfi);
-                        amrex::LoopOnCpu(tb, [=] (int i, int j, int k) {
-                            mask_arr(i,j,k,0) = (phase_arr(i,j,k,0) == main_phase_id_analysis) ? 1 : 0;
+                        amrex::LoopOnCpu(tb, [=](int i, int j, int k) {
+                            mask_arr(i, j, k, 0) =
+                                (phase_arr(i, j, k, 0) == main_phase_id_analysis) ? 1 : 0;
                         });
                     }
-                    calculate_Deff_tensor_homogenization(
-                        Deff_tensor_full, mf_chi_x_full, mf_chi_y_full, mf_chi_z_full,
-                        active_mask_full, geom_full, main_verbose);
+                    calculate_Deff_tensor_homogenization(Deff_tensor_full, mf_chi_x_full,
+                                                         mf_chi_y_full, mf_chi_z_full,
+                                                         active_mask_full, geom_full, main_verbose);
 
                     if (amrex::ParallelDescriptor::IOProcessor()) {
-                        amrex::Print() << "Full Domain Effective Diffusivity Tensor D_eff / D_material:\n";
-                        for (int r_print = 0; r_print < AMREX_SPACEDIM; ++r_print) { 
+                        amrex::Print()
+                            << "Full Domain Effective Diffusivity Tensor D_eff / D_material:\n";
+                        for (int r_print = 0; r_print < AMREX_SPACEDIM; ++r_print) {
                             amrex::Print() << "  [";
-                            for (int c_print = 0; c_print < AMREX_SPACEDIM; ++c_print) { 
-                                amrex::Print() << std::scientific << std::setprecision(8) << Deff_tensor_full[r_print][c_print]
+                            for (int c_print = 0; c_print < AMREX_SPACEDIM; ++c_print) {
+                                amrex::Print() << std::scientific << std::setprecision(8)
+                                               << Deff_tensor_full[r_print][c_print]
                                                << (c_print == AMREX_SPACEDIM - 1 ? "" : ", ");
                             }
                             amrex::Print() << "]\n";
                         }
                     }
                 } else {
-                    if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "Full domain D_eff calculation skipped due to chi_k non-convergence.\n";
+                    if (amrex::ParallelDescriptor::IOProcessor())
+                        amrex::Print() << "Full domain D_eff calculation skipped due to chi_k "
+                                          "non-convergence.\n";
                 }
 
-           } else if (main_calculation_method == "flow_through") {
-    // ===================================================================================
-    // --- Tortuosity via Flow-Through (Laplacian Solve) - Implemented Logic ---
-    // This block calculates tortuosity by solving a potential equation (Laplace's)
-    // with Dirichlet boundary conditions on inlet/outlet faces and Neumann (no-flux)
-    // conditions on the side walls. It uses the TortuosityHypre class.
-    // ===================================================================================
+            } else if (main_calculation_method == "flow_through") {
+                // ===================================================================================
+                // --- Tortuosity via Flow-Through (Laplacian Solve) - Implemented Logic ---
+                // This block calculates tortuosity by solving a potential equation (Laplace's)
+                // with Dirichlet boundary conditions on inlet/outlet faces and Neumann (no-flux)
+                // conditions on the side walls. It uses the TortuosityHypre class.
+                // ===================================================================================
 
-    if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "\n--- Full Domain Calculation: Tortuosity via Flow-Through ---\n";
-    }
+                if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                    amrex::Print()
+                        << "\n--- Full Domain Calculation: Tortuosity via Flow-Through ---\n";
+                }
 
-    // --- Get Tortuosity-Specific Parameters ---
-    // Set default boundary condition values for the potential field
-    amrex::Real vlo = -1.0;
-    amrex::Real vhi = 1.0;
+                // --- Get Tortuosity-Specific Parameters ---
+                // Set default boundary condition values for the potential field
+                amrex::Real vlo = -1.0;
+                amrex::Real vhi = 1.0;
 
-    // Allow users to override these defaults from a [tortuosity] block in the inputs file
-    amrex::ParmParse pp_tort("tortuosity");
-    pp_tort.query("vlo", vlo);
-    pp_tort.query("vhi", vhi);
+                // Allow users to override these defaults from a [tortuosity] block in the inputs
+                // file
+                amrex::ParmParse pp_tort("tortuosity");
+                pp_tort.query("vlo", vlo);
+                pp_tort.query("vhi", vhi);
 
-    // --- Calculate Volume Fraction (Prerequisite for Tortuosity) ---
-    if (main_verbose > 0) amrex::Print() << "Calculating Volume Fraction for Phase ID: " << main_phase_id_analysis << "\n";
-    OpenImpala::VolumeFraction vf_calc(mf_phase_full, main_phase_id_analysis);
+                // --- Calculate Volume Fraction (Prerequisite for Tortuosity) ---
+                if (main_verbose > 0)
+                    amrex::Print()
+                        << "Calculating Volume Fraction for Phase ID: " << main_phase_id_analysis
+                        << "\n";
+                OpenImpala::VolumeFraction vf_calc(mf_phase_full, main_phase_id_analysis);
 
-    // FIX 1: The 'value()' method was called without arguments.
-    // The correct function signature is 'void value(long long&, long long&, bool)',
-    // which requires variables to be passed by reference to store the results.
-    long long phase_voxels = 0;
-    long long total_voxels = 0;
-    vf_calc.value(phase_voxels, total_voxels, false); // Call with the required arguments
-    amrex::Real volume_fraction = (total_voxels > 0) ? (static_cast<amrex::Real>(phase_voxels) / static_cast<amrex::Real>(total_voxels)) : 0.0;
+                // FIX 1: The 'value()' method was called without arguments.
+                // The correct function signature is 'void value(long long&, long long&, bool)',
+                // which requires variables to be passed by reference to store the results.
+                long long phase_voxels = 0;
+                long long total_voxels = 0;
+                vf_calc.value(phase_voxels, total_voxels,
+                              false); // Call with the required arguments
+                amrex::Real volume_fraction = (total_voxels > 0)
+                                                  ? (static_cast<amrex::Real>(phase_voxels) /
+                                                     static_cast<amrex::Real>(total_voxels))
+                                                  : 0.0;
 
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  Volume Fraction = " << std::fixed << std::setprecision(8) << volume_fraction << "\n";
-    }
+                if (amrex::ParallelDescriptor::IOProcessor()) {
+                    amrex::Print() << "  Volume Fraction = " << std::fixed << std::setprecision(8)
+                                   << volume_fraction << "\n";
+                }
 
-    // --- Parse Directions to Run ---
-    std::map<std::string, amrex::Real> tortuosity_results;
-    std::string direction_str;
-    amrex::ParmParse pp; // Top-level ParmParse to get "direction"
-    pp.get("direction", direction_str);
-    std::string upper_direction_str = direction_str;
-    std::transform(upper_direction_str.begin(), upper_direction_str.end(), upper_direction_str.begin(), ::toupper);
+                // --- Parse Directions to Run ---
+                std::map<std::string, amrex::Real> tortuosity_results;
+                std::string direction_str;
+                amrex::ParmParse pp; // Top-level ParmParse to get "direction"
+                pp.get("direction", direction_str);
+                std::string upper_direction_str = direction_str;
+                std::transform(upper_direction_str.begin(), upper_direction_str.end(),
+                               upper_direction_str.begin(), ::toupper);
 
-    std::vector<OpenImpala::Direction> directions_to_run;
-    if (upper_direction_str.find("ALL") != std::string::npos) {
-        directions_to_run = {OpenImpala::Direction::X, OpenImpala::Direction::Y, OpenImpala::Direction::Z};
-    } else {
-        std::stringstream ss(upper_direction_str);
-        std::string single_dir;
-        while (ss >> single_dir) {
-            if (single_dir == "X") directions_to_run.push_back(OpenImpala::Direction::X);
-            else if (single_dir == "Y") directions_to_run.push_back(OpenImpala::Direction::Y);
-            else if (single_dir == "Z") directions_to_run.push_back(OpenImpala::Direction::Z);
-        }
-    }
+                std::vector<OpenImpala::Direction> directions_to_run;
+                if (upper_direction_str.find("ALL") != std::string::npos) {
+                    directions_to_run = {OpenImpala::Direction::X, OpenImpala::Direction::Y,
+                                         OpenImpala::Direction::Z};
+                } else {
+                    std::stringstream ss(upper_direction_str);
+                    std::string single_dir;
+                    while (ss >> single_dir) {
+                        if (single_dir == "X")
+                            directions_to_run.push_back(OpenImpala::Direction::X);
+                        else if (single_dir == "Y")
+                            directions_to_run.push_back(OpenImpala::Direction::Y);
+                        else if (single_dir == "Z")
+                            directions_to_run.push_back(OpenImpala::Direction::Z);
+                    }
+                }
 
-    if (directions_to_run.empty()) {
-        amrex::Warning("No valid directions specified in 'direction' input. Skipping tortuosity calculation.");
-    }
+                if (directions_to_run.empty()) {
+                    amrex::Warning("No valid directions specified in 'direction' input. Skipping "
+                                   "tortuosity calculation.");
+                }
 
-    // --- Main Calculation Loop for Each Direction ---
-    for (const auto& dir : directions_to_run) {
-        std::string dir_char = (dir == OpenImpala::Direction::X) ? "X" : (dir == OpenImpala::Direction::Y) ? "Y" : "Z";
-        if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "\n--- Solving for Tortuosity in Direction: " << dir_char << " ---\n";
-        }
+                // --- Main Calculation Loop for Each Direction ---
+                for (const auto& dir : directions_to_run) {
+                    std::string dir_char = (dir == OpenImpala::Direction::X)   ? "X"
+                                           : (dir == OpenImpala::Direction::Y) ? "Y"
+                                                                               : "Z";
+                    if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print() << "\n--- Solving for Tortuosity in Direction: " << dir_char
+                                       << " ---\n";
+                    }
 
-        // FIX 2: The 'stringToSolverType' function returns an 'EffectiveDiffusivityHypre::SolverType',
-        // but the TortuosityHypre constructor requires a 'TortuosityHypre::SolverType'.
-        // We must cast the enum to the correct type.
-        auto solver_type_enum_effdiff = stringToSolverType(main_solver_str);
-        auto solver_type_enum = static_cast<OpenImpala::TortuosityHypre::SolverType>(solver_type_enum_effdiff);
+                    // FIX 2: The 'stringToSolverType' function returns an
+                    // 'EffectiveDiffusivityHypre::SolverType', but the TortuosityHypre constructor
+                    // requires a 'TortuosityHypre::SolverType'. We must cast the enum to the
+                    // correct type.
+                    auto solver_type_enum_effdiff = stringToSolverType(main_solver_str);
+                    auto solver_type_enum = static_cast<OpenImpala::TortuosityHypre::SolverType>(
+                        solver_type_enum_effdiff);
 
-       // ======================= NEW CODE TO ADD =======================
-        // The main geom_full is periodic, but Tortuosity requires a
-        // non-periodic geometry to have distinct inlet/outlet faces.
-        // We must create a new geometry object for this specific calculation.
-        amrex::Geometry geom_tortuosity;
-        {
-            amrex::RealBox rb_nonperiodic = geom_full.ProbDomain();
-            amrex::Box domain_box_nonperiodic = geom_full.Domain();
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic_nonperiodic = {AMREX_D_DECL(0,0,0)}; // 0 = Not Periodic
-            geom_tortuosity.define(domain_box_nonperiodic, &rb_nonperiodic, 0, is_periodic_nonperiodic.data());
-        }
-        // ===================== END OF NEW CODE =======================
+                    // ======================= NEW CODE TO ADD =======================
+                    // The main geom_full is periodic, but Tortuosity requires a
+                    // non-periodic geometry to have distinct inlet/outlet faces.
+                    // We must create a new geometry object for this specific calculation.
+                    amrex::Geometry geom_tortuosity;
+                    {
+                        amrex::RealBox rb_nonperiodic = geom_full.ProbDomain();
+                        amrex::Box domain_box_nonperiodic = geom_full.Domain();
+                        amrex::Array<int, AMREX_SPACEDIM> is_periodic_nonperiodic = {
+                            AMREX_D_DECL(0, 0, 0)}; // 0 = Not Periodic
+                        geom_tortuosity.define(domain_box_nonperiodic, &rb_nonperiodic, 0,
+                                               is_periodic_nonperiodic.data());
+                    }
+                    // ===================== END OF NEW CODE =======================
 
 
-        // Create the main solver object for tortuosity
-        // *** NOTE: Pass the NEW geom_tortuosity object here ***
-        OpenImpala::TortuosityHypre tort_solver(
-            geom_tortuosity, // <<< USE THE CORRECT GEOMETRY
-            ba_full,
-            dm_full,
-            mf_phase_full,
-            volume_fraction,
-            main_phase_id_analysis,
-            dir,
-            solver_type_enum,
-            main_results_path_str,
-            vlo,
-            vhi,
-            main_verbose,
-            (main_write_plotfile_full != 0)
-        );
+                    // Create the main solver object for tortuosity
+                    // *** NOTE: Pass the NEW geom_tortuosity object here ***
+                    OpenImpala::TortuosityHypre tort_solver(
+                        geom_tortuosity, // <<< USE THE CORRECT GEOMETRY
+                        ba_full, dm_full, mf_phase_full, volume_fraction, main_phase_id_analysis,
+                        dir, solver_type_enum, main_results_path_str, vlo, vhi, main_verbose,
+                        (main_write_plotfile_full != 0));
 
-        amrex::Real tau = tort_solver.value();
+                    amrex::Real tau = tort_solver.value();
 
-        tortuosity_results["Tortuosity_" + dir_char] = tau;
+                    tortuosity_results["Tortuosity_" + dir_char] = tau;
 
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  >>> Calculated Tortuosity (" << dir_char << "): " << std::fixed << std::setprecision(8) << tau << " <<<\n";
-        }
-    }
+                    if (amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print()
+                            << "  >>> Calculated Tortuosity (" << dir_char << "): " << std::fixed
+                            << std::setprecision(8) << tau << " <<<\n";
+                    }
+                }
 
-    // --- Write Final Summary Results to File ---
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-        // FIX 3: 'output_filename' was not declared. I added its declaration
-        // and ParmParse query at the top of the main() function.
-        std::string output_filename = "results.txt"; // Default value
-        pp.query("output_filename", output_filename); // Read from inputs
+                // --- Write Final Summary Results to File ---
+                if (amrex::ParallelDescriptor::IOProcessor()) {
+                    // FIX 3: 'output_filename' was not declared. I added its declaration
+                    // and ParmParse query at the top of the main() function.
+                    std::string output_filename = "results.txt";  // Default value
+                    pp.query("output_filename", output_filename); // Read from inputs
 
-        std::filesystem::path output_filepath = std::filesystem::path(main_results_path_str) / output_filename;
-        amrex::Print() << "\nWriting final results to: " << output_filepath << "\n";
+                    std::filesystem::path output_filepath =
+                        std::filesystem::path(main_results_path_str) / output_filename;
+                    amrex::Print() << "\nWriting final results to: " << output_filepath << "\n";
 
-        std::ofstream outfile(output_filepath);
-        if (outfile.is_open()) {
-            outfile << "# Tortuosity Calculation Results (Flow-Through Method)\n";
-            outfile << "# Input File: " << main_filename << "\n";
-            outfile << "# Analysis Phase ID: " << main_phase_id_analysis << "\n";
-            outfile << "# -----------------------------\n";
-            outfile << "VolumeFraction: " << std::fixed << std::setprecision(9) << volume_fraction << "\n";
-            for (const auto& pair : tortuosity_results) {
-                outfile << pair.first << ": " << std::fixed << std::setprecision(9) << pair.second << "\n";
+                    std::ofstream outfile(output_filepath);
+                    if (outfile.is_open()) {
+                        outfile << "# Tortuosity Calculation Results (Flow-Through Method)\n";
+                        outfile << "# Input File: " << main_filename << "\n";
+                        outfile << "# Analysis Phase ID: " << main_phase_id_analysis << "\n";
+                        outfile << "# -----------------------------\n";
+                        outfile << "VolumeFraction: " << std::fixed << std::setprecision(9)
+                                << volume_fraction << "\n";
+                        for (const auto& pair : tortuosity_results) {
+                            outfile << pair.first << ": " << std::fixed << std::setprecision(9)
+                                    << pair.second << "\n";
+                        }
+                        outfile.close();
+                    } else {
+                        amrex::Warning("Could not open output file for writing: " +
+                                       output_filepath.string());
+                    }
+                }
             }
-            outfile.close();
-        } else {
-            amrex::Warning("Could not open output file for writing: " + output_filepath.string());
-        }
-    }
-}
         }
 
 
         amrex::Real master_stop_time = amrex::second() - master_strt_time;
-        amrex::ParallelDescriptor::ReduceRealMax(master_stop_time,amrex::ParallelDescriptor::IOProcessorNumber());
+        amrex::ParallelDescriptor::ReduceRealMax(master_stop_time,
+                                                 amrex::ParallelDescriptor::IOProcessorNumber());
         if (amrex::ParallelDescriptor::IOProcessor())
-            amrex::Print() << std::endl << "Total run time (seconds) = " << master_stop_time << std::endl;
-
+            amrex::Print() << std::endl
+                           << "Total run time (seconds) = " << master_stop_time << std::endl;
     }
     amrex::Finalize();
-    HYPRE_Finalize(); 
+    HYPRE_Finalize();
     return 0;
 }
-
-
-
-
-
-

--- a/src/props/EffDiffFillMtx_F.H
+++ b/src/props/EffDiffFillMtx_F.H
@@ -27,43 +27,41 @@ extern "C" {
  *   interfaces between active and inactive cells.
  * - Decoupling of inactive cells (A_ii=1, A_ij=0, b_i=0).
  *
- * @param[out]  a_out             Pointer to matrix stencil coefficient array (size npts_valid*7, flattened).
- *                                  Assumed HYPRE 7-point stencil order: Center, -X, +X, -Y, +Y, -Z, +Z.
+ * @param[out]  a_out             Pointer to matrix stencil coefficient array (size npts_valid*7,
+ * flattened). Assumed HYPRE 7-point stencil order: Center, -X, +X, -Y, +Y, -Z, +Z.
  * @param[out]  rhs_out           Pointer to RHS array (size npts_valid).
  * @param[out]  xinit_out         Pointer to initial guess array for χ_k (size npts_valid).
  * @param[in]   npts_valid        Pointer to the number of points/cells in the 'valid_bx' region.
- * @param[in]   active_mask_ptr   Pointer to the active_mask data array (INTEGER, 1=active/pore, 0=inactive/solid).
- *                                  Accessed as 3D in Fortran.
- * @param[in]   mask_lo           Pointer to the lower bound of the 'active_mask_ptr' array (Fortran indexing, including ghosts).
- * @param[in]   mask_hi           Pointer to the upper bound of the 'active_mask_ptr' array (Fortran indexing, including ghosts).
- * @param[in]   valid_bx_lo       Pointer to the lower bound of the current valid box/region to fill (Fortran indexing).
- * @param[in]   valid_bx_hi       Pointer to the upper bound of the current valid box/region to fill (Fortran indexing).
- * @param[in]   domain_lo         Pointer to the lower bound of the overall simulation domain (Fortran indexing).
- * @param[in]   domain_hi         Pointer to the upper bound of the overall simulation domain (Fortran indexing).
+ * @param[in]   active_mask_ptr   Pointer to the active_mask data array (INTEGER, 1=active/pore,
+ * 0=inactive/solid). Accessed as 3D in Fortran.
+ * @param[in]   mask_lo           Pointer to the lower bound of the 'active_mask_ptr' array (Fortran
+ * indexing, including ghosts).
+ * @param[in]   mask_hi           Pointer to the upper bound of the 'active_mask_ptr' array (Fortran
+ * indexing, including ghosts).
+ * @param[in]   valid_bx_lo       Pointer to the lower bound of the current valid box/region to fill
+ * (Fortran indexing).
+ * @param[in]   valid_bx_hi       Pointer to the upper bound of the current valid box/region to fill
+ * (Fortran indexing).
+ * @param[in]   domain_lo         Pointer to the lower bound of the overall simulation domain
+ * (Fortran indexing).
+ * @param[in]   domain_hi         Pointer to the upper bound of the overall simulation domain
+ * (Fortran indexing).
  * @param[in]   cell_sizes_in     Pointer to an array[3] of cell sizes [dx, dy, dz].
- * @param[in]   dir_k_in          Pointer to an integer representing the direction 'k' of ê_k (0 for X, 1 for Y, 2 for Z).
- * @param[in]   verbose_level_in  Pointer to an integer for the verbosity/debug print level in the Fortran kernel.
+ * @param[in]   dir_k_in          Pointer to an integer representing the direction 'k' of ê_k (0 for
+ * X, 1 for Y, 2 for Z).
+ * @param[in]   verbose_level_in  Pointer to an integer for the verbosity/debug print level in the
+ * Fortran kernel.
  *
- * @warning Ensure 'npts_valid' matches the number of points in the box defined by 'valid_bx_lo':'valid_bx_hi'.
- * @warning The 'active_mask_ptr' array must have its ghost cells filled appropriately before calling,
- *          as the kernel will access neighbor information.
+ * @warning Ensure 'npts_valid' matches the number of points in the box defined by
+ * 'valid_bx_lo':'valid_bx_hi'.
+ * @warning The 'active_mask_ptr' array must have its ghost cells filled appropriately before
+ * calling, as the kernel will access neighbor information.
  */
-void effdiff_fillmtx (
-    amrex_real* a_out,
-    amrex_real* rhs_out,
-    amrex_real* xinit_out,
-    const int* npts_valid,
-    const int* active_mask_ptr,
-    const int* mask_lo,
-    const int* mask_hi,
-    const int* valid_bx_lo,
-    const int* valid_bx_hi,
-    const int* domain_lo,
-    const int* domain_hi,
-    const amrex_real* cell_sizes_in,
-    const int* dir_k_in,
-    const int* verbose_level_in
-);
+void effdiff_fillmtx(amrex_real* a_out, amrex_real* rhs_out, amrex_real* xinit_out,
+                     const int* npts_valid, const int* active_mask_ptr, const int* mask_lo,
+                     const int* mask_hi, const int* valid_bx_lo, const int* valid_bx_hi,
+                     const int* domain_lo, const int* domain_hi, const amrex_real* cell_sizes_in,
+                     const int* dir_k_in, const int* verbose_level_in);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/props/EffectiveDiffusivityHypre.H
+++ b/src/props/EffectiveDiffusivityHypre.H
@@ -18,11 +18,13 @@
 #include <HYPRE.h>
 #include <HYPRE_struct_ls.h>
 
-// Assuming OpenImpala::Direction is defined in a shared header like "Tortuosity.H" or a new "Common.H"
+// Assuming OpenImpala::Direction is defined in a shared header like "Tortuosity.H" or a new
+// "Common.H"
 #include "Tortuosity.H" // Or your common enum definitions header
 
 /** @file EffectiveDiffusivityHypre.H
- * @brief Defines a class to solve the cell problem for effective diffusivity calculation using HYPRE.
+ * @brief Defines a class to solve the cell problem for effective diffusivity calculation using
+ * HYPRE.
  */
 
 namespace OpenImpala {
@@ -38,49 +40,37 @@ namespace OpenImpala {
  * The full effective diffusivity tensor D_eff calculation, which requires
  * all three χ_k fields, is intended to be performed outside this class.
  */
-class EffectiveDiffusivityHypre
-{
+class EffectiveDiffusivityHypre {
 
 public:
-
     /** @brief Specifies the HYPRE structured solver algorithm to use.
      *  (Identical to TortuosityHypre::SolverType, could be a shared enum)
      */
-    enum class SolverType {
-        Jacobi,
-        GMRES,
-        FlexGMRES,
-        PCG,
-        BiCGSTAB,
-        SMG,
-        PFMG
-    };
+    enum class SolverType { Jacobi, GMRES, FlexGMRES, PCG, BiCGSTAB, SMG, PFMG };
 
     /** @brief Construct new solver for the effective diffusivity cell problem.
      *
      * @param geom AMReX Geometry object defining the domain (REV).
      * @param ba AMReX BoxArray defining the distribution of grid patches.
      * @param dm AMReX DistributionMapping defining processor assignments.
-     * @param mf_phase_input Input iMultiFab containing phase IDs (expects 1 component, >=1 ghost cell).
-     * @param phase_id The ID of the phase considered to be the conductive material (where D=D_material, e.g., pores).
-     * @param dir_of_chi_k The direction 'k' (X, Y, or Z) for which the corrector function χ_k is being solved.
-     *                     This determines the ê_k vector in the RHS of the cell problem.
+     * @param mf_phase_input Input iMultiFab containing phase IDs (expects 1 component, >=1 ghost
+     * cell).
+     * @param phase_id The ID of the phase considered to be the conductive material (where
+     * D=D_material, e.g., pores).
+     * @param dir_of_chi_k The direction 'k' (X, Y, or Z) for which the corrector function χ_k is
+     * being solved. This determines the ê_k vector in the RHS of the cell problem.
      * @param solver_type Solver type to use (from SolverType enum).
      * @param resultspath Path to directory for writing output files (e.g., plotfiles for χ_k).
-     * @param verbose_level Verbosity level (0=silent, 1=basic, 2+=detailed HYPRE output). Default 1.
+     * @param verbose_level Verbosity level (0=silent, 1=basic, 2+=detailed HYPRE output).
+     * Default 1.
      * @param write_plotfile_flag If true, write a plotfile of the solved χ_k field. Default false.
      */
-    EffectiveDiffusivityHypre(
-        const amrex::Geometry& geom,
-        const amrex::BoxArray& ba,
-        const amrex::DistributionMapping& dm,
-        const amrex::iMultiFab& mf_phase_input,
-        const int phase_id,
-        const OpenImpala::Direction dir_of_chi_k,
-        const SolverType solver_type,
-        const std::string& resultspath,
-        int verbose_level = 1,
-        bool write_plotfile_flag = false);
+    EffectiveDiffusivityHypre(const amrex::Geometry& geom, const amrex::BoxArray& ba,
+                              const amrex::DistributionMapping& dm,
+                              const amrex::iMultiFab& mf_phase_input, const int phase_id,
+                              const OpenImpala::Direction dir_of_chi_k,
+                              const SolverType solver_type, const std::string& resultspath,
+                              int verbose_level = 1, bool write_plotfile_flag = false);
 
     /** @brief Destructor. Cleans up allocated HYPRE resources. */
     ~EffectiveDiffusivityHypre();
@@ -112,18 +102,25 @@ public:
 
 
     // --- Public Getters for Status and Solver Information ---
-    bool getSolverConverged() const { return m_converged; }
-    amrex::Real getFinalRelativeResidualNorm() const { return m_final_res_norm; }
-    int getSolverIterations() const { return m_num_iterations; }
-    const amrex::iMultiFab& getActiveMask() const { return m_mf_active_mask; } // Useful for D_eff calc
+    bool getSolverConverged() const {
+        return m_converged;
+    }
+    amrex::Real getFinalRelativeResidualNorm() const {
+        return m_final_res_norm;
+    }
+    int getSolverIterations() const {
+        return m_num_iterations;
+    }
+    const amrex::iMultiFab& getActiveMask() const {
+        return m_mf_active_mask;
+    } // Useful for D_eff calc
 
     // Static Helper Functions for HYPRE box conversion (can be shared if moved to a common utility)
-    static amrex::Array<HYPRE_Int,AMREX_SPACEDIM> loV (const amrex::Box& b);
-    static amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hiV (const amrex::Box& b);
+    static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> loV(const amrex::Box& b);
+    static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hiV(const amrex::Box& b);
 
 
 private:
-
     // --- Private Methods ---
     void setupGrids();
     void setupStencil();
@@ -134,13 +131,13 @@ private:
     // Configuration
     const SolverType m_solvertype;
     std::string m_resultspath;
-    const int m_phase_id;                 // Phase ID where D=D_material
+    const int m_phase_id;                    // Phase ID where D=D_material
     const OpenImpala::Direction m_dir_solve; // Direction k for current chi_k
-    amrex::Real m_eps;                    // Solver tolerance
-    int m_maxiter;                  // Max solver iterations
+    amrex::Real m_eps;                       // Solver tolerance
+    int m_maxiter;                           // Max solver iterations
     int m_verbose;
     bool m_write_plotfile;
-    amrex::RealVect m_dx;                 // Cell sizes [dx, dy, dz]
+    amrex::RealVect m_dx; // Cell sizes [dx, dy, dz]
 
     // AMReX Data
     const amrex::Geometry& m_geom;
@@ -167,34 +164,30 @@ private:
 // --- Fortran Interface Declaration ---
 // This will be for your new Fortran kernel for the cell problem
 extern "C" {
-    /**
-     * @brief Fills HYPRE matrix (A) and RHS (b) for the cell problem:
-     *        ∇_ξ ⋅ (D ∇_ξ χ_k) = -∇_ξ ⋅ (D ê_k)
-     * @param a Output buffer for matrix stencil coefficients.
-     * @param rhs Output buffer for RHS values.
-     * @param xinit Output buffer for initial guess of chi_k (typically zero).
-     * @param npts_valid Number of points in the valid_bx region to fill.
-     * @param active_mask_ptr Pointer to the active_mask data (1 for D=D_material, 0 otherwise).
-     * @param mask_lo Lower bounds of the active_mask FAB.
-     * @param mask_hi Upper bounds of the active_mask FAB.
-     * @param valid_bx_lo Lower bounds of the current valid region to fill.
-     * @param valid_bx_hi Upper bounds of the current valid region to fill.
-     * @param domain_lo Lower bounds of the overall simulation domain.
-     * @param domain_hi Upper bounds of the overall simulation domain.
-     * @param cell_sizes Array of cell sizes [dx, dy, dz].
-     * @param dir_k Integer representing the direction of ê_k (0 for X, 1 for Y, 2 for Z).
-     * @param verbose_level Verbosity level for debugging in Fortran.
-     */
-    void effdiff_fillmtx( // Name matches the one used in the .cpp
-        amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit,
-        const int* npts_valid,
-        const int* active_mask_ptr, const int* mask_lo, const int* mask_hi,
-        const int* valid_bx_lo, const int* valid_bx_hi,
-        const int* domain_lo, const int* domain_hi,
-        const amrex::Real* cell_sizes, // Pass dx, dy, dz
-        const int* dir_k,
-        const int* verbose_level
-    );
+/**
+ * @brief Fills HYPRE matrix (A) and RHS (b) for the cell problem:
+ *        ∇_ξ ⋅ (D ∇_ξ χ_k) = -∇_ξ ⋅ (D ê_k)
+ * @param a Output buffer for matrix stencil coefficients.
+ * @param rhs Output buffer for RHS values.
+ * @param xinit Output buffer for initial guess of chi_k (typically zero).
+ * @param npts_valid Number of points in the valid_bx region to fill.
+ * @param active_mask_ptr Pointer to the active_mask data (1 for D=D_material, 0 otherwise).
+ * @param mask_lo Lower bounds of the active_mask FAB.
+ * @param mask_hi Upper bounds of the active_mask FAB.
+ * @param valid_bx_lo Lower bounds of the current valid region to fill.
+ * @param valid_bx_hi Upper bounds of the current valid region to fill.
+ * @param domain_lo Lower bounds of the overall simulation domain.
+ * @param domain_hi Upper bounds of the overall simulation domain.
+ * @param cell_sizes Array of cell sizes [dx, dy, dz].
+ * @param dir_k Integer representing the direction of ê_k (0 for X, 1 for Y, 2 for Z).
+ * @param verbose_level Verbosity level for debugging in Fortran.
+ */
+void effdiff_fillmtx( // Name matches the one used in the .cpp
+    amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit, const int* npts_valid,
+    const int* active_mask_ptr, const int* mask_lo, const int* mask_hi, const int* valid_bx_lo,
+    const int* valid_bx_hi, const int* domain_lo, const int* domain_hi,
+    const amrex::Real* cell_sizes, // Pass dx, dy, dz
+    const int* dir_k, const int* verbose_level);
 }
 
 

--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <algorithm>
 #include <sstream>
-#include <atomic> 
+#include <atomic>
 
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
@@ -40,97 +40,88 @@
 #include <mpi.h>
 
 // HYPRE_CHECK macro
-#define HYPRE_CHECK(ierr) do { \
-    if (ierr != 0) { \
-        char hypre_error_msg[256]; \
-        HYPRE_DescribeError(ierr, hypre_error_msg); \
-        amrex::Abort("HYPRE Error: " + std::string(hypre_error_msg) + \
-                     " - Error Code: " + std::to_string(ierr) + \
-                     " File: " + __FILE__ + " Line: " + std::to_string(__LINE__)); \
-    } \
-} while (0)
+#define HYPRE_CHECK(ierr)                                                                          \
+    do {                                                                                           \
+        if (ierr != 0) {                                                                           \
+            char hypre_error_msg[256];                                                             \
+            HYPRE_DescribeError(ierr, hypre_error_msg);                                            \
+            amrex::Abort("HYPRE Error: " + std::string(hypre_error_msg) +                          \
+                         " - Error Code: " + std::to_string(ierr) + " File: " + __FILE__ +         \
+                         " Line: " + std::to_string(__LINE__));                                    \
+        }                                                                                          \
+    } while (0)
 
 // Constants namespace
 namespace {
-    constexpr int ChiComp = 0;
-    constexpr int MaskComp = 0;
-    constexpr int numComponentsChi = 1;
-    constexpr int stencil_size = 7;
-    constexpr int cell_inactive = 0;
-    constexpr int cell_active = 1;
-    constexpr int istn_c  = 0;
-    constexpr int istn_mx = 1;
-    constexpr int istn_px = 2;
-    constexpr int istn_my = 3;
-    constexpr int istn_py = 4;
-    constexpr int istn_mz = 5;
-    constexpr int istn_pz = 6;
+constexpr int ChiComp = 0;
+constexpr int MaskComp = 0;
+constexpr int numComponentsChi = 1;
+constexpr int stencil_size = 7;
+constexpr int cell_inactive = 0;
+constexpr int cell_active = 1;
+constexpr int istn_c = 0;
+constexpr int istn_mx = 1;
+constexpr int istn_px = 2;
+constexpr int istn_my = 3;
+constexpr int istn_py = 4;
+constexpr int istn_mz = 5;
+constexpr int istn_pz = 6;
 
-    // Helper function to manually sum active cells in an iMultiFab
-    long ManualSumActiveCells(const amrex::iMultiFab& imf, int component, int active_value) {
-        long total_active_cells = 0;
-        // Not using TilingIfNotGPU() here as it's a simple sum,
-        // and this function might be called outside OMP regions too.
-        // The MFIter itself is safe.
-        for (amrex::MFIter mfi(imf, false); mfi.isValid(); ++mfi) {
-            const amrex::Box& vbox = mfi.validbox();
-            amrex::Array4<const int> const arr = imf.const_array(mfi);
-            long local_s = 0;
-            amrex::LoopOnCpu(vbox, [&](int i, int j, int k){
-                if(arr(i,j,k,component) == active_value) local_s++;
-            });
-            total_active_cells += local_s;
-        }
-        amrex::ParallelDescriptor::ReduceLongSum(total_active_cells);
-        return total_active_cells;
+// Helper function to manually sum active cells in an iMultiFab
+long ManualSumActiveCells(const amrex::iMultiFab& imf, int component, int active_value) {
+    long total_active_cells = 0;
+    // Not using TilingIfNotGPU() here as it's a simple sum,
+    // and this function might be called outside OMP regions too.
+    // The MFIter itself is safe.
+    for (amrex::MFIter mfi(imf, false); mfi.isValid(); ++mfi) {
+        const amrex::Box& vbox = mfi.validbox();
+        amrex::Array4<const int> const arr = imf.const_array(mfi);
+        long local_s = 0;
+        amrex::LoopOnCpu(vbox, [&](int i, int j, int k) {
+            if (arr(i, j, k, component) == active_value)
+                local_s++;
+        });
+        total_active_cells += local_s;
     }
+    amrex::ParallelDescriptor::ReduceLongSum(total_active_cells);
+    return total_active_cells;
 }
+} // namespace
 
 namespace OpenImpala {
 
-amrex::Array<HYPRE_Int,AMREX_SPACEDIM> EffectiveDiffusivityHypre::loV (const amrex::Box& b) {
+amrex::Array<HYPRE_Int, AMREX_SPACEDIM> EffectiveDiffusivityHypre::loV(const amrex::Box& b) {
     const int* lo_ptr = b.loVect();
-    amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hypre_lo;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) hypre_lo[i] = static_cast<HYPRE_Int>(lo_ptr[i]);
+    amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hypre_lo;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        hypre_lo[i] = static_cast<HYPRE_Int>(lo_ptr[i]);
     return hypre_lo;
 }
-amrex::Array<HYPRE_Int,AMREX_SPACEDIM> EffectiveDiffusivityHypre::hiV (const amrex::Box& b) {
+amrex::Array<HYPRE_Int, AMREX_SPACEDIM> EffectiveDiffusivityHypre::hiV(const amrex::Box& b) {
     const int* hi_ptr = b.hiVect();
-    amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hypre_hi;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) hypre_hi[i] = static_cast<HYPRE_Int>(hi_ptr[i]);
+    amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hypre_hi;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        hypre_hi[i] = static_cast<HYPRE_Int>(hi_ptr[i]);
     return hypre_hi;
 }
 
 EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
-    const amrex::Geometry& geom,
-    const amrex::BoxArray& ba,
-    const amrex::DistributionMapping& dm,
-    const amrex::iMultiFab& mf_phase_input,
-    const int phase_id_arg, 
-    const OpenImpala::Direction dir_of_chi_k,
-    const SolverType solver_type,
-    const std::string& resultspath,
-    int verbose_level,
-    bool write_plotfile_flag)
+    const amrex::Geometry& geom, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,
+    const amrex::iMultiFab& mf_phase_input, const int phase_id_arg,
+    const OpenImpala::Direction dir_of_chi_k, const SolverType solver_type,
+    const std::string& resultspath, int verbose_level, bool write_plotfile_flag)
     : m_geom(geom), m_ba(ba), m_dm(dm),
       m_mf_phase_original(ba, dm, mf_phase_input.nComp(), mf_phase_input.nGrow()),
-      m_phase_id(phase_id_arg), 
-      m_dir_solve(dir_of_chi_k),
-      m_solvertype(solver_type),
-      m_eps(1e-9), m_maxiter(1000),
-      m_resultspath(resultspath),
-      m_verbose(verbose_level),
-      m_write_plotfile(write_plotfile_flag),
-      m_mf_chi(ba, dm, numComponentsChi, 1),
-      m_mf_active_mask(ba, dm, 1, 1),
-      m_grid(NULL), m_stencil(NULL), m_A(NULL), m_b(NULL), m_x(NULL),
-      m_num_iterations(-1),
-      m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()),
-      m_converged(false)
-{
+      m_phase_id(phase_id_arg), m_dir_solve(dir_of_chi_k), m_solvertype(solver_type), m_eps(1e-9),
+      m_maxiter(1000), m_resultspath(resultspath), m_verbose(verbose_level),
+      m_write_plotfile(write_plotfile_flag), m_mf_chi(ba, dm, numComponentsChi, 1),
+      m_mf_active_mask(ba, dm, 1, 1), m_grid(NULL), m_stencil(NULL), m_A(NULL), m_b(NULL),
+      m_x(NULL), m_num_iterations(-1),
+      m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()), m_converged(false) {
     BL_PROFILE("EffectiveDiffusivityHypre::Constructor");
 
-    amrex::Copy(m_mf_phase_original, mf_phase_input, 0, 0, m_mf_phase_original.nComp(), m_mf_phase_original.nGrow());
+    amrex::Copy(m_mf_phase_original, mf_phase_input, 0, 0, m_mf_phase_original.nComp(),
+                m_mf_phase_original.nGrow());
     if (m_mf_phase_original.nGrow() > 0) {
         m_mf_phase_original.FillBoundary(m_geom.periodicity());
     }
@@ -138,15 +129,21 @@ EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "EffectiveDiffusivityHypre: Initializing for chi_k in direction "
                        << static_cast<int>(m_dir_solve) << "..." << std::endl;
-        amrex::Print() << "  DEBUG HYPRE: Constructor received m_phase_id (member) = " << m_phase_id << std::endl;
+        amrex::Print() << "  DEBUG HYPRE: Constructor received m_phase_id (member) = " << m_phase_id
+                       << std::endl;
     }
 
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { // Keep this detailed check for high verbosity
+    if (m_verbose > 1 &&
+        amrex::ParallelDescriptor::IOProcessor()) { // Keep this detailed check for high verbosity
         long initial_phase_count_debug = ManualSumActiveCells(m_mf_phase_original, 0, m_phase_id);
-        amrex::Print() << "  DEBUG HYPRE: Number of cells in input m_mf_phase_original matching m_phase_id (" << m_phase_id
-                       << ") before generateActiveMask (manual sum): " << initial_phase_count_debug << std::endl;
-        amrex::Print() << "  DEBUG HYPRE: m_mf_phase_original nComp: " << m_mf_phase_original.nComp()
-                       << ", nGrow: " << m_mf_phase_original.nGrow() << std::endl;
+        amrex::Print()
+            << "  DEBUG HYPRE: Number of cells in input m_mf_phase_original matching m_phase_id ("
+            << m_phase_id
+            << ") before generateActiveMask (manual sum): " << initial_phase_count_debug
+            << std::endl;
+        amrex::Print() << "  DEBUG HYPRE: m_mf_phase_original nComp: "
+                       << m_mf_phase_original.nComp() << ", nGrow: " << m_mf_phase_original.nGrow()
+                       << std::endl;
     }
 
     amrex::ParmParse pp_hypre("hypre");
@@ -157,29 +154,33 @@ EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_maxiter > 0, "Solver max iterations must be positive");
 
     const amrex::Real* dx_tmp = m_geom.CellSize();
-    for(int i_dim=0; i_dim<AMREX_SPACEDIM; ++i_dim) { 
+    for (int i_dim = 0; i_dim < AMREX_SPACEDIM; ++i_dim) {
         m_dx[i_dim] = dx_tmp[i_dim];
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_dx[i_dim] > 0.0, "Cell size must be positive.");
     }
 
     m_mf_active_mask.setVal(cell_inactive);
-    generateActiveMask(); 
+    generateActiveMask();
 
     long num_active_cells = ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
 
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()){
-        amrex::Print() << "  Active mask generated. Number of active cells (Manually summed): " << num_active_cells << std::endl;
-        if (m_verbose > 1) { // If very verbose, also show the iMultiFab::sum() for comparison/awareness
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  Active mask generated. Number of active cells (Manually summed): "
+                       << num_active_cells << std::endl;
+        if (m_verbose >
+            1) { // If very verbose, also show the iMultiFab::sum() for comparison/awareness
             long num_active_cells_imfsum = m_mf_active_mask.sum(MaskComp, true);
             amrex::ParallelDescriptor::ReduceLongSum(num_active_cells_imfsum);
-            amrex::Print() << "  Active mask generated. Number of active cells (from m_mf_active_mask.sum()): " << num_active_cells_imfsum << std::endl;
+            amrex::Print()
+                << "  Active mask generated. Number of active cells (from m_mf_active_mask.sum()): "
+                << num_active_cells_imfsum << std::endl;
         }
     }
 
-    if (num_active_cells == 0) { 
+    if (num_active_cells == 0) {
         if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "WARNING: No active cells found (manual sum) for phase_id " << m_phase_id
-                           << ". HYPRE setup will be skipped." << std::endl;
+            amrex::Print() << "WARNING: No active cells found (manual sum) for phase_id "
+                           << m_phase_id << ". HYPRE setup will be skipped." << std::endl;
         }
         m_converged = true;
         m_num_iterations = 0;
@@ -200,80 +201,97 @@ EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
     }
 }
 
-EffectiveDiffusivityHypre::~EffectiveDiffusivityHypre()
-{
-    if (m_x)       HYPRE_StructVectorDestroy(m_x);
-    if (m_b)       HYPRE_StructVectorDestroy(m_b);
-    if (m_A)       HYPRE_StructMatrixDestroy(m_A);
-    if (m_stencil) HYPRE_StructStencilDestroy(m_stencil);
-    if (m_grid)    HYPRE_StructGridDestroy(m_grid);
-    m_x = m_b = NULL; m_A = NULL; m_stencil = NULL; m_grid = NULL;
+EffectiveDiffusivityHypre::~EffectiveDiffusivityHypre() {
+    if (m_x)
+        HYPRE_StructVectorDestroy(m_x);
+    if (m_b)
+        HYPRE_StructVectorDestroy(m_b);
+    if (m_A)
+        HYPRE_StructMatrixDestroy(m_A);
+    if (m_stencil)
+        HYPRE_StructStencilDestroy(m_stencil);
+    if (m_grid)
+        HYPRE_StructGridDestroy(m_grid);
+    m_x = m_b = NULL;
+    m_A = NULL;
+    m_stencil = NULL;
+    m_grid = NULL;
 }
 
-void EffectiveDiffusivityHypre::generateActiveMask()
-{
+void EffectiveDiffusivityHypre::generateActiveMask() {
     BL_PROFILE("EffectiveDiffusivityHypre::generateActiveMask");
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        long phase_original_sum_debug_again = ManualSumActiveCells(m_mf_phase_original, 0, m_phase_id);
-        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_phase_original for m_phase_id (" << m_phase_id
-                       << ") *immediately before* mask generation loop: " << phase_original_sum_debug_again << std::endl;
+        long phase_original_sum_debug_again =
+            ManualSumActiveCells(m_mf_phase_original, 0, m_phase_id);
+        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_phase_original for "
+                          "m_phase_id ("
+                       << m_phase_id << ") *immediately before* mask generation loop: "
+                       << phase_original_sum_debug_again << std::endl;
     }
 
     if (m_mf_phase_original.nGrow() > 0) {
-         m_mf_phase_original.FillBoundary(m_geom.periodicity());
+        m_mf_phase_original.FillBoundary(m_geom.periodicity());
     }
 
     std::atomic<long> cells_not_target_became_active(0); // Renamed for clarity
     std::atomic<long> cells_target_became_active(0);     // Renamed
     std::atomic<long> cells_target_became_inactive(0);   // Renamed
 
-    #ifdef AMREX_USE_OMP
-    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-    #endif
-    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& current_tile_box = mfi.tilebox();
         amrex::Array4<int> const mask_arr = m_mf_active_mask.array(mfi);
         amrex::Array4<const int> const phase_arr = m_mf_phase_original.const_array(mfi);
-        
+
         const int local_m_phase_id = m_phase_id;
 
-        if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor() && mfi.LocalIndex() == 0 && amrex::ParallelDescriptor::MyProc() == amrex::ParallelDescriptor::IOProcessorNumber()) { // Changed to verbose > 2
-             amrex::Print() << "  DEBUG HYPRE: generateActiveMask MFIter loop (verbose > 2) is using local_m_phase_id = " << local_m_phase_id
-                           << " (from m_phase_id = " << m_phase_id << ") for comparison." << std::endl;
+        if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor() && mfi.LocalIndex() == 0 &&
+            amrex::ParallelDescriptor::MyProc() ==
+                amrex::ParallelDescriptor::IOProcessorNumber()) { // Changed to verbose > 2
+            amrex::Print() << "  DEBUG HYPRE: generateActiveMask MFIter loop (verbose > 2) is "
+                              "using local_m_phase_id = "
+                           << local_m_phase_id << " (from m_phase_id = " << m_phase_id
+                           << ") for comparison." << std::endl;
         }
 
         const amrex::Box& valid_bx_for_debug = mfi.validbox();
 
-        amrex::LoopOnCpu(current_tile_box, [=, &cells_not_target_became_active, &cells_target_became_active, &cells_target_became_inactive] (int i, int j, int k) noexcept
-        {
-            int original_phase_val = phase_arr(i,j,k,0);
-            bool is_target_phase = (original_phase_val == local_m_phase_id);
-            
-            if (is_target_phase) {
-                mask_arr(i,j,k,MaskComp) = cell_active;
-                if (valid_bx_for_debug.contains(i,j,k)) { 
-                    cells_target_became_active++; 
+        amrex::LoopOnCpu(
+            current_tile_box, [=, &cells_not_target_became_active, &cells_target_became_active,
+                               &cells_target_became_inactive](int i, int j, int k) noexcept {
+                int original_phase_val = phase_arr(i, j, k, 0);
+                bool is_target_phase = (original_phase_val == local_m_phase_id);
+
+                if (is_target_phase) {
+                    mask_arr(i, j, k, MaskComp) = cell_active;
+                    if (valid_bx_for_debug.contains(i, j, k)) {
+                        cells_target_became_active++;
+                    }
+                } else {
+                    mask_arr(i, j, k, MaskComp) = cell_inactive;
+                    if (valid_bx_for_debug.contains(i, j, k)) {
+                        // This cell was not target_phase and correctly made inactive.
+                        // If it *was* target phase but made inactive (error in logic), this counter
+                        // is not for it.
+                    }
                 }
-            } else {
-                mask_arr(i,j,k,MaskComp) = cell_inactive;
-                 if (valid_bx_for_debug.contains(i,j,k)) { 
-                    // This cell was not target_phase and correctly made inactive.
-                    // If it *was* target phase but made inactive (error in logic), this counter is not for it.
-                 }
-            }
-            // Separate check for errors in valid region
-            if (valid_bx_for_debug.contains(i,j,k)) {
-                if (!is_target_phase && mask_arr(i,j,k,MaskComp) == cell_active) { // Was not target, but became active
-                    cells_not_target_became_active++; 
-                } else if (is_target_phase && mask_arr(i,j,k,MaskComp) == cell_inactive) { // Was target, but became inactive
-                    cells_target_became_inactive++;
+                // Separate check for errors in valid region
+                if (valid_bx_for_debug.contains(i, j, k)) {
+                    if (!is_target_phase && mask_arr(i, j, k, MaskComp) ==
+                                                cell_active) { // Was not target, but became active
+                        cells_not_target_became_active++;
+                    } else if (is_target_phase &&
+                               mask_arr(i, j, k, MaskComp) ==
+                                   cell_inactive) { // Was target, but became inactive
+                        cells_target_became_inactive++;
+                    }
                 }
-            }
-        });
+            });
     }
-    
+
     long cells_not_target_became_active_val = cells_not_target_became_active.load();
     long cells_target_became_active_val = cells_target_became_active.load();
     long cells_target_became_inactive_val = cells_target_became_inactive.load();
@@ -283,51 +301,67 @@ void EffectiveDiffusivityHypre::generateActiveMask()
     amrex::ParallelDescriptor::ReduceLongSum(cells_target_became_inactive_val);
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { // Changed to verbose > 1
-        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally NOT m_phase_id that BECAME ACTIVE: "
+        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally NOT "
+                          "m_phase_id that BECAME ACTIVE: "
                        << cells_not_target_became_active_val << std::endl;
-        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally m_phase_id that BECAME ACTIVE: "
+        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally "
+                          "m_phase_id that BECAME ACTIVE: "
                        << cells_target_became_active_val << std::endl;
-        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally m_phase_id that BECAME INACTIVE: "
+        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Count of (valid) cells originally "
+                          "m_phase_id that BECAME INACTIVE: "
                        << cells_target_became_inactive_val << std::endl;
     }
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        long active_mask_sum_manual_before_fb = ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
-        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_active_mask (valid cells) *after* loop, *before* FillBoundary: "
+        long active_mask_sum_manual_before_fb =
+            ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
+        amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_active_mask (valid "
+                          "cells) *after* loop, *before* FillBoundary: "
                        << active_mask_sum_manual_before_fb << std::endl;
     }
 
     if (m_mf_active_mask.nGrow() > 0) {
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "  DEBUG HYPRE generateActiveMask: Calling m_mf_active_mask.FillBoundary()..." << std::endl;
+            amrex::Print()
+                << "  DEBUG HYPRE generateActiveMask: Calling m_mf_active_mask.FillBoundary()..."
+                << std::endl;
         }
-        m_mf_active_mask.FillBoundary(m_geom.periodicity()); 
+        m_mf_active_mask.FillBoundary(m_geom.periodicity());
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "  DEBUG HYPRE generateActiveMask: Returned from m_mf_active_mask.FillBoundary()." << std::endl;
+            amrex::Print() << "  DEBUG HYPRE generateActiveMask: Returned from "
+                              "m_mf_active_mask.FillBoundary()."
+                           << std::endl;
         }
 
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { // Changed to verbose > 1 for these detailed checks
-            long active_mask_sum_manual_after_fb = ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
-            amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_active_mask (valid cells) *immediately after* FillBoundary: "
+        if (m_verbose > 1 &&
+            amrex::ParallelDescriptor::IOProcessor()) { // Changed to verbose > 1 for these detailed
+                                                        // checks
+            long active_mask_sum_manual_after_fb =
+                ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
+            amrex::Print() << "  DEBUG HYPRE generateActiveMask: Manual sum of m_mf_active_mask "
+                              "(valid cells) *immediately after* FillBoundary: "
                            << active_mask_sum_manual_after_fb << std::endl;
-            long active_mask_sum_imf_after_fb = m_mf_active_mask.sum(MaskComp, true); 
+            long active_mask_sum_imf_after_fb = m_mf_active_mask.sum(MaskComp, true);
             amrex::ParallelDescriptor::ReduceLongSum(active_mask_sum_imf_after_fb);
-            amrex::Print() << "  DEBUG HYPRE generateActiveMask: m_mf_active_mask.sum() (valid cells) *immediately after* FillBoundary: "
+            amrex::Print() << "  DEBUG HYPRE generateActiveMask: m_mf_active_mask.sum() (valid "
+                              "cells) *immediately after* FillBoundary: "
                            << active_mask_sum_imf_after_fb << std::endl;
         }
     } else {
-         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  DEBUG HYPRE generateActiveMask: Skipped m_mf_active_mask.FillBoundary() as nGrow is 0." << std::endl;
-         }
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  DEBUG HYPRE generateActiveMask: Skipped "
+                              "m_mf_active_mask.FillBoundary() as nGrow is 0."
+                           << std::endl;
+        }
     }
 }
 
 // ... (setupGrids, setupStencil, setupMatrixEquation are unchanged from your last correct version)
-void EffectiveDiffusivityHypre::setupGrids()
-{
+void EffectiveDiffusivityHypre::setupGrids() {
     BL_PROFILE("EffectiveDiffusivityHypre::setupGrids");
     HYPRE_Int ierr = 0;
-    ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, AMREX_SPACEDIM, &m_grid); HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, AMREX_SPACEDIM, &m_grid);
+    HYPRE_CHECK(ierr);
 
     bool any_dim_periodic = false;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
@@ -344,112 +378,138 @@ void EffectiveDiffusivityHypre::setupGrids()
             if (m_geom.isPeriodic(d)) {
                 periodic_hyp[d] = static_cast<HYPRE_Int>(domain_geom_box.length(d));
                 if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-                     amrex::Print() << "  setupGrids: Dim " << d << " is periodic with length " << periodic_hyp[d] << std::endl;
+                    amrex::Print() << "  setupGrids: Dim " << d << " is periodic with length "
+                                   << periodic_hyp[d] << std::endl;
                 }
             } else {
                 periodic_hyp[d] = 0;
-                 if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-                     amrex::Print() << "  setupGrids: Dim " << d << " is NOT periodic (in AMReX geom)." << std::endl;
+                if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                    amrex::Print() << "  setupGrids: Dim " << d
+                                   << " is NOT periodic (in AMReX geom)." << std::endl;
                 }
             }
         }
-         for (int i_ba = 0; i_ba < m_ba.size(); ++i_ba) {
+        for (int i_ba = 0; i_ba < m_ba.size(); ++i_ba) {
             if (m_dm[i_ba] == amrex::ParallelDescriptor::MyProc()) {
                 amrex::Box bx = m_ba[i_ba];
                 auto lo = EffectiveDiffusivityHypre::loV(bx);
                 auto hi = EffectiveDiffusivityHypre::hiV(bx);
                 if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
-                     amrex::Print() << "  setupGrids: Rank " << amrex::ParallelDescriptor::MyProc()
-                                    << " adding box " << bx << std::endl;
+                    amrex::Print() << "  setupGrids: Rank " << amrex::ParallelDescriptor::MyProc()
+                                   << " adding box " << bx << std::endl;
                 }
-                ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data()); HYPRE_CHECK(ierr);
+                ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data());
+                HYPRE_CHECK(ierr);
             }
         }
-        ierr = HYPRE_StructGridSetPeriodic(m_grid, periodic_hyp); HYPRE_CHECK(ierr);
+        ierr = HYPRE_StructGridSetPeriodic(m_grid, periodic_hyp);
+        HYPRE_CHECK(ierr);
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "  setupGrids: HYPRE_StructGridSetPeriodic called." << std::endl;
         }
-    } else { 
-         for (int i_ba = 0; i_ba < m_ba.size(); ++i_ba) {
+    } else {
+        for (int i_ba = 0; i_ba < m_ba.size(); ++i_ba) {
             if (m_dm[i_ba] == amrex::ParallelDescriptor::MyProc()) {
                 amrex::Box bx = m_ba[i_ba];
                 auto lo = EffectiveDiffusivityHypre::loV(bx);
                 auto hi = EffectiveDiffusivityHypre::hiV(bx);
                 if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
-                     amrex::Print() << "  setupGrids (Non-Periodic AMReX Geom): Rank " << amrex::ParallelDescriptor::MyProc()
-                                    << " adding box " << bx << std::endl;
+                    amrex::Print()
+                        << "  setupGrids (Non-Periodic AMReX Geom): Rank "
+                        << amrex::ParallelDescriptor::MyProc() << " adding box " << bx << std::endl;
                 }
-                ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data()); HYPRE_CHECK(ierr);
+                ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data());
+                HYPRE_CHECK(ierr);
             }
         }
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  setupGrids: SKIPPING HYPRE_StructGridSetPeriodic (AMReX geom is non-periodic)." << std::endl;
+            amrex::Print() << "  setupGrids: SKIPPING HYPRE_StructGridSetPeriodic (AMReX geom is "
+                              "non-periodic)."
+                           << std::endl;
         }
     }
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "  setupGrids: Calling HYPRE_StructGridAssemble..." << std::endl;
     }
-    ierr = HYPRE_StructGridAssemble(m_grid); HYPRE_CHECK(ierr);
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_grid != NULL, "m_grid is NULL after HYPRE_StructGridAssemble!");
+    ierr = HYPRE_StructGridAssemble(m_grid);
+    HYPRE_CHECK(ierr);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_grid != NULL,
+                                     "m_grid is NULL after HYPRE_StructGridAssemble!");
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "  setupGrids: Assemble complete." << std::endl;
     }
 }
 
-void EffectiveDiffusivityHypre::setupStencil()
-{
+void EffectiveDiffusivityHypre::setupStencil() {
     BL_PROFILE("EffectiveDiffusivityHypre::setupStencil");
     HYPRE_Int ierr = 0;
-    HYPRE_Int offsets[stencil_size][AMREX_SPACEDIM] = {
-        { 0, 0, 0}, {-1, 0, 0}, { 1, 0, 0}, { 0,-1, 0}, { 0, 1, 0}, { 0, 0,-1}, { 0, 0, 1}
-    };
+    HYPRE_Int offsets[stencil_size][AMREX_SPACEDIM] = {{0, 0, 0}, {-1, 0, 0}, {1, 0, 0}, {0, -1, 0},
+                                                       {0, 1, 0}, {0, 0, -1}, {0, 0, 1}};
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  setupStencil: Creating " << stencil_size << "-point stencil..." << std::endl;
+        amrex::Print() << "  setupStencil: Creating " << stencil_size << "-point stencil..."
+                       << std::endl;
     }
-    ierr = HYPRE_StructStencilCreate(AMREX_SPACEDIM, stencil_size, &m_stencil); HYPRE_CHECK(ierr);
-    for (int i_stn = 0; i_stn < stencil_size; ++i_stn) { 
-        ierr = HYPRE_StructStencilSetElement(m_stencil, i_stn, offsets[i_stn]); HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructStencilCreate(AMREX_SPACEDIM, stencil_size, &m_stencil);
+    HYPRE_CHECK(ierr);
+    for (int i_stn = 0; i_stn < stencil_size; ++i_stn) {
+        ierr = HYPRE_StructStencilSetElement(m_stencil, i_stn, offsets[i_stn]);
+        HYPRE_CHECK(ierr);
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stencil != NULL, "m_stencil is NULL after HYPRE_StructStencilCreate/SetElement!");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_stencil != NULL, "m_stencil is NULL after HYPRE_StructStencilCreate/SetElement!");
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "  setupStencil: Complete." << std::endl;
     }
 }
 
-void EffectiveDiffusivityHypre::setupMatrixEquation()
-{
+void EffectiveDiffusivityHypre::setupMatrixEquation() {
     BL_PROFILE("EffectiveDiffusivityHypre::setupMatrixEquation");
     HYPRE_Int ierr = 0;
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  setupMatrixEquation: Creating HYPRE Matrix and Vectors..." << std::endl;
+        amrex::Print() << "  setupMatrixEquation: Creating HYPRE Matrix and Vectors..."
+                       << std::endl;
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_grid != NULL, "m_grid is NULL in setupMatrixEquation. Call setupGrids first.");
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_stencil != NULL, "m_stencil is NULL in setupMatrixEquation. Call setupStencil first.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_grid != NULL, "m_grid is NULL in setupMatrixEquation. Call setupGrids first.");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        m_stencil != NULL, "m_stencil is NULL in setupMatrixEquation. Call setupStencil first.");
 
-    ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, m_grid, m_stencil, &m_A); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructMatrixCreate: OK" << std::endl;
+    ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, m_grid, m_stencil, &m_A);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructMatrixCreate: OK" << std::endl;
 
-    ierr = HYPRE_StructMatrixInitialize(m_A); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructMatrixInitialize: OK" << std::endl;
+    ierr = HYPRE_StructMatrixInitialize(m_A);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructMatrixInitialize: OK" << std::endl;
 
-    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_b); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorCreate (b): OK" << std::endl;
+    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_b);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorCreate (b): OK" << std::endl;
 
-    ierr = HYPRE_StructVectorInitialize(m_b); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorInitialize (b): OK" << std::endl;
+    ierr = HYPRE_StructVectorInitialize(m_b);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorInitialize (b): OK" << std::endl;
 
-    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_x); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorCreate (x): OK" << std::endl;
+    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_x);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorCreate (x): OK" << std::endl;
 
-    ierr = HYPRE_StructVectorInitialize(m_x); HYPRE_CHECK(ierr);
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorInitialize (x): OK" << std::endl;
+    ierr = HYPRE_StructVectorInitialize(m_x);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorInitialize (x): OK" << std::endl;
 
     const amrex::Box& domain_for_kernel = m_geom.Domain();
-    int stencil_indices_hypre[stencil_size]; 
-    for(int i_loop=0; i_loop<stencil_size; ++i_loop) {
+    int stencil_indices_hypre[stencil_size];
+    for (int i_loop = 0; i_loop < stencil_size; ++i_loop) {
         stencil_indices_hypre[i_loop] = i_loop;
     }
     const int current_dir_int = static_cast<int>(m_dir_solve);
@@ -457,18 +517,24 @@ void EffectiveDiffusivityHypre::setupMatrixEquation()
     if (m_mf_active_mask.nGrow() > 0) {
         // This FillBoundary is crucial for the Fortran kernel if it accesses ghost cells
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  DEBUG HYPRE setupMatrixEquation: Calling m_mf_active_mask.FillBoundary() before Fortran..." << std::endl;
+            amrex::Print() << "  DEBUG HYPRE setupMatrixEquation: Calling "
+                              "m_mf_active_mask.FillBoundary() before Fortran..."
+                           << std::endl;
         }
         m_mf_active_mask.FillBoundary(m_geom.periodicity());
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
             long sum_check = ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
-            amrex::Print() << "  DEBUG HYPRE setupMatrixEquation: Manual sum of m_mf_active_mask after FillBoundary (before Fortran) = " << sum_check << std::endl;
+            amrex::Print() << "  DEBUG HYPRE setupMatrixEquation: Manual sum of m_mf_active_mask "
+                              "after FillBoundary (before Fortran) = "
+                           << sum_check << std::endl;
         }
     }
 
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  setupMatrixEquation: Calling Fortran kernel 'effdiff_fillmtx' and SetBoxValues..." << std::endl;
+        amrex::Print()
+            << "  setupMatrixEquation: Calling Fortran kernel 'effdiff_fillmtx' and SetBoxValues..."
+            << std::endl;
     }
 
     std::vector<amrex::Real> matrix_values_buffer;
@@ -476,40 +542,36 @@ void EffectiveDiffusivityHypre::setupMatrixEquation()
     std::vector<amrex::Real> initial_guess_buffer;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) \
-                 private(matrix_values_buffer, rhs_values_buffer, initial_guess_buffer)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(                                 \
+        matrix_values_buffer, rhs_values_buffer, initial_guess_buffer)
 #endif
-    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& valid_bx = mfi.validbox();
         const int npts_valid = static_cast<int>(valid_bx.numPts());
-        if (npts_valid == 0) continue;
+        if (npts_valid == 0)
+            continue;
 
         matrix_values_buffer.resize(static_cast<size_t>(npts_valid) * stencil_size);
         rhs_values_buffer.resize(npts_valid);
         initial_guess_buffer.resize(npts_valid);
 
-        const amrex::IArrayBox& mask_fab = m_mf_active_mask[mfi]; 
+        const amrex::IArrayBox& mask_fab = m_mf_active_mask[mfi];
         const int* mask_ptr = mask_fab.dataPtr(MaskComp);
         const auto* mask_fab_lo = mask_fab.loVect();
         const auto* mask_fab_hi = mask_fab.hiVect();
 
-        effdiff_fillmtx(
-            matrix_values_buffer.data(), rhs_values_buffer.data(), initial_guess_buffer.data(),
-            &npts_valid,
-            mask_ptr, mask_fab_lo, mask_fab_hi,
-            valid_bx.loVect(), valid_bx.hiVect(),
-            domain_for_kernel.loVect(), domain_for_kernel.hiVect(),
-            m_dx.dataPtr(),
-            &current_dir_int, 
-            &m_verbose
-        );
+        effdiff_fillmtx(matrix_values_buffer.data(), rhs_values_buffer.data(),
+                        initial_guess_buffer.data(), &npts_valid, mask_ptr, mask_fab_lo,
+                        mask_fab_hi, valid_bx.loVect(), valid_bx.hiVect(),
+                        domain_for_kernel.loVect(), domain_for_kernel.hiVect(), m_dx.dataPtr(),
+                        &current_dir_int, &m_verbose);
 
         auto hypre_lo_valid = EffectiveDiffusivityHypre::loV(valid_bx);
         auto hypre_hi_valid = EffectiveDiffusivityHypre::hiV(valid_bx);
 
         ierr = HYPRE_StructMatrixSetBoxValues(m_A, hypre_lo_valid.data(), hypre_hi_valid.data(),
-                                              stencil_size, stencil_indices_hypre, matrix_values_buffer.data());
+                                              stencil_size, stencil_indices_hypre,
+                                              matrix_values_buffer.data());
         HYPRE_CHECK(ierr);
         ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo_valid.data(), hypre_hi_valid.data(),
                                               rhs_values_buffer.data());
@@ -520,48 +582,58 @@ void EffectiveDiffusivityHypre::setupMatrixEquation()
     }
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-       amrex::Print() << "  setupMatrixEquation: Attempting HYPRE_StructMatrixAssemble(m_A)..." << std::endl;
+        amrex::Print() << "  setupMatrixEquation: Attempting HYPRE_StructMatrixAssemble(m_A)..."
+                       << std::endl;
     }
-    ierr = HYPRE_StructMatrixAssemble(m_A); HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructMatrixAssemble(m_A);
+    HYPRE_CHECK(ierr);
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-       amrex::Print() << "    HYPRE_StructMatrixAssemble(m_A): OK" << std::endl;
+        amrex::Print() << "    HYPRE_StructMatrixAssemble(m_A): OK" << std::endl;
     }
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-       amrex::Print() << "  setupMatrixEquation: Attempting Vector Assembles..." << std::endl;
+        amrex::Print() << "  setupMatrixEquation: Attempting Vector Assembles..." << std::endl;
     }
-    ierr = HYPRE_StructVectorAssemble(m_b); HYPRE_CHECK(ierr); 
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorAssemble(m_b): OK" << std::endl;
-    ierr = HYPRE_StructVectorAssemble(m_x); HYPRE_CHECK(ierr); 
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "    HYPRE_StructVectorAssemble(m_x): OK" << std::endl;
+    ierr = HYPRE_StructVectorAssemble(m_b);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorAssemble(m_b): OK" << std::endl;
+    ierr = HYPRE_StructVectorAssemble(m_x);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "    HYPRE_StructVectorAssemble(m_x): OK" << std::endl;
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  setupMatrixEquation: Setup complete (All Assembles Done)." << std::endl;
+        amrex::Print() << "  setupMatrixEquation: Setup complete (All Assembles Done)."
+                       << std::endl;
     }
 }
 
-bool EffectiveDiffusivityHypre::solve()
-{
+bool EffectiveDiffusivityHypre::solve() {
     BL_PROFILE("EffectiveDiffusivityHypre::solve");
 
     long num_active_cells_in_solve = ManualSumActiveCells(m_mf_active_mask, MaskComp, cell_active);
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  DEBUG HYPRE solve: num_active_cells_in_solve (Manually summed) = " << num_active_cells_in_solve << std::endl;
+        amrex::Print() << "  DEBUG HYPRE solve: num_active_cells_in_solve (Manually summed) = "
+                       << num_active_cells_in_solve << std::endl;
         // For comparison, also print the iMultiFab::sum() result
         long num_active_cells_imfsum_solve = m_mf_active_mask.sum(MaskComp, true);
         amrex::ParallelDescriptor::ReduceLongSum(num_active_cells_imfsum_solve);
-        amrex::Print() << "  DEBUG HYPRE solve: num_active_cells_in_solve (from m_mf_active_mask.sum()) = " << num_active_cells_imfsum_solve << std::endl;
-
+        amrex::Print()
+            << "  DEBUG HYPRE solve: num_active_cells_in_solve (from m_mf_active_mask.sum()) = "
+            << num_active_cells_imfsum_solve << std::endl;
     }
 
-    if (num_active_cells_in_solve == 0) { 
+    if (num_active_cells_in_solve == 0) {
         if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "EffectiveDiffusivityHypre::solve: Skipping HYPRE solve as no active cells were found (manual sum) for phase "
+            amrex::Print() << "EffectiveDiffusivityHypre::solve: Skipping HYPRE solve as no active "
+                              "cells were found (manual sum) for phase "
                            << m_phase_id << std::endl;
         }
-        m_mf_chi.setVal(0.0); 
-        if (m_mf_chi.nGrow() > 0) m_mf_chi.FillBoundary(m_geom.periodicity()); 
+        m_mf_chi.setVal(0.0);
+        if (m_mf_chi.nGrow() > 0)
+            m_mf_chi.FillBoundary(m_geom.periodicity());
 
         m_converged = true;
         m_num_iterations = 0;
@@ -579,31 +651,40 @@ bool EffectiveDiffusivityHypre::solve()
 
     if (m_solvertype == SolverType::FlexGMRES) {
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  solve: Setting up HYPRE FlexGMRES Solver with PFMG Preconditioner..." << std::endl; 
+            amrex::Print()
+                << "  solve: Setting up HYPRE FlexGMRES Solver with PFMG Preconditioner..."
+                << std::endl;
         }
-        ierr = HYPRE_StructFlexGMRESCreate(MPI_COMM_WORLD, &solver_hypre); HYPRE_CHECK(ierr);
+        ierr = HYPRE_StructFlexGMRESCreate(MPI_COMM_WORLD, &solver_hypre);
+        HYPRE_CHECK(ierr);
         HYPRE_StructFlexGMRESSetTol(solver_hypre, m_eps);
         HYPRE_StructFlexGMRESSetMaxIter(solver_hypre, m_maxiter);
         HYPRE_StructFlexGMRESSetPrintLevel(solver_hypre, (m_verbose > 2) ? 3 : 0);
 
-        ierr = HYPRE_StructPFMGCreate(MPI_COMM_WORLD, &precond); HYPRE_CHECK(ierr);
-        HYPRE_StructPFMGSetTol(precond, 0.0);      
-        HYPRE_StructPFMGSetMaxIter(precond, 1);    
-        HYPRE_StructPFMGSetNumPreRelax(precond, 1); 
-        HYPRE_StructPFMGSetNumPostRelax(precond, 1); 
+        ierr = HYPRE_StructPFMGCreate(MPI_COMM_WORLD, &precond);
+        HYPRE_CHECK(ierr);
+        HYPRE_StructPFMGSetTol(precond, 0.0);
+        HYPRE_StructPFMGSetMaxIter(precond, 1);
+        HYPRE_StructPFMGSetNumPreRelax(precond, 1);
+        HYPRE_StructPFMGSetNumPostRelax(precond, 1);
         HYPRE_StructPFMGSetPrintLevel(precond, (m_verbose > 3) ? 1 : 0);
-        HYPRE_StructFlexGMRESSetPrecond(solver_hypre, HYPRE_StructPFMGSolve, HYPRE_StructPFMGSetup, precond); 
+        HYPRE_StructFlexGMRESSetPrecond(solver_hypre, HYPRE_StructPFMGSolve, HYPRE_StructPFMGSetup,
+                                        precond);
 
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  solve: Running HYPRE_StructFlexGMRESSetup (with PFMG precond)..." << std::endl;
+            amrex::Print() << "  solve: Running HYPRE_StructFlexGMRESSetup (with PFMG precond)..."
+                           << std::endl;
         }
-        ierr = HYPRE_StructFlexGMRESSetup(solver_hypre, m_A, m_b, m_x); HYPRE_CHECK(ierr); 
+        ierr = HYPRE_StructFlexGMRESSetup(solver_hypre, m_A, m_b, m_x);
+        HYPRE_CHECK(ierr);
 
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "  solve: Running HYPRE_StructFlexGMRESSolve..." << std::endl;
         }
         ierr = HYPRE_StructFlexGMRESSolve(solver_hypre, m_A, m_b, m_x);
-        if (ierr != 0 && ierr != HYPRE_ERROR_CONV) { HYPRE_CHECK(ierr); }
+        if (ierr != 0 && ierr != HYPRE_ERROR_CONV) {
+            HYPRE_CHECK(ierr);
+        }
 
         HYPRE_StructFlexGMRESGetNumIterations(solver_hypre, &m_num_iterations);
         HYPRE_StructFlexGMRESGetFinalRelativeResidualNorm(solver_hypre, &m_final_res_norm);
@@ -611,23 +692,27 @@ bool EffectiveDiffusivityHypre::solve()
         m_converged = !(std::isnan(m_final_res_norm) || std::isinf(m_final_res_norm));
         m_converged = m_converged && (m_final_res_norm >= 0.0) && (m_final_res_norm <= m_eps);
 
-        if (ierr == HYPRE_ERROR_CONV && !m_converged && m_verbose >=0) {
-            amrex::Warning("HYPRE FlexGMRES solver (with PFMG precond) did not converge within tolerance!");
-        } else if (ierr !=0 && ierr != HYPRE_ERROR_CONV && m_verbose >=0) {
-             amrex::Warning("HYPRE FlexGMRES solver (with PFMG precond) returned error code: " + std::to_string(ierr));
+        if (ierr == HYPRE_ERROR_CONV && !m_converged && m_verbose >= 0) {
+            amrex::Warning(
+                "HYPRE FlexGMRES solver (with PFMG precond) did not converge within tolerance!");
+        } else if (ierr != 0 && ierr != HYPRE_ERROR_CONV && m_verbose >= 0) {
+            amrex::Warning("HYPRE FlexGMRES solver (with PFMG precond) returned error code: " +
+                           std::to_string(ierr));
         }
         HYPRE_StructFlexGMRESDestroy(solver_hypre);
-        if (precond) HYPRE_StructPFMGDestroy(precond); 
-    }
-    else {
-        amrex::Abort("Unsupported solver type requested in EffectiveDiffusivityHypre::solve: "
-                     + std::to_string(static_cast<int>(m_solvertype)));
+        if (precond)
+            HYPRE_StructPFMGDestroy(precond);
+    } else {
+        amrex::Abort("Unsupported solver type requested in EffectiveDiffusivityHypre::solve: " +
+                     std::to_string(static_cast<int>(m_solvertype)));
     }
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "  HYPRE Solver Iterations: " << m_num_iterations << std::endl;
-        amrex::Print() << "  HYPRE Final Relative Residual Norm: " << std::scientific << m_final_res_norm << std::defaultfloat << std::endl;
-        amrex::Print() << "  Solver Converged Status: " << (m_converged ? "Yes" : "No") << std::endl;
+        amrex::Print() << "  HYPRE Final Relative Residual Norm: " << std::scientific
+                       << m_final_res_norm << std::defaultfloat << std::endl;
+        amrex::Print() << "  Solver Converged Status: " << (m_converged ? "Yes" : "No")
+                       << std::endl;
     }
 
     if (std::isnan(m_final_res_norm) || std::isinf(m_final_res_norm)) {
@@ -636,40 +721,42 @@ bool EffectiveDiffusivityHypre::solve()
     }
 
     if (m_converged) {
-        getChiSolution(m_mf_chi); 
+        getChiSolution(m_mf_chi);
     } else {
-        m_mf_chi.setVal(0.0); 
-        if (m_mf_chi.nGrow() > 0) m_mf_chi.FillBoundary(m_geom.periodicity());
-        if (m_verbose >=0 && amrex::ParallelDescriptor::IOProcessor()) {
+        m_mf_chi.setVal(0.0);
+        if (m_mf_chi.nGrow() > 0)
+            m_mf_chi.FillBoundary(m_geom.periodicity());
+        if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Warning("Solver did not converge. Chi solution (m_mf_chi) set to 0.");
         }
     }
 
-    if (m_write_plotfile && (m_converged || num_active_cells_in_solve == 0) ) { // Use logic based on num_active_cells_in_solve
+    if (m_write_plotfile &&
+        (m_converged ||
+         num_active_cells_in_solve == 0)) { // Use logic based on num_active_cells_in_solve
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "  Writing solution plotfile for chi_k in direction "
-                            << static_cast<int>(m_dir_solve) << "..." << std::endl;
+            amrex::Print() << "  Writing solution plotfile for chi_k in direction "
+                           << static_cast<int>(m_dir_solve) << "..." << std::endl;
         }
         amrex::MultiFab mf_plot(m_ba, m_dm, 2, 0);
         amrex::Copy(mf_plot, m_mf_chi, ChiComp, 0, 1, 0);
 
-        #ifdef AMREX_USE_OMP
-        #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-        #endif
-        for (amrex::MFIter mfi(mf_plot, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-        {
-            const amrex::Box& bx_plot = mfi.tilebox(); 
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(mf_plot, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            const amrex::Box& bx_plot = mfi.tilebox();
             amrex::Array4<amrex::Real> const plot_arr = mf_plot.array(mfi);
             // Use m_mf_active_mask which has the correct content for visualization
-            amrex::Array4<const int> const mask_arr_plot = m_mf_active_mask.const_array(mfi); 
+            amrex::Array4<const int> const mask_arr_plot = m_mf_active_mask.const_array(mfi);
 
-            amrex::LoopOnCpu(bx_plot, [=] (int i, int j, int k) noexcept
-            {
-                plot_arr(i,j,k,1) = static_cast<amrex::Real>(mask_arr_plot(i,j,k,MaskComp));
+            amrex::LoopOnCpu(bx_plot, [=](int i, int j, int k) noexcept {
+                plot_arr(i, j, k, 1) = static_cast<amrex::Real>(mask_arr_plot(i, j, k, MaskComp));
             });
         }
 
-        std::string plot_filename_str = "effdiff_chi_dir" + std::to_string(static_cast<int>(m_dir_solve));
+        std::string plot_filename_str =
+            "effdiff_chi_dir" + std::to_string(static_cast<int>(m_dir_solve));
         std::string full_plot_path = m_resultspath + "/" + plot_filename_str;
 
         amrex::Vector<std::string> varnames = {"chi_k", "active_mask_from_solver"}; // Clarify name
@@ -680,27 +767,29 @@ bool EffectiveDiffusivityHypre::solve()
         }
     } else if (m_write_plotfile && !m_converged) {
         if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Warning("Skipping plotfile write for chi_k because solver did not converge and had active cells.");
+            amrex::Warning("Skipping plotfile write for chi_k because solver did not converge and "
+                           "had active cells.");
         }
     }
     return m_converged;
 }
 
-void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field)
-{
+void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field) {
     BL_PROFILE("EffectiveDiffusivityHypre::getChiSolution");
 
     if (!m_x) {
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  getChiSolution: HYPRE solution vector m_x is NULL. Setting chi_field to 0." << std::endl;
+            amrex::Print()
+                << "  getChiSolution: HYPRE solution vector m_x is NULL. Setting chi_field to 0."
+                << std::endl;
         }
         chi_field.setVal(0.0);
         if (chi_field.nGrow() > 0) {
-             chi_field.FillBoundary(m_geom.periodicity());
+            chi_field.FillBoundary(m_geom.periodicity());
         }
         return;
     }
-    AMREX_ALWAYS_ASSERT(chi_field.nComp() >= numComponentsChi); 
+    AMREX_ALWAYS_ASSERT(chi_field.nComp() >= numComponentsChi);
     AMREX_ALWAYS_ASSERT(chi_field.boxArray() == m_ba);
     AMREX_ALWAYS_ASSERT(chi_field.DistributionMap() == m_dm);
 
@@ -708,18 +797,19 @@ void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field)
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(soln_buffer)
 #endif
-    for (amrex::MFIter mfi(chi_field, false); mfi.isValid(); ++mfi)
-    {
-        const amrex::Box& bx_getsol = mfi.validbox(); 
+    for (amrex::MFIter mfi(chi_field, false); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx_getsol = mfi.validbox();
         const int npts = static_cast<int>(bx_getsol.numPts());
-        if (npts == 0) continue;
+        if (npts == 0)
+            continue;
 
         soln_buffer.resize(npts);
 
         auto hypre_lo = EffectiveDiffusivityHypre::loV(bx_getsol);
         auto hypre_hi = EffectiveDiffusivityHypre::hiV(bx_getsol);
 
-        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer.data());
+        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
+                                                            soln_buffer.data());
         if (get_ierr != 0) {
             amrex::Warning("HYPRE_StructVectorGetBoxValues failed during getChiSolution!");
             chi_field[mfi].setVal(0.0, bx_getsol, ChiComp, numComponentsChi);
@@ -729,14 +819,15 @@ void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field)
         amrex::Array4<amrex::Real> const chi_arr = chi_field.array(mfi);
         long long k_lin_idx = 0;
 
-        amrex::LoopOnCpu(bx_getsol, [=,&k_lin_idx] (int i, int j, int k) noexcept
-        {
-            if (k_lin_idx < npts) { 
-                chi_arr(i,j,k, ChiComp) = soln_buffer[k_lin_idx]; 
+        amrex::LoopOnCpu(bx_getsol, [=, &k_lin_idx](int i, int j, int k) noexcept {
+            if (k_lin_idx < npts) {
+                chi_arr(i, j, k, ChiComp) = soln_buffer[k_lin_idx];
             }
             k_lin_idx++;
         });
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(k_lin_idx == npts, "Point count mismatch during HYPRE GetBoxValues copy in getChiSolution");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            k_lin_idx == npts,
+            "Point count mismatch during HYPRE GetBoxValues copy in getChiSolution");
     }
 
     if (chi_field.nGrow() > 0) {

--- a/src/props/Tortuosity.H
+++ b/src/props/Tortuosity.H
@@ -6,11 +6,7 @@
 namespace OpenImpala { // Wrap definitions in a project-specific namespace
 
 /** @brief Defines cardinal directions for calculations. */
-enum class Direction {
-    X = 0,
-    Y = 1,
-    Z = 2
-};
+enum class Direction { X = 0, Y = 1, Z = 2 };
 
 /**
  * @brief Cell types identifying the role of a cell within the domain.
@@ -44,8 +40,7 @@ enum class CellType {
  * often by solving a transport equation (like Laplace's equation for diffusion)
  * on a representation of the structure.
  */
-class Tortuosity
-{
+class Tortuosity {
 public:
     /**
      * @brief Virtual destructor (essential for base classes with virtual functions).

--- a/src/props/TortuosityDirect.H
+++ b/src/props/TortuosityDirect.H
@@ -8,12 +8,12 @@
 #include <AMReX_BoxArray.H>
 #include <AMReX_Geometry.H> // Include Geometry explicitly
 #include <AMReX_DistributionMapping.H>
-#include <AMReX_Array.H>          // For amrex::Array (Needed for m_dxinv)
+#include <AMReX_Array.H> // For amrex::Array (Needed for m_dxinv)
 // #include <AMReX_GpuContainers.H> // <<< REMOVED: No longer needed for GpuArray >>>
-#include "Tortuosity.H"          // Includes base class and enums under OpenImpala namespace
+#include "Tortuosity.H" // Includes base class and enums under OpenImpala namespace
 
-#include <string>                // For std::string
-#include <limits>                // For numeric_limits
+#include <string> // For std::string
+#include <limits> // For numeric_limits
 
 // Forward declaration if needed, although includes seem sufficient
 // namespace amrex { class MultiFab; class iMultiFab; ... }
@@ -21,7 +21,8 @@
 namespace OpenImpala {
 
 /**
- * @brief Computes tortuosity using a simple iterative Finite Volume solver for the Poisson equation.
+ * @brief Computes tortuosity using a simple iterative Finite Volume solver for the Poisson
+ * equation.
  *
  * This class implements the Tortuosity interface by solving the Laplace/Poisson equation
  * on the specified phase within the domain using a basic, parallel iterative method.
@@ -39,45 +40,44 @@ namespace OpenImpala {
  * not designed for concurrent access from multiple threads within the same
  * MPI rank. Ensure each instance is used sequentially.
  */
-class TortuosityDirect : public OpenImpala::Tortuosity
-{
+class TortuosityDirect : public OpenImpala::Tortuosity {
 
 public:
-
     /**
      * @brief Construct a new TortuosityDirect solver instance.
      *
      * @param geom Reference to the problem domain geometry. Must remain valid.
      * @param ba Reference to the BoxArray defining the domain decomposition. Must remain valid.
      * @param dm Reference to the DistributionMapping for parallel distribution. Must remain valid.
-     * @param mf_phase Reference to the iMultiFab containing phase identifiers. Requires at least 1 ghost cell. Must remain valid.
+     * @param mf_phase Reference to the iMultiFab containing phase identifiers. Requires at least 1
+     * ghost cell. Must remain valid.
      * @param phase The integer identifier of the phase for which tortuosity is calculated.
-     * @param dir The principal direction (X, Y, or Z) for applying boundary conditions to drive flux.
+     * @param dir The principal direction (X, Y, or Z) for applying boundary conditions to drive
+     * flux.
      * @param eps Convergence criterion (e.g., relative residual norm) for the iterative solver.
-     * @param n_steps Maximum number of iterations allowed for the solver. <<< Changed from size_t to int >>>
-     * @param plot_interval Frequency for checking residual and optionally plotting (0 disables). <<< ADDED >>>
+     * @param n_steps Maximum number of iterations allowed for the solver. <<< Changed from size_t
+     * to int >>>
+     * @param plot_interval Frequency for checking residual and optionally plotting (0 disables).
+     * <<< ADDED >>>
      * @param plot_basename Base filename for diagnostic plotfiles. <<< ADDED >>>
      * @param vlo Potential value applied at the low boundary in the specified direction.
      * @param vhi Potential value applied at the high boundary in the specified direction.
      */
-    TortuosityDirect(const amrex::Geometry& geom,
-                     const amrex::BoxArray& ba,
+    TortuosityDirect(const amrex::Geometry& geom, const amrex::BoxArray& ba,
                      const amrex::DistributionMapping& dm,
                      const amrex::iMultiFab& mf_phase, // Phase data input
-                     const int phase,
-                     const OpenImpala::Direction dir,
-                     const amrex::Real eps,
+                     const int phase, const OpenImpala::Direction dir, const amrex::Real eps,
                      // const size_t max_steps, // Original was size_t
-                     const int n_steps,           // <<< Changed to int >>>
-                     const int plot_interval,       // <<< ADDED >>>
+                     const int n_steps,                // <<< Changed to int >>>
+                     const int plot_interval,          // <<< ADDED >>>
                      const std::string& plot_basename, // <<< ADDED >>>
-                     const amrex::Real vlo,
-                     const amrex::Real vhi);
+                     const amrex::Real vlo, const amrex::Real vhi);
 
     // Override the virtual destructor from the base class
     ~TortuosityDirect() override = default; // Default is sufficient if no raw resources owned
 
-    // Delete copy constructor and assignment operator (managing state/references makes copying complex/unsafe)
+    // Delete copy constructor and assignment operator (managing state/references makes copying
+    // complex/unsafe)
     TortuosityDirect(const TortuosityDirect&) = delete;
     TortuosityDirect& operator=(const TortuosityDirect&) = delete;
 
@@ -86,8 +86,10 @@ public:
      *
      * Computes or retrieves the cached tortuosity. Calls the internal solver if needed.
      *
-     * @param refresh If true, forces a recalculation. If false (default), returns cached value if available.
-     * @return The calculated tortuosity. Returns cached value if refresh=false and calculation was already done. Returns NaN on failure.
+     * @param refresh If true, forces a recalculation. If false (default), returns cached value if
+     * available.
+     * @return The calculated tortuosity. Returns cached value if refresh=false and calculation was
+     * already done. Returns NaN on failure.
      */
     amrex::Real value(const bool refresh = false) override;
 
@@ -97,18 +99,23 @@ public:
      * @brief Returns the number of iterations performed during the last call to solve().
      * @return Number of iterations, or 0 if solve() hasn't been called.
      */
-    int getNumIterations() const { return m_last_iterations; }
+    int getNumIterations() const {
+        return m_last_iterations;
+    }
 
     /**
      * @brief Returns the final residual norm achieved during the last call to solve().
-     * @return Final residual norm, or a negative value if solve() hasn't been called or failed early.
+     * @return Final residual norm, or a negative value if solve() hasn't been called or failed
+     * early.
      */
-    amrex::Real getFinalResidual() const { return m_last_residual; }
+    amrex::Real getFinalResidual() const {
+        return m_last_residual;
+    }
 
 
 private:
-
-    /** @brief Executes the iterative solver loop until convergence or max iterations. Returns true if converged. */
+    /** @brief Executes the iterative solver loop until convergence or max iterations. Returns true
+     * if converged. */
     bool solve();
 
     /**
@@ -128,21 +135,23 @@ private:
      */
     amrex::Real residual(const amrex::MultiFab& phiold, const amrex::MultiFab& phinew) const;
 
-    /** @brief Sets up the m_bc member variable describing boundary condition types (e.g., Dirichlet, Neumann). */
+    /** @brief Sets up the m_bc member variable describing boundary condition types (e.g.,
+     * Dirichlet, Neumann). */
     // void initializeBoundaryConditions() ; // FIX 2: Corrected spelling
     void initializeBoundaryConditions(); // <<< FIX 2: Corrected spelling >>>
 
     /** @brief Creates and initializes the m_flux MultiFab array for storing face fluxes. */
     // void initializeFluxMultiFabs();    // FIX 2: Corrected spelling
-    void initializeFluxMultiFabs();    // <<< FIX 2: Corrected spelling >>>
+    void initializeFluxMultiFabs(); // <<< FIX 2: Corrected spelling >>>
 
     /**
-     * @brief Applies boundary conditions to the ghost cells of the potential MultiFab for a specific component.
-     * Uses the geometry and m_bc settings. Primarily handles external Dirichlet.
+     * @brief Applies boundary conditions to the ghost cells of the potential MultiFab for a
+     * specific component. Uses the geometry and m_bc settings. Primarily handles external
+     * Dirichlet.
      * @param phi The MultiFab whose ghost cells need filling based on BCs.
      * @param comp The component index to fill boundary conditions for.
      */
-    void fillDomainBoundary (amrex::MultiFab& phi, int comp);
+    void fillDomainBoundary(amrex::MultiFab& phi, int comp);
 
 
     /**
@@ -155,7 +164,8 @@ private:
 
     /**
      * @brief Sets the initial guess for the potential field (phi component).
-     * Often a linear interpolation between boundary values (m_vlo, m_vhi) in the specified direction.
+     * Often a linear interpolation between boundary values (m_vlo, m_vhi) in the specified
+     * direction.
      * @param phi The MultiFab to fill with the initial state (modifies comp_phi).
      */
     void fillInitialState(amrex::MultiFab& phi); // Fills component comp_phi
@@ -165,7 +175,8 @@ private:
      * @brief Performs one iteration of the Finite Volume solver (e.g., Jacobi, SOR).
      * Calculates face fluxes (updates m_flux) based on phi_old.
      * Updates the potential field phi_new based on conservation laws using calculated fluxes.
-     * @param phi_old Input: Potential field from the previous iteration (requires filled ghost cells).
+     * @param phi_old Input: Potential field from the previous iteration (requires filled ghost
+     * cells).
      * @param phi_new Output: Updated potential field for the current iteration.
      * @param dt Timestep or relaxation parameter used in the update.
      */
@@ -185,28 +196,29 @@ private:
     amrex::BCRec m_bc; // Describes boundary condition types for phi (comp 0)
 
     // Phase and Direction info
-    const int m_phase;                     // Phase ID to compute tortuosity for
-    const OpenImpala::Direction m_dir;     // Principal direction for flux
+    const int m_phase;                 // Phase ID to compute tortuosity for
+    const OpenImpala::Direction m_dir; // Principal direction for flux
 
     // Solver Control Parameters (set via constructor)
-    const int m_n_steps;         // <<< Changed type >>> Max iterations
-    const amrex::Real m_eps;     // Convergence tolerance
+    const int m_n_steps;     // <<< Changed type >>> Max iterations
+    const amrex::Real m_eps; // Convergence tolerance
 
     // Boundary Condition Values (set via constructor)
     const amrex::Real m_vlo; // Potential at low boundary face in m_dir
     const amrex::Real m_vhi; // Potential at high boundary face in m_dir
 
     // Caching and Diagnostics
-    amrex::Real m_value;           // Cached tortuosity value
-    bool m_first_call;             // Flag for caching logic
-    int m_last_iterations;         // Iterations used in last solve
-    amrex::Real m_last_residual;   // Residual achieved in last solve
+    amrex::Real m_value;         // Cached tortuosity value
+    bool m_first_call;           // Flag for caching logic
+    int m_last_iterations;       // Iterations used in last solve
+    amrex::Real m_last_residual; // Residual achieved in last solve
 
     // <<< ADDED Missing Member Declarations (from .cpp analysis) >>>
     // FIX 1: Changed GpuArray to Array for CPU compatibility
-    amrex::Array<amrex::Real, AMREX_SPACEDIM> m_dxinv; // Inverse cell sizes (calculated in constructor)
-    int m_plot_interval;                 // Plotting frequency (from constructor)
-    std::string m_plot_basename;         // Base name for plotfiles (from constructor)
+    amrex::Array<amrex::Real, AMREX_SPACEDIM>
+        m_dxinv;                 // Inverse cell sizes (calculated in constructor)
+    int m_plot_interval;         // Plotting frequency (from constructor)
+    std::string m_plot_basename; // Base name for plotfiles (from constructor)
 
 }; // class TortuosityDirect
 

--- a/src/props/TortuosityDirect.cpp
+++ b/src/props/TortuosityDirect.cpp
@@ -14,23 +14,23 @@
 #include <AMReX_BCRec.H>    // Include BCRec header
 #include <AMReX_BCUtil.H>
 #include <AMReX_PlotFileUtil.H>
-#include <AMReX_Loop.H>            // For amrex::Loop
-#include <AMReX_GpuLaunch.H>       // For amrex::ParallelFor (check if needed for CPU build)
-#include <AMReX_GpuQualifiers.H> // For AMREX_GPU_DEVICE etc. (check if needed for CPU build)
+#include <AMReX_Loop.H>               // For amrex::Loop
+#include <AMReX_GpuLaunch.H>          // For amrex::ParallelFor (check if needed for CPU build)
+#include <AMReX_GpuQualifiers.H>      // For AMREX_GPU_DEVICE etc. (check if needed for CPU build)
 #include <AMReX_ParallelDescriptor.H> // For reductions etc.
-#include <AMReX_Array4.H>          // Explicit include for Array4
-#include <AMReX_Vector.H>          // For amrex::Vector
-#include <AMReX_Array.H>           // For amrex::Array (m_dxinv type)
+#include <AMReX_Array4.H>             // Explicit include for Array4
+#include <AMReX_Vector.H>             // For amrex::Vector
+#include <AMReX_Array.H>              // For amrex::Array (m_dxinv type)
 
 
 namespace OpenImpala {
 
 // Define constants for clarity and maintainability
 namespace {
-    constexpr int comp_phi = 0; // Index for potential phi in MultiFab
-    constexpr int comp_ct  = 1; // Index for cell type in MultiFab (matches Fortran comp_ct=2)
-    constexpr int NUM_GHOST_CELLS = 1; // Required ghost cells for MultiFabs
-}
+constexpr int comp_phi = 0;        // Index for potential phi in MultiFab
+constexpr int comp_ct = 1;         // Index for cell type in MultiFab (matches Fortran comp_ct=2)
+constexpr int NUM_GHOST_CELLS = 1; // Required ghost cells for MultiFabs
+} // namespace
 
 //-----------------------------------------------------------------------
 // REMINDER: Ensure m_dxinv is declared correctly in TortuosityDirect.H
@@ -39,29 +39,24 @@ namespace {
 
 // Constructor implementation
 TortuosityDirect::TortuosityDirect(const amrex::Geometry& geom, const amrex::BoxArray& ba,
-                                   const amrex::DistributionMapping& dm, const amrex::iMultiFab& mf_phase,
-                                   const int phase, const OpenImpala::Direction dir,
-                                   const amrex::Real eps,
-                                   const int n_steps,
-                                   const int plot_interval,
-                                   const std::string& plot_basename,
-                                   const amrex::Real vlo, const amrex::Real vhi)
-    : m_geom(geom), m_ba(ba), m_dm(dm), m_mf_phase(mf_phase),
-      m_phase(phase), m_dir(dir),
-      m_n_steps(n_steps), m_eps(eps),
-      m_plot_interval(plot_interval), m_plot_basename(plot_basename),
-      m_vlo(vlo), m_vhi(vhi),
-      m_first_call(true), m_value(std::numeric_limits<amrex::Real>::quiet_NaN()),
-      m_last_iterations(0), m_last_residual(-1.0)
-{
+                                   const amrex::DistributionMapping& dm,
+                                   const amrex::iMultiFab& mf_phase, const int phase,
+                                   const OpenImpala::Direction dir, const amrex::Real eps,
+                                   const int n_steps, const int plot_interval,
+                                   const std::string& plot_basename, const amrex::Real vlo,
+                                   const amrex::Real vhi)
+    : m_geom(geom), m_ba(ba), m_dm(dm), m_mf_phase(mf_phase), m_phase(phase), m_dir(dir),
+      m_n_steps(n_steps), m_eps(eps), m_plot_interval(plot_interval),
+      m_plot_basename(plot_basename), m_vlo(vlo), m_vhi(vhi), m_first_call(true),
+      m_value(std::numeric_limits<amrex::Real>::quiet_NaN()), m_last_iterations(0),
+      m_last_residual(-1.0) {
     // Ensure m_dxinv type is amrex::Array<amrex::Real, AMREX_SPACEDIM> in header
     const amrex::Real* dx = m_geom.CellSize();
-    for (int i=0; i<AMREX_SPACEDIM; ++i)
-    {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         if (dx[i] <= 0.0) {
             amrex::Abort("TortuosityDirect: Non-positive dx");
         }
-        m_dxinv[i] = 1.0/ dx[i];
+        m_dxinv[i] = 1.0 / dx[i];
     }
 
     // Create a datastructure describing the boundary conditions
@@ -70,11 +65,9 @@ TortuosityDirect::TortuosityDirect(const amrex::Geometry& geom, const amrex::Box
 }
 
 
-void TortuosityDirect::initializeFluxMultiFabs()
-{
+void TortuosityDirect::initializeFluxMultiFabs() {
     // Build the flux multi-fabs
-    for (int i_dir = 0; i_dir < AMREX_SPACEDIM; ++i_dir)
-    {
+    for (int i_dir = 0; i_dir < AMREX_SPACEDIM; ++i_dir) {
         amrex::BoxArray edge_ba = m_ba;
         edge_ba.surroundingNodes(i_dir);
         m_flux[i_dir].define(edge_ba, m_dm, 1, 0);
@@ -82,19 +75,16 @@ void TortuosityDirect::initializeFluxMultiFabs()
     }
 }
 
-amrex::Real TortuosityDirect::value(const bool refresh)
-{
-    if ( refresh || m_first_call )
-    {
-        if (!solve())
-        {
+amrex::Real TortuosityDirect::value(const bool refresh) {
+    if (refresh || m_first_call) {
+        if (!solve()) {
             amrex::Warning("TortuosityDirect::solve() failed to converge. Returning NaN.");
             m_first_call = true;
             m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
             return m_value;
         }
     } else if (std::isnan(m_value)) {
-         return m_value;
+        return m_value;
     }
 
     amrex::Real fxin = 0.0, fxout = 0.0;
@@ -105,52 +95,62 @@ amrex::Real TortuosityDirect::value(const bool refresh)
     const amrex::IntVect& sz = bx_domain.size();
 
     amrex::Real cross_sectional_area = 0.0;
-    switch(m_dir)
-    {
-        case Direction::X : cross_sectional_area = static_cast<amrex::Real>(sz[1]) * static_cast<amrex::Real>(sz[2]); break;
-        case Direction::Y : cross_sectional_area = static_cast<amrex::Real>(sz[0]) * static_cast<amrex::Real>(sz[2]); break;
-        case Direction::Z : cross_sectional_area = static_cast<amrex::Real>(sz[0]) * static_cast<amrex::Real>(sz[1]); break;
-        default: amrex::Abort("TortuosityDirect::value: Invalid direction");
+    switch (m_dir) {
+    case Direction::X:
+        cross_sectional_area = static_cast<amrex::Real>(sz[1]) * static_cast<amrex::Real>(sz[2]);
+        break;
+    case Direction::Y:
+        cross_sectional_area = static_cast<amrex::Real>(sz[0]) * static_cast<amrex::Real>(sz[2]);
+        break;
+    case Direction::Z:
+        cross_sectional_area = static_cast<amrex::Real>(sz[0]) * static_cast<amrex::Real>(sz[1]);
+        break;
+    default:
+        amrex::Abort("TortuosityDirect::value: Invalid direction");
     }
 
     if (cross_sectional_area <= 0.0) {
-         amrex::Warning("TortuosityDirect::value: Domain cross-sectional area is non-positive. Cannot calculate tortuosity.");
-         m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
-         return m_value;
+        amrex::Warning("TortuosityDirect::value: Domain cross-sectional area is non-positive. "
+                       "Cannot calculate tortuosity.");
+        m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
+        return m_value;
     }
 
     amrex::Real avg_flux_density = fx / cross_sectional_area;
 
     constexpr amrex::Real flux_dens_tol = 1e-15;
     if (std::abs(avg_flux_density) < flux_dens_tol) {
-        amrex::Warning("Calculated average flux density is near zero. Setting tortuosity to infinity.");
+        amrex::Warning(
+            "Calculated average flux density is near zero. Setting tortuosity to infinity.");
         m_value = std::numeric_limits<amrex::Real>::infinity();
     } else {
         amrex::Real vf = 1.0; // Placeholder - Needs actual Volume Fraction calculation!
         amrex::Real length = m_geom.ProbLength(static_cast<int>(m_dir));
         amrex::Real delta_V = m_vhi - m_vlo;
 
-        if (std::abs(delta_V) < flux_dens_tol || length <= 0.0 ) {
-             amrex::Warning("TortuosityDirect::value: Cannot calculate tortuosity due to zero potential difference or non-positive length.");
-             m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
+        if (std::abs(delta_V) < flux_dens_tol || length <= 0.0) {
+            amrex::Warning("TortuosityDirect::value: Cannot calculate tortuosity due to zero "
+                           "potential difference or non-positive length.");
+            m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
         } else {
-             amrex::Real rel_diff = -avg_flux_density * length / delta_V;
-             if (std::abs(rel_diff) < flux_dens_tol) {
-                 amrex::Warning("Calculated relative diffusivity is near zero. Setting tortuosity to infinity.");
-                 m_value = std::numeric_limits<amrex::Real>::infinity();
-             } else {
-                 m_value = vf / rel_diff;
-                  if (m_value < 0.0 && vf > 0.0) {
-                      amrex::Warning("Calculated negative tortuosity, check flux direction, BCs, or definition.");
-                  }
-             }
+            amrex::Real rel_diff = -avg_flux_density * length / delta_V;
+            if (std::abs(rel_diff) < flux_dens_tol) {
+                amrex::Warning("Calculated relative diffusivity is near zero. Setting tortuosity "
+                               "to infinity.");
+                m_value = std::numeric_limits<amrex::Real>::infinity();
+            } else {
+                m_value = vf / rel_diff;
+                if (m_value < 0.0 && vf > 0.0) {
+                    amrex::Warning("Calculated negative tortuosity, check flux direction, BCs, or "
+                                   "definition.");
+                }
+            }
         }
     }
     return m_value;
 }
 
-bool TortuosityDirect::solve()
-{
+bool TortuosityDirect::solve() {
     amrex::MultiFab mf_phi_old(m_ba, m_dm, 2, NUM_GHOST_CELLS);
     amrex::MultiFab mf_phi_new(m_ba, m_dm, 2, NUM_GHOST_CELLS);
 
@@ -159,8 +159,9 @@ bool TortuosityDirect::solve()
     amrex::MultiFab::Copy(mf_phi_new, mf_phi_old, 0, 0, 2, NUM_GHOST_CELLS);
 
     const amrex::Real* dx = m_geom.CellSize();
-    amrex::Real min_dx_sq = dx[0]*dx[0];
-    for(int i=1; i<AMREX_SPACEDIM; ++i) min_dx_sq = std::min(min_dx_sq, dx[i]*dx[i]);
+    amrex::Real min_dx_sq = dx[0] * dx[0];
+    for (int i = 1; i < AMREX_SPACEDIM; ++i)
+        min_dx_sq = std::min(min_dx_sq, dx[i] * dx[i]);
     const amrex::Real dt = 0.5 * min_dx_sq / (2.0 * AMREX_SPACEDIM);
 
     amrex::Real current_res = std::numeric_limits<amrex::Real>::max();
@@ -169,29 +170,28 @@ bool TortuosityDirect::solve()
     m_last_iterations = 0;
     m_last_residual = -1.0;
 
-    for (int n = 1; n <= m_n_steps; ++n)
-    {
+    for (int n = 1; n <= m_n_steps; ++n) {
         m_last_iterations = n;
         amrex::MultiFab::Copy(mf_phi_old, mf_phi_new, comp_phi, comp_phi, 1, NUM_GHOST_CELLS);
         advance(mf_phi_old, mf_phi_new, dt);
 
-        if (m_plot_interval > 0 && n % m_plot_interval == 0)
-        {
+        if (m_plot_interval > 0 && n % m_plot_interval == 0) {
             current_res = residual(mf_phi_old, mf_phi_new);
             global_fluxes(fxin, fxout);
             m_last_residual = current_res;
 
-            if(amrex::ParallelDescriptor::IOProcessor()) {
+            if (amrex::ParallelDescriptor::IOProcessor()) {
                 amrex::Print() << "Step " << n << ": ";
-                amrex::Print() << std::scientific << std::setprecision(4) << std::setw(12) << std::setfill(' ');
+                amrex::Print() << std::scientific << std::setprecision(4) << std::setw(12)
+                               << std::setfill(' ');
                 amrex::Print() << "Residual: " << current_res << " | ";
-                amrex::Print() << "flux[in]: " << fxin << " flux[out]: " << fxout << " Delta: " << std::abs(fxout + fxin) << std::endl;
+                amrex::Print() << "flux[in]: " << fxin << " flux[out]: " << fxout
+                               << " Delta: " << std::abs(fxout + fxin) << std::endl;
             }
 
-            if (current_res < m_eps)
-            {
-                if(amrex::ParallelDescriptor::IOProcessor()) {
-                     amrex::Print() << "Convergence reached in " << n << " steps." << std::endl;
+            if (current_res < m_eps) {
+                if (amrex::ParallelDescriptor::IOProcessor()) {
+                    amrex::Print() << "Convergence reached in " << n << " steps." << std::endl;
                 }
                 converged = true;
                 break;
@@ -200,27 +200,28 @@ bool TortuosityDirect::solve()
     }
 
     if (!converged) {
-         amrex::Warning("TortuosityDirect::solve() did not converge within max steps.");
-         if (!(m_plot_interval > 0 && m_n_steps % m_plot_interval == 0)) {
-             current_res = residual(mf_phi_old, mf_phi_new);
-             global_fluxes(fxin, fxout);
-             m_last_residual = current_res;
-             if(amrex::ParallelDescriptor::IOProcessor()) {
-                 amrex::Print() << "Final Step " << m_n_steps << ": ";
-                 amrex::Print() << "Residual: " << current_res << " | ";
-                 amrex::Print() << "flux[in]: " << fxin << " flux[out]: " << fxout << std::endl;
-             }
-         }
+        amrex::Warning("TortuosityDirect::solve() did not converge within max steps.");
+        if (!(m_plot_interval > 0 && m_n_steps % m_plot_interval == 0)) {
+            current_res = residual(mf_phi_old, mf_phi_new);
+            global_fluxes(fxin, fxout);
+            m_last_residual = current_res;
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "Final Step " << m_n_steps << ": ";
+                amrex::Print() << "Residual: " << current_res << " | ";
+                amrex::Print() << "flux[in]: " << fxin << " flux[out]: " << fxout << std::endl;
+            }
+        }
     }
 
-    if (m_plot_interval > 0)
-    {
-        std::string plot_file_path_str = m_plot_basename + "_step_" + std::to_string(m_last_iterations);
-        if(amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "Writing plot file: " << plot_file_path_str << std::endl;
+    if (m_plot_interval > 0) {
+        std::string plot_file_path_str =
+            m_plot_basename + "_step_" + std::to_string(m_last_iterations);
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "Writing plot file: " << plot_file_path_str << std::endl;
         }
         amrex::Vector<std::string> plot_varnames = {"potential", "cell_type"};
-        amrex::WriteSingleLevelPlotfile(plot_file_path_str, mf_phi_new, plot_varnames, m_geom, 0.0, m_last_iterations);
+        amrex::WriteSingleLevelPlotfile(plot_file_path_str, mf_phi_new, plot_varnames, m_geom, 0.0,
+                                        m_last_iterations);
     }
 
     if (!converged && !(m_plot_interval > 0 && m_n_steps % m_plot_interval == 0)) {
@@ -232,8 +233,7 @@ bool TortuosityDirect::solve()
 }
 
 
-void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) const
-{
+void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) const {
     fxin = 0.0;
     fxout = 0.0;
 
@@ -241,7 +241,7 @@ void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) cons
     const int dir_int = static_cast<int>(m_dir);
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:fxin, fxout)
+#pragma omp parallel reduction(+ : fxin, fxout)
 #endif
     {
         amrex::Real lfxin = 0.0;
@@ -251,8 +251,7 @@ void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) cons
             amrex::Abort("Invalid direction specified for global_fluxes");
         }
 
-        for ( amrex::MFIter mfi(m_flux[idir]); mfi.isValid(); ++mfi )
-        {
+        for (amrex::MFIter mfi(m_flux[idir]); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.tilebox();
 
             const auto& fx_arr = m_flux[0].const_array(mfi);
@@ -266,11 +265,9 @@ void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) cons
             const auto& fybox = m_flux[1].box(mfi.index());
             const auto& fzbox = m_flux[2].box(mfi.index());
 
-            tortuosity_poisson_fio(bx.loVect(), bx.hiVect(),
-                                   fx_ptr, fxbox.loVect(), fxbox.hiVect(),
-                                   fy_ptr, fybox.loVect(), fybox.hiVect(),
-                                   fz_ptr, fzbox.loVect(), fzbox.hiVect(),
-                                   &dir_int, &lfxin, &lfxout);
+            tortuosity_poisson_fio(bx.loVect(), bx.hiVect(), fx_ptr, fxbox.loVect(), fxbox.hiVect(),
+                                   fy_ptr, fybox.loVect(), fybox.hiVect(), fz_ptr, fzbox.loVect(),
+                                   fzbox.hiVect(), &dir_int, &lfxin, &lfxout);
         }
     } // End OMP parallel region
 
@@ -279,8 +276,8 @@ void TortuosityDirect::global_fluxes(amrex::Real& fxin, amrex::Real& fxout) cons
 }
 
 
-void TortuosityDirect::advance(amrex::MultiFab& phi_old, amrex::MultiFab& phi_new, const amrex::Real& dt)
-{
+void TortuosityDirect::advance(amrex::MultiFab& phi_old, amrex::MultiFab& phi_new,
+                               const amrex::Real& dt) {
     phi_old.FillBoundary(m_geom.periodicity());
     // Removed incorrect amrex::FillDomainBoundary call
     fillDomainBoundary(phi_old, comp_phi); // Apply explicit Dirichlet for comp_phi
@@ -289,8 +286,7 @@ void TortuosityDirect::advance(amrex::MultiFab& phi_old, amrex::MultiFab& phi_ne
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     {
-        for ( amrex::MFIter mfi(phi_old, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi )
-        {
+        for (amrex::MFIter mfi(phi_old, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.tilebox();
 
             auto fx_arr = m_flux[0].array(mfi);
@@ -310,20 +306,17 @@ void TortuosityDirect::advance(amrex::MultiFab& phi_old, amrex::MultiFab& phi_ne
 
             const amrex::Real* dxinv_ptr = m_dxinv.data(); // Assumes m_dxinv is amrex::Array
 
-            tortuosity_poisson_flux(bx.loVect(), bx.hiVect(),
-                                    fx_ptr, fxbox.loVect(), fxbox.hiVect(),
-                                    fy_ptr, fybox.loVect(), fybox.hiVect(),
-                                    fz_ptr, fzbox.loVect(), fzbox.hiVect(),
-                                    sol_ptr, solbox.loVect(), solbox.hiVect(),
-                                    dxinv_ptr);
+            tortuosity_poisson_flux(bx.loVect(), bx.hiVect(), fx_ptr, fxbox.loVect(),
+                                    fxbox.hiVect(), fy_ptr, fybox.loVect(), fybox.hiVect(), fz_ptr,
+                                    fzbox.loVect(), fzbox.hiVect(), sol_ptr, solbox.loVect(),
+                                    solbox.hiVect(), dxinv_ptr);
         }
 
-        for ( amrex::MFIter mfi(phi_new, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi )
-        {
+        for (amrex::MFIter mfi(phi_new, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.tilebox();
 
             const auto& p_arr = phi_old.const_array(mfi);
-            auto        n_arr = phi_new.array(mfi);
+            auto n_arr = phi_new.array(mfi);
             const auto& fx_arr = m_flux[0].const_array(mfi);
             const auto& fy_arr = m_flux[1].const_array(mfi);
             const auto& fz_arr = m_flux[2].const_array(mfi);
@@ -345,43 +338,39 @@ void TortuosityDirect::advance(amrex::MultiFab& phi_old, amrex::MultiFab& phi_ne
             // *** FIX: Add ncomp argument to the call ***
             const int ncomp_val = phi_new.nComp(); // Get number of components
 
-            tortuosity_poisson_update(bx.loVect(), bx.hiVect(),
-                                      p_ptr, pbox.loVect(), pbox.hiVect(),
-                                      n_ptr, nbox.loVect(), nbox.hiVect(),
-                                      fx_ptr, fxbox.loVect(), fxbox.hiVect(),
-                                      fy_ptr, fybox.loVect(), fybox.hiVect(),
+            tortuosity_poisson_update(bx.loVect(), bx.hiVect(), p_ptr, pbox.loVect(), pbox.hiVect(),
+                                      n_ptr, nbox.loVect(), nbox.hiVect(), fx_ptr, fxbox.loVect(),
+                                      fxbox.hiVect(), fy_ptr, fybox.loVect(), fybox.hiVect(),
                                       fz_ptr, fzbox.loVect(), fzbox.hiVect(),
                                       &ncomp_val, // Pass address of ncomp
-                                      dxinv_ptr,
-                                      &dt);
+                                      dxinv_ptr, &dt);
 
             // Ensure cell type remains unchanged in phi_new (copy from phi_old)
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                n_arr(i,j,k, comp_ct) = p_arr(i,j,k, comp_ct);
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                n_arr(i, j, k, comp_ct) = p_arr(i, j, k, comp_ct);
             });
         }
     } // End OMP parallel region
 }
 
 
-amrex::Real TortuosityDirect::residual(const amrex::MultiFab& phi_old, const amrex::MultiFab& phi_new ) const
-{
+amrex::Real TortuosityDirect::residual(const amrex::MultiFab& phi_old,
+                                       const amrex::MultiFab& phi_new) const {
     amrex::Real delta_sum = 0.0;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) reduction(+:delta_sum)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) reduction(+ : delta_sum)
 #endif
-    for (amrex::MFIter mfi(phi_old, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(phi_old, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.tilebox();
         const auto& arr_old = phi_old.const_array(mfi, comp_phi);
         const auto& arr_new = phi_new.const_array(mfi, comp_phi);
-        const auto& ct_arr  = phi_old.const_array(mfi, comp_ct);
+        const auto& ct_arr = phi_old.const_array(mfi, comp_ct);
 
         amrex::Real thread_delta = 0.0;
-        amrex::Loop(bx, [&] (int i, int j, int k) {
-            if (static_cast<int>(ct_arr(i,j,k)) == 1) {
-                thread_delta += std::abs(arr_new(i,j,k) - arr_old(i,j,k));
+        amrex::Loop(bx, [&](int i, int j, int k) {
+            if (static_cast<int>(ct_arr(i, j, k)) == 1) {
+                thread_delta += std::abs(arr_new(i, j, k) - arr_old(i, j, k));
             }
         });
         delta_sum += thread_delta;
@@ -392,13 +381,11 @@ amrex::Real TortuosityDirect::residual(const amrex::MultiFab& phi_old, const amr
 }
 
 
-void TortuosityDirect::initializeBoundaryConditions()
-{
+void TortuosityDirect::initializeBoundaryConditions() {
     m_bc = amrex::BCRec(); // Use default constructor
 
     // Set default Neumann conditions for component 0
-    for (int i=0; i<AMREX_SPACEDIM; ++i)
-    {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         m_bc.setLo(i, static_cast<int>(amrex::BCType::reflect_even));
         m_bc.setHi(i, static_cast<int>(amrex::BCType::reflect_even));
     }
@@ -408,15 +395,13 @@ void TortuosityDirect::initializeBoundaryConditions()
     m_bc.setHi(static_cast<int>(m_dir), static_cast<int>(amrex::BCType::ext_dir));
 }
 
-void TortuosityDirect::fillCellTypes(amrex::MultiFab& phi)
-{
+void TortuosityDirect::fillCellTypes(amrex::MultiFab& phi) {
     const amrex::Box& domain_box = m_geom.Domain();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         auto phi_arr = phi.array(mfi);
         const auto& phase_arr = m_mf_phase.const_array(mfi);
 
@@ -425,25 +410,20 @@ void TortuosityDirect::fillCellTypes(amrex::MultiFab& phi)
         const auto& qbox = phi.box(mfi.LocalTileIndex());
         const auto& pbox = m_mf_phase.box(mfi.LocalTileIndex());
 
-        tortuosity_filct(phi_arr.dataPtr(),
-                         qbox.loVect(), qbox.hiVect(), &q_ncomp,
-                         phase_arr.dataPtr(),
-                         pbox.loVect(), pbox.hiVect(), &p_ncomp,
-                         domain_box.loVect(), domain_box.hiVect(),
-                         &m_phase);
+        tortuosity_filct(phi_arr.dataPtr(), qbox.loVect(), qbox.hiVect(), &q_ncomp,
+                         phase_arr.dataPtr(), pbox.loVect(), pbox.hiVect(), &p_ncomp,
+                         domain_box.loVect(), domain_box.hiVect(), &m_phase);
     }
 }
 
-void TortuosityDirect::fillInitialState(amrex::MultiFab& phi)
-{
+void TortuosityDirect::fillInitialState(amrex::MultiFab& phi) {
     const amrex::Box& domain_box = m_geom.Domain();
     const int dir_int = static_cast<int>(m_dir);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.tilebox();
 
         auto phi_arr = phi.array(mfi);
@@ -454,55 +434,46 @@ void TortuosityDirect::fillInitialState(amrex::MultiFab& phi)
         const auto& qbox = phi.box(mfi.LocalTileIndex());
         const auto& pbox = m_mf_phase.box(mfi.LocalTileIndex());
 
-        tortuosity_filic(phi_arr.dataPtr(),
-                         qbox.loVect(), qbox.hiVect(), &q_ncomp,
-                         phase_arr.dataPtr(),
-                         pbox.loVect(), pbox.hiVect(), &p_ncomp,
-                         bx.loVect(), bx.hiVect(),
-                         domain_box.loVect(), domain_box.hiVect(),
-                         &m_vlo, &m_vhi,
-                         &m_phase,
-                         &dir_int);
+        tortuosity_filic(phi_arr.dataPtr(), qbox.loVect(), qbox.hiVect(), &q_ncomp,
+                         phase_arr.dataPtr(), pbox.loVect(), pbox.hiVect(), &p_ncomp, bx.loVect(),
+                         bx.hiVect(), domain_box.loVect(), domain_box.hiVect(), &m_vlo, &m_vhi,
+                         &m_phase, &dir_int);
     }
 }
 
 
-void TortuosityDirect::fillDomainBoundary (amrex::MultiFab& phi, int comp)
-{
-    if (comp != comp_phi) return;
+void TortuosityDirect::fillDomainBoundary(amrex::MultiFab& phi, int comp) {
+    if (comp != comp_phi)
+        return;
 
     const amrex::Box& domain_box = m_geom.Domain();
 
-    int bc_c_array[AMREX_SPACEDIM*2];
+    int bc_c_array[AMREX_SPACEDIM * 2];
     for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
         auto map_bc = [&](int amrex_bc_type_int) -> int {
-            if (amrex_bc_type_int == static_cast<int>(amrex::BCType::ext_dir)) return 1;
+            if (amrex_bc_type_int == static_cast<int>(amrex::BCType::ext_dir))
+                return 1;
             return 0;
         };
-        bc_c_array[idim*2 + 0] = map_bc(m_bc.lo(idim));
-        bc_c_array[idim*2 + 1] = map_bc(m_bc.hi(idim));
+        bc_c_array[idim * 2 + 0] = map_bc(m_bc.lo(idim));
+        bc_c_array[idim * 2 + 1] = map_bc(m_bc.hi(idim));
     }
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(phi, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& fab_box_ghosts = mfi.fabbox();
 
         bool touches_boundary = !domain_box.contains(fab_box_ghosts);
-        if (touches_boundary)
-        {
-             auto phi_arr = phi.array(mfi);
+        if (touches_boundary) {
+            auto phi_arr = phi.array(mfi);
 
-             int q_ncomp = phi.nComp();
-             const auto& qbox = phi.box(mfi.LocalTileIndex());
+            int q_ncomp = phi.nComp();
+            const auto& qbox = phi.box(mfi.LocalTileIndex());
 
-             tortuosity_filbc(phi_arr.dataPtr(),
-                              qbox.loVect(), qbox.hiVect(), &q_ncomp,
-                              domain_box.loVect(), domain_box.hiVect(),
-                              &m_vlo, &m_vhi,
-                              bc_c_array);
+            tortuosity_filbc(phi_arr.dataPtr(), qbox.loVect(), qbox.hiVect(), &q_ncomp,
+                             domain_box.loVect(), domain_box.hiVect(), &m_vlo, &m_vhi, bc_c_array);
         }
     }
 }

--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -30,23 +30,21 @@ namespace OpenImpala {
  * Solves a diffusion equation (-Div(Grad(phi)) = 0 with Dirichlet BCs)
  * on a masked subset of the domain derived from phase data, using HYPRE's
  * structured-grid solvers (PFMG, SMG, Krylov methods) to find the potential field.
- * Tortuosity is calculated from the resulting flux and **active** volume fraction, // <-- Doc update
- * including checks for solver convergence and flux conservation.
+ * Tortuosity is calculated from the resulting flux and **active** volume fraction, // <-- Doc
+ * update including checks for solver convergence and flux conservation.
  */
-class TortuosityHypre : public OpenImpala::Tortuosity
-{
+class TortuosityHypre : public OpenImpala::Tortuosity {
 
 public:
-
     /** @brief Specifies the HYPRE structured solver algorithm to use. */
     enum class SolverType {
-        Jacobi,     /**< HYPRE_StructJacobi */
-        GMRES,      /**< HYPRE_StructGMRES */
-        FlexGMRES,  /**< HYPRE_StructFlexGMRES */
-        PCG,        /**< HYPRE_StructPCG */
-        BiCGSTAB,   /**< HYPRE_StructBiCGSTAB */
-        SMG,        /**< HYPRE_StructSMG */
-        PFMG        /**< HYPRE_StructPFMG */
+        Jacobi,    /**< HYPRE_StructJacobi */
+        GMRES,     /**< HYPRE_StructGMRES */
+        FlexGMRES, /**< HYPRE_StructFlexGMRES */
+        PCG,       /**< HYPRE_StructPCG */
+        BiCGSTAB,  /**< HYPRE_StructBiCGSTAB */
+        SMG,       /**< HYPRE_StructSMG */
+        PFMG       /**< HYPRE_StructPFMG */
     };
 
     /** Construct new Tortuosity solver using HYPRE.
@@ -54,29 +52,27 @@ public:
      * @param geom AMReX Geometry object defining the domain.
      * @param ba AMReX BoxArray defining the distribution of grid patches.
      * @param dm AMReX DistributionMapping defining processor assignments.
-     * @param mf_phase_input Input iMultiFab containing phase IDs (expects 1 component, >=1 ghost cell).
-     * @param vf Volume fraction of the phase of interest (*total* VF, passed for potential reference). // <-- Doc update
+     * @param mf_phase_input Input iMultiFab containing phase IDs (expects 1 component, >=1 ghost
+     * cell).
+     * @param vf Volume fraction of the phase of interest (*total* VF, passed for potential
+     * reference). // <-- Doc update
      * @param phase Phase ID to calculate tortuosity for.
      * @param dir Direction across which to apply potential difference (X, Y, or Z).
      * @param solvertype Solver type to use (from SolverType enum).
      * @param resultspath Path to directory for writing output files (e.g., plotfiles).
-     * @param vlo Potential value applied at the low boundary in the specified direction. Default 0.0.
-     * @param vhi Potential value applied at the high boundary in the specified direction. Default 1.0.
+     * @param vlo Potential value applied at the low boundary in the specified direction. Default
+     * 0.0.
+     * @param vhi Potential value applied at the high boundary in the specified direction.
+     * Default 1.0.
      * @param verbose Verbosity level (0=silent, 1=basic, 2=detailed HYPRE output). Default 0.
-     * @param write_plotfile If true, write a plotfile of the solution potential field. Default false.
+     * @param write_plotfile If true, write a plotfile of the solution potential field. Default
+     * false.
      */
-    TortuosityHypre(const amrex::Geometry& geom,
-                    const amrex::BoxArray& ba,
-                    const amrex::DistributionMapping& dm,
-                    const amrex::iMultiFab& mf_phase_input,
-                    const amrex::Real vf,
-                    const int phase,
-                    const OpenImpala::Direction dir,
-                    const SolverType solvertype,
-                    const std::string& resultspath,
-                    const amrex::Real vlo = 0.0,
-                    const amrex::Real vhi = 1.0,
-                    int verbose = 0,
+    TortuosityHypre(const amrex::Geometry& geom, const amrex::BoxArray& ba,
+                    const amrex::DistributionMapping& dm, const amrex::iMultiFab& mf_phase_input,
+                    const amrex::Real vf, const int phase, const OpenImpala::Direction dir,
+                    const SolverType solvertype, const std::string& resultspath,
+                    const amrex::Real vlo = 0.0, const amrex::Real vhi = 1.0, int verbose = 0,
                     bool write_plotfile = false);
 
     /** Destructor. Cleans up allocated HYPRE resources. */
@@ -105,39 +101,53 @@ public:
      * @details Iterates over local cells, retrieves matrix/vector values using HYPRE
      * functions, and verifies properties like NaN/Inf absence, expected diagonal
      * values based on cell activity/BCs, and row sums for interior nodes.
-     * Intended for use in testing/debugging *after* object construction but *before* calling value() or solve().
+     * Intended for use in testing/debugging *after* object construction but *before* calling
+     * value() or solve().
      * @return True if all checks pass on all ranks, False otherwise.
      */
     bool checkMatrixProperties();
 
     // --- Public Getters for Status and Results ---
-    bool        getSolverConverged() const { return m_converged; }
-    amrex::Real getFinalRelativeResidualNorm() const { return m_final_res_norm; }
-    int         getSolverIterations() const { return m_num_iterations; }
-    amrex::Real getFluxIn() const { return m_flux_in; }
-    amrex::Real getFluxOut() const { return m_flux_out; }
+    bool getSolverConverged() const {
+        return m_converged;
+    }
+    amrex::Real getFinalRelativeResidualNorm() const {
+        return m_final_res_norm;
+    }
+    int getSolverIterations() const {
+        return m_num_iterations;
+    }
+    amrex::Real getFluxIn() const {
+        return m_flux_in;
+    }
+    amrex::Real getFluxOut() const {
+        return m_flux_out;
+    }
     // --- ADDED Getter for Active VF ---
-    amrex::Real getActiveVolumeFraction() const { return m_active_vf; }
+    amrex::Real getActiveVolumeFraction() const {
+        return m_active_vf;
+    }
     // --- END ADD ---
 
 
     // Static Helper Functions
-    static amrex::Array<HYPRE_Int,AMREX_SPACEDIM> loV (const amrex::Box& b);
-    static amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hiV (const amrex::Box& b);
+    static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> loV(const amrex::Box& b);
+    static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hiV(const amrex::Box& b);
 
 
 private:
-
     // --- Private Methods ---
     bool solve();
     void setupGrids();
     void setupStencil();
     void setupMatrixEquation();
     void preconditionPhaseFab();
-    void generateActivityMask(const amrex::iMultiFab& phaseFab, int phaseID, OpenImpala::Direction dir);
-    void parallelFloodFill(amrex::iMultiFab& reachabilityMask, const amrex::iMultiFab& phaseFab, int phaseID, const amrex::Vector<amrex::IntVect>& seedPoints);
-    void getSolution (amrex::MultiFab& soln, int ncomp=0); // Not implemented
-    void getCellTypes(amrex::MultiFab& phi, int ncomp=1); // Not implemented
+    void generateActivityMask(const amrex::iMultiFab& phaseFab, int phaseID,
+                              OpenImpala::Direction dir);
+    void parallelFloodFill(amrex::iMultiFab& reachabilityMask, const amrex::iMultiFab& phaseFab,
+                           int phaseID, const amrex::Vector<amrex::IntVect>& seedPoints);
+    void getSolution(amrex::MultiFab& soln, int ncomp = 0); // Not implemented
+    void getCellTypes(amrex::MultiFab& phi, int ncomp = 1); // Not implemented
     void global_fluxes();
 
     // --- Member Variables ---
@@ -169,7 +179,7 @@ private:
     // Solver Statistics and Results
     HYPRE_Int m_num_iterations = -1;
     amrex::Real m_final_res_norm = std::numeric_limits<amrex::Real>::quiet_NaN();
-    bool        m_converged = false;
+    bool m_converged = false;
     amrex::Real m_flux_in = 0.0;
     amrex::Real m_flux_out = 0.0;
     // --- ADDED: Active Volume Fraction ---
@@ -189,27 +199,17 @@ private:
 // --- Fortran Interface Declarations ---
 // (Remain the same as in your provided file)
 extern "C" {
-    void tortuosity_fillmtx(
-        amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit,
-        const int* nval,
-        const int* p, const int* p_lo, const int* p_hi,
-        const int* active_mask, const int* mask_lo, const int* mask_hi,
-        const int* bxlo, const int* bxhi,
-        const int* domlo, const int* domhi,
-        const amrex::Real* dxinv,
-        const amrex::Real* vlo, const amrex::Real* vhi,
-        const int* phase_unused, const int* dir,
-        const int* debug_print_level
-    );
+void tortuosity_fillmtx(amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit, const int* nval,
+                        const int* p, const int* p_lo, const int* p_hi, const int* active_mask,
+                        const int* mask_lo, const int* mask_hi, const int* bxlo, const int* bxhi,
+                        const int* domlo, const int* domhi, const amrex::Real* dxinv,
+                        const amrex::Real* vlo, const amrex::Real* vhi, const int* phase_unused,
+                        const int* dir, const int* debug_print_level);
 
-    void tortuosity_remspot(
-        int* q, const int* q_lo, const int* q_hi,
-        const int* ncomp,
-        const int* bxlo, const int* bxhi,
-        const int* domlo, const int* domhi
-    );
+void tortuosity_remspot(int* q, const int* q_lo, const int* q_hi, const int* ncomp, const int* bxlo,
+                        const int* bxhi, const int* domlo, const int* domhi);
 
-    // Add others if needed...
+// Add others if needed...
 }
 
 

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -1,7 +1,7 @@
 // --- TortuosityHypre.cpp ---
 
 #include "TortuosityHypre.H"
-#include "Tortuosity_filcc_F.H"     // For tortuosity_remspot
+#include "Tortuosity_filcc_F.H"    // For tortuosity_remspot
 #include "TortuosityHypreFill_F.H" // For tortuosity_fillmtx
 
 // Includes remain the same...
@@ -9,8 +9,8 @@
 #include <ctime>
 #include <vector>
 #include <string>
-#include <cmath>   // Required for std::isnan, std::isinf, std::abs
-#include <limits>  // Required for std::numeric_limits
+#include <cmath>     // Required for std::isnan, std::isinf, std::abs
+#include <limits>    // Required for std::numeric_limits
 #include <stdexcept> // For potential error throwing (optional)
 #include <iomanip>   // For std::setprecision
 #include <iostream>  // For std::cout, std::flush
@@ -45,49 +45,52 @@
 #include <mpi.h>
 
 // HYPRE_CHECK macro remains the same...
-#define HYPRE_CHECK(ierr) do { \
-    if (ierr != 0) { \
-        char hypre_error_msg[256]; \
-        HYPRE_DescribeError(ierr, hypre_error_msg); \
-        amrex::Abort("HYPRE Error: " + std::string(hypre_error_msg) + \
-                     " - Error Code: " + std::to_string(ierr) + \
-                     " File: " + __FILE__ + " Line: " + std::to_string(__LINE__)); \
-    } \
-} while (0)
+#define HYPRE_CHECK(ierr)                                                                          \
+    do {                                                                                           \
+        if (ierr != 0) {                                                                           \
+            char hypre_error_msg[256];                                                             \
+            HYPRE_DescribeError(ierr, hypre_error_msg);                                            \
+            amrex::Abort("HYPRE Error: " + std::string(hypre_error_msg) +                          \
+                         " - Error Code: " + std::to_string(ierr) + " File: " + __FILE__ +         \
+                         " Line: " + std::to_string(__LINE__));                                    \
+        }                                                                                          \
+    } while (0)
 
 
 // Constants namespace remains the same...
 namespace {
-    constexpr int SolnComp = 0;
-    constexpr int MaskComp = 0;
-    constexpr int numComponentsPhi = 3;
-    constexpr amrex::Real tiny_flux_threshold = 1.e-15;
-    constexpr int stencil_size = 7;
-    constexpr int cell_inactive = 0;
-    constexpr int cell_active = 1;
-    constexpr int istn_c  = 0;
-    constexpr int istn_mx = 1;
-    constexpr int istn_px = 2;
-    constexpr int istn_my = 3;
-    constexpr int istn_py = 4;
-    constexpr int istn_mz = 5;
-    constexpr int istn_pz = 6;
-}
+constexpr int SolnComp = 0;
+constexpr int MaskComp = 0;
+constexpr int numComponentsPhi = 3;
+constexpr amrex::Real tiny_flux_threshold = 1.e-15;
+constexpr int stencil_size = 7;
+constexpr int cell_inactive = 0;
+constexpr int cell_active = 1;
+constexpr int istn_c = 0;
+constexpr int istn_mx = 1;
+constexpr int istn_px = 2;
+constexpr int istn_my = 3;
+constexpr int istn_py = 4;
+constexpr int istn_mz = 5;
+constexpr int istn_pz = 6;
+} // namespace
 
 // Helper Functions and Class Implementation
 namespace OpenImpala {
 
 // loV and hiV helpers remain the same...
-amrex::Array<HYPRE_Int,AMREX_SPACEDIM> TortuosityHypre::loV (const amrex::Box& b) {
+amrex::Array<HYPRE_Int, AMREX_SPACEDIM> TortuosityHypre::loV(const amrex::Box& b) {
     const int* lo_ptr = b.loVect();
-    amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hypre_lo;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) hypre_lo[i] = static_cast<HYPRE_Int>(lo_ptr[i]);
+    amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hypre_lo;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        hypre_lo[i] = static_cast<HYPRE_Int>(lo_ptr[i]);
     return hypre_lo;
 }
-amrex::Array<HYPRE_Int,AMREX_SPACEDIM> TortuosityHypre::hiV (const amrex::Box& b) {
+amrex::Array<HYPRE_Int, AMREX_SPACEDIM> TortuosityHypre::hiV(const amrex::Box& b) {
     const int* hi_ptr = b.hiVect();
-    amrex::Array<HYPRE_Int,AMREX_SPACEDIM> hypre_hi;
-    for (int i=0; i<AMREX_SPACEDIM; ++i) hypre_hi[i] = static_cast<HYPRE_Int>(hi_ptr[i]);
+    amrex::Array<HYPRE_Int, AMREX_SPACEDIM> hypre_hi;
+    for (int i = 0; i < AMREX_SPACEDIM; ++i)
+        hypre_hi[i] = static_cast<HYPRE_Int>(hi_ptr[i]);
     return hypre_hi;
 }
 
@@ -97,37 +100,24 @@ amrex::Array<HYPRE_Int,AMREX_SPACEDIM> TortuosityHypre::hiV (const amrex::Box& b
 // private:
 //     amrex::Real m_active_vf = 0.0; // Volume fraction of the percolating phase
 //
-OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom,
-                                             const amrex::BoxArray& ba,
+OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom, const amrex::BoxArray& ba,
                                              const amrex::DistributionMapping& dm,
                                              const amrex::iMultiFab& mf_phase_input,
                                              const amrex::Real vf, // Original total VF
-                                             const int phase,
-                                             const OpenImpala::Direction dir,
-                                             const SolverType st,
-                                             const std::string& resultspath,
-                                             const amrex::Real vlo,
-                                             const amrex::Real vhi,
-                                             int verbose,
-                                             bool write_plotfile)
+                                             const int phase, const OpenImpala::Direction dir,
+                                             const SolverType st, const std::string& resultspath,
+                                             const amrex::Real vlo, const amrex::Real vhi,
+                                             int verbose, bool write_plotfile)
     : m_geom(geom), m_ba(ba), m_dm(dm),
-      m_mf_phase(ba, dm, mf_phase_input.nComp(), mf_phase_input.nGrow()),
-      m_phase(phase),
+      m_mf_phase(ba, dm, mf_phase_input.nComp(), mf_phase_input.nGrow()), m_phase(phase),
       m_vf(vf), // Store original total VF
-      m_dir(dir), m_solvertype(st),
-      m_vlo(vlo), m_vhi(vhi),
-      m_resultspath(resultspath), m_verbose(verbose),
-      m_write_plotfile(write_plotfile),
-      m_mf_phi(ba, dm, numComponentsPhi, 1),
-      m_mf_active_mask(ba, dm, 1, 1),
-      m_active_vf(0.0), // <<< CHANGE: Initialize active VF member
-      m_first_call(true), m_value(std::numeric_limits<amrex::Real>::quiet_NaN()),
-      m_grid(NULL), m_stencil(NULL), m_A(NULL), m_b(NULL), m_x(NULL),
-      m_num_iterations(-1), m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()),
-      m_converged(false),
-      m_flux_in(0.0),
-      m_flux_out(0.0)
-{
+      m_dir(dir), m_solvertype(st), m_vlo(vlo), m_vhi(vhi), m_resultspath(resultspath),
+      m_verbose(verbose), m_write_plotfile(write_plotfile), m_mf_phi(ba, dm, numComponentsPhi, 1),
+      m_mf_active_mask(ba, dm, 1, 1), m_active_vf(0.0), // <<< CHANGE: Initialize active VF member
+      m_first_call(true), m_value(std::numeric_limits<amrex::Real>::quiet_NaN()), m_grid(NULL),
+      m_stencil(NULL), m_A(NULL), m_b(NULL), m_x(NULL), m_num_iterations(-1),
+      m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()), m_converged(false),
+      m_flux_in(0.0), m_flux_out(0.0) {
     // Copy data from input iMultiFab to member iMultiFab
     amrex::Copy(m_mf_phase, mf_phase_input, 0, 0, m_mf_phase.nComp(), m_mf_phase.nGrow());
 
@@ -155,34 +145,44 @@ OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom,
         amrex::Print() << "  Class Verbose Level: " << m_verbose << std::endl;
         amrex::Print() << "  Write Plotfile Flag: " << m_write_plotfile << std::endl;
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_vf >= 0.0 && m_vf <= 1.0, "Original Volume fraction must be between 0 and 1");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_vf >= 0.0 && m_vf <= 1.0,
+                                     "Original Volume fraction must be between 0 and 1");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_eps > 0.0, "Solver tolerance (eps) must be positive");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_maxiter > 0, "Solver max iterations must be positive");
 
 
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "TortuosityHypre: Running preconditionPhaseFab (remspot)..." << std::endl;
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "TortuosityHypre: Running preconditionPhaseFab (remspot)..." << std::endl;
     preconditionPhaseFab();
 
-    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "TortuosityHypre: Generating activity mask via boundary search..." << std::endl;
-    generateActivityMask(m_mf_phase, m_phase, m_dir); // <<< This now calculates and stores m_active_vf
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "TortuosityHypre: Generating activity mask via boundary search..."
+                       << std::endl;
+    generateActivityMask(m_mf_phase, m_phase,
+                         m_dir); // <<< This now calculates and stores m_active_vf
 
     // Check if active VF is zero after generation
     if (m_active_vf <= std::numeric_limits<amrex::Real>::epsilon()) {
-         if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "WARNING: Active volume fraction is zero. Skipping matrix setup and solve." << std::endl;
-         }
-         // No need to setup HYPRE if there's no active phase
-         m_first_call = false; // Mark as "calculated" (result is NaN or Inf)
-         m_value = std::numeric_limits<amrex::Real>::quiet_NaN(); // Or Inf if you prefer for zero VF
-         return; // Exit constructor early
+        if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print()
+                << "WARNING: Active volume fraction is zero. Skipping matrix setup and solve."
+                << std::endl;
+        }
+        // No need to setup HYPRE if there's no active phase
+        m_first_call = false; // Mark as "calculated" (result is NaN or Inf)
+        m_value = std::numeric_limits<amrex::Real>::quiet_NaN(); // Or Inf if you prefer for zero VF
+        return;                                                  // Exit constructor early
     }
 
     // Setup HYPRE structures only if there's an active phase
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "TortuosityHypre: Running setupGrids..." << std::endl;
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "TortuosityHypre: Running setupGrids..." << std::endl;
     setupGrids();
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "TortuosityHypre: Running setupStencil..." << std::endl;
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "TortuosityHypre: Running setupStencil..." << std::endl;
     setupStencil();
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "TortuosityHypre: Running setupMatrixEquation..." << std::endl;
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "TortuosityHypre: Running setupMatrixEquation..." << std::endl;
     setupMatrixEquation();
 
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
@@ -192,63 +192,88 @@ OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom,
 
 // --- Destructor ---
 // Remains the same...
-OpenImpala::TortuosityHypre::~TortuosityHypre()
-{
-    if (m_x)       HYPRE_StructVectorDestroy(m_x);
-    if (m_b)       HYPRE_StructVectorDestroy(m_b);
-    if (m_A)       HYPRE_StructMatrixDestroy(m_A);
-    if (m_stencil) HYPRE_StructStencilDestroy(m_stencil);
-    if (m_grid)    HYPRE_StructGridDestroy(m_grid);
-    m_x = m_b = NULL; m_A = NULL; m_stencil = NULL; m_grid = NULL;
+OpenImpala::TortuosityHypre::~TortuosityHypre() {
+    if (m_x)
+        HYPRE_StructVectorDestroy(m_x);
+    if (m_b)
+        HYPRE_StructVectorDestroy(m_b);
+    if (m_A)
+        HYPRE_StructMatrixDestroy(m_A);
+    if (m_stencil)
+        HYPRE_StructStencilDestroy(m_stencil);
+    if (m_grid)
+        HYPRE_StructGridDestroy(m_grid);
+    m_x = m_b = NULL;
+    m_A = NULL;
+    m_stencil = NULL;
+    m_grid = NULL;
 }
 
 
 // --- setupGrids ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::setupGrids()
-{
+void OpenImpala::TortuosityHypre::setupGrids() {
     HYPRE_Int ierr = 0;
-    ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, AMREX_SPACEDIM, &m_grid); HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, AMREX_SPACEDIM, &m_grid);
+    HYPRE_CHECK(ierr);
     for (int i = 0; i < m_ba.size(); ++i) {
         if (m_dm[i] == amrex::ParallelDescriptor::MyProc()) { // Process only local boxes
             amrex::Box bx = m_ba[i];
             auto lo = OpenImpala::TortuosityHypre::loV(bx);
             auto hi = OpenImpala::TortuosityHypre::hiV(bx);
-            if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupGrids: Rank " << amrex::ParallelDescriptor::MyProc() << " adding box " << bx << std::endl; }
-            ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data()); HYPRE_CHECK(ierr);
+            if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "  setupGrids: Rank " << amrex::ParallelDescriptor::MyProc()
+                               << " adding box " << bx << std::endl;
+            }
+            ierr = HYPRE_StructGridSetExtents(m_grid, lo.data(), hi.data());
+            HYPRE_CHECK(ierr);
         }
     }
-    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupGrids: Calling Assemble..." << std::endl; }
-    ierr = HYPRE_StructGridAssemble(m_grid); HYPRE_CHECK(ierr);
-    if (!m_grid) { amrex::Abort("FATAL: m_grid handle is NULL after HYPRE_StructGridAssemble!"); }
-    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupGrids: Assemble complete." << std::endl; }
+    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupGrids: Calling Assemble..." << std::endl;
+    }
+    ierr = HYPRE_StructGridAssemble(m_grid);
+    HYPRE_CHECK(ierr);
+    if (!m_grid) {
+        amrex::Abort("FATAL: m_grid handle is NULL after HYPRE_StructGridAssemble!");
+    }
+    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupGrids: Assemble complete." << std::endl;
+    }
 }
 
 // --- setupStencil ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::setupStencil()
-{
+void OpenImpala::TortuosityHypre::setupStencil() {
     HYPRE_Int ierr = 0;
-    HYPRE_Int offsets[stencil_size][AMREX_SPACEDIM] = {{ 0, 0, 0},
-                                                       {-1, 0, 0}, { 1, 0, 0},
-                                                       { 0,-1, 0}, { 0, 1, 0},
-                                                       { 0, 0,-1}, { 0, 0, 1}};
-    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupStencil: Creating..." << std::endl; }
-    ierr = HYPRE_StructStencilCreate(AMREX_SPACEDIM, stencil_size, &m_stencil); HYPRE_CHECK(ierr);
-    for (int i = 0; i < stencil_size; i++) {
-        if (m_verbose > 3 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "    Setting stencil element " << i << std::endl; }
-        ierr = HYPRE_StructStencilSetElement(m_stencil, i, offsets[i]); HYPRE_CHECK(ierr);
+    HYPRE_Int offsets[stencil_size][AMREX_SPACEDIM] = {{0, 0, 0}, {-1, 0, 0}, {1, 0, 0}, {0, -1, 0},
+                                                       {0, 1, 0}, {0, 0, -1}, {0, 0, 1}};
+    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupStencil: Creating..." << std::endl;
     }
-    if (!m_stencil) { amrex::Abort("FATAL: m_stencil handle is NULL after HYPRE_StructStencilCreate/SetElement!"); }
-    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupStencil: Complete." << std::endl; }
+    ierr = HYPRE_StructStencilCreate(AMREX_SPACEDIM, stencil_size, &m_stencil);
+    HYPRE_CHECK(ierr);
+    for (int i = 0; i < stencil_size; i++) {
+        if (m_verbose > 3 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "    Setting stencil element " << i << std::endl;
+        }
+        ierr = HYPRE_StructStencilSetElement(m_stencil, i, offsets[i]);
+        HYPRE_CHECK(ierr);
+    }
+    if (!m_stencil) {
+        amrex::Abort("FATAL: m_stencil handle is NULL after HYPRE_StructStencilCreate/SetElement!");
+    }
+    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupStencil: Complete." << std::endl;
+    }
 }
 
 // --- preconditionPhaseFab ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::preconditionPhaseFab()
-{
+void OpenImpala::TortuosityHypre::preconditionPhaseFab() {
     BL_PROFILE("TortuosityHypre::preconditionPhaseFab");
-    AMREX_ASSERT_WITH_MESSAGE(m_mf_phase.nGrow() >= 1, "Phase fab needs ghost cells for preconditionPhaseFab");
+    AMREX_ASSERT_WITH_MESSAGE(m_mf_phase.nGrow() >= 1,
+                              "Phase fab needs ghost cells for preconditionPhaseFab");
 
     const amrex::Box& domain_box = m_geom.Domain();
     int num_remspot_passes = 0; // Default to 0 based on input file
@@ -257,32 +282,33 @@ void OpenImpala::TortuosityHypre::preconditionPhaseFab()
 
     if (num_remspot_passes <= 0) {
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "  Skipping tortuosity_remspot filter (remspot_passes <= 0)." << std::endl;
+            amrex::Print() << "  Skipping tortuosity_remspot filter (remspot_passes <= 0)."
+                           << std::endl;
         }
         return;
     }
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  Applying tortuosity_remspot filter (" << num_remspot_passes << " passes)..." << std::endl;
+        amrex::Print() << "  Applying tortuosity_remspot filter (" << num_remspot_passes
+                       << " passes)..." << std::endl;
     }
 
     for (int pass = 0; pass < num_remspot_passes; ++pass) {
         m_mf_phase.FillBoundary(m_geom.periodicity());
-        #ifdef AMREX_USE_OMP
-        #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-        #endif
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
         for (amrex::MFIter mfi(m_mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             const amrex::Box& tile_box = mfi.tilebox();
             amrex::IArrayBox& fab = m_mf_phase[mfi];
             int ncomp = fab.nComp();
-            tortuosity_remspot(fab.dataPtr(0),
-                               fab.loVect(), fab.hiVect(),
-                               &ncomp,
-                               tile_box.loVect(), tile_box.hiVect(),
-                               domain_box.loVect(), domain_box.hiVect());
+            tortuosity_remspot(fab.dataPtr(0), fab.loVect(), fab.hiVect(), &ncomp,
+                               tile_box.loVect(), tile_box.hiVect(), domain_box.loVect(),
+                               domain_box.hiVect());
         }
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "    DEBUG [preconditionPhaseFab]: Finished remspot pass " << pass + 1 << std::endl;
+            amrex::Print() << "    DEBUG [preconditionPhaseFab]: Finished remspot pass " << pass + 1
+                           << std::endl;
         }
     }
     m_mf_phase.FillBoundary(m_geom.periodicity());
@@ -295,297 +321,323 @@ void OpenImpala::TortuosityHypre::preconditionPhaseFab()
 // --- parallelFloodFill ---
 // Remains the same...
 void OpenImpala::TortuosityHypre::parallelFloodFill(
-    amrex::iMultiFab& reachabilityMask,
-    const amrex::iMultiFab& phaseFab,
-    int phaseID,
-    const amrex::Vector<amrex::IntVect>& seedPoints)
-{
-     BL_PROFILE("TortuosityHypre::parallelFloodFill");
-     AMREX_ASSERT(reachabilityMask.nGrow() >= 1);
-     AMREX_ASSERT(phaseFab.nGrow() >= 1);
-     AMREX_ASSERT(phaseFab.nComp() > 0);
-     AMREX_ASSERT(reachabilityMask.nComp() == 1);
+    amrex::iMultiFab& reachabilityMask, const amrex::iMultiFab& phaseFab, int phaseID,
+    const amrex::Vector<amrex::IntVect>& seedPoints) {
+    BL_PROFILE("TortuosityHypre::parallelFloodFill");
+    AMREX_ASSERT(reachabilityMask.nGrow() >= 1);
+    AMREX_ASSERT(phaseFab.nGrow() >= 1);
+    AMREX_ASSERT(phaseFab.nComp() > 0);
+    AMREX_ASSERT(reachabilityMask.nComp() == 1);
 
-     reachabilityMask.setVal(cell_inactive);
- #ifdef AMREX_USE_OMP
- #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
- #endif
-     for (amrex::MFIter mfi(reachabilityMask, true); mfi.isValid(); ++mfi) {
-         const amrex::Box& tileBox = mfi.tilebox();
-         auto mask_arr = reachabilityMask.array(mfi);
-         const auto phase_arr = phaseFab.const_array(mfi, 0);
-         for (const auto& seed : seedPoints) {
-             if (tileBox.contains(seed)) {
-                 if (phase_arr(seed) == phaseID) {
-                     mask_arr(seed, MaskComp) = cell_active;
-                 }
-             }
-         }
-     }
+    reachabilityMask.setVal(cell_inactive);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(reachabilityMask, true); mfi.isValid(); ++mfi) {
+        const amrex::Box& tileBox = mfi.tilebox();
+        auto mask_arr = reachabilityMask.array(mfi);
+        const auto phase_arr = phaseFab.const_array(mfi, 0);
+        for (const auto& seed : seedPoints) {
+            if (tileBox.contains(seed)) {
+                if (phase_arr(seed) == phaseID) {
+                    mask_arr(seed, MaskComp) = cell_active;
+                }
+            }
+        }
+    }
 
-     int iter = 0;
-     amrex::IntVect domain_size = m_geom.Domain().size();
-     const int max_flood_iter = domain_size[0] + domain_size[1] + domain_size[2] + 2;
-     bool changed_globally = true;
-     const std::vector<amrex::IntVect> offsets = {
-         amrex::IntVect{1, 0, 0}, amrex::IntVect{-1, 0, 0},
-         amrex::IntVect{0, 1, 0}, amrex::IntVect{0, -1, 0},
-         amrex::IntVect{0, 0, 1}, amrex::IntVect{0, 0, -1}
-     };
+    int iter = 0;
+    amrex::IntVect domain_size = m_geom.Domain().size();
+    const int max_flood_iter = domain_size[0] + domain_size[1] + domain_size[2] + 2;
+    bool changed_globally = true;
+    const std::vector<amrex::IntVect> offsets = {amrex::IntVect{1, 0, 0}, amrex::IntVect{-1, 0, 0},
+                                                 amrex::IntVect{0, 1, 0}, amrex::IntVect{0, -1, 0},
+                                                 amrex::IntVect{0, 0, 1}, amrex::IntVect{0, 0, -1}};
 
-     while (changed_globally && iter < max_flood_iter) {
-         ++iter;
-         changed_globally = false;
-         reachabilityMask.FillBoundary(m_geom.periodicity());
- #ifdef AMREX_USE_OMP
- #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
- #endif
-         {
-             bool changed_locally = false;
-             for (amrex::MFIter mfi(reachabilityMask, true); mfi.isValid(); ++mfi) {
-                 const amrex::Box& tileBox = mfi.tilebox();
-                 auto mask_arr = reachabilityMask.array(mfi);
-                 const auto phase_arr = phaseFab.const_array(mfi, 0);
-                 const amrex::Box& grownTileBox = amrex::grow(tileBox, reachabilityMask.nGrow());
-                 amrex::LoopOnCpu(tileBox, [&](int i, int j, int k)
-                 {
-                     amrex::IntVect current_cell(i, j, k);
-                     if (mask_arr(current_cell, MaskComp) == cell_active || phase_arr(current_cell) != phaseID) {
-                         return;
-                     }
-                     bool reached_by_neighbor = false;
-                     for (const auto& offset : offsets) {
-                         amrex::IntVect neighbor_cell = current_cell + offset;
-                         if (grownTileBox.contains(neighbor_cell)) {
-                             if (mask_arr(neighbor_cell, MaskComp) == cell_active) {
-                                 reached_by_neighbor = true;
-                                 break;
-                             }
-                         }
-                     }
-                     if (reached_by_neighbor) {
-                         mask_arr(current_cell, MaskComp) = cell_active;
-                         changed_locally = true;
-                     }
-                 });
-             }
-             #ifdef AMREX_USE_OMP
-             #pragma omp critical (flood_fill_crit)
-             #endif
-             {
-                 if (changed_locally) { changed_globally = true; }
-             }
-         }
-         amrex::ParallelDescriptor::ReduceBoolOr(changed_globally);
-     }
+    while (changed_globally && iter < max_flood_iter) {
+        ++iter;
+        changed_globally = false;
+        reachabilityMask.FillBoundary(m_geom.periodicity());
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        {
+            bool changed_locally = false;
+            for (amrex::MFIter mfi(reachabilityMask, true); mfi.isValid(); ++mfi) {
+                const amrex::Box& tileBox = mfi.tilebox();
+                auto mask_arr = reachabilityMask.array(mfi);
+                const auto phase_arr = phaseFab.const_array(mfi, 0);
+                const amrex::Box& grownTileBox = amrex::grow(tileBox, reachabilityMask.nGrow());
+                amrex::LoopOnCpu(tileBox, [&](int i, int j, int k) {
+                    amrex::IntVect current_cell(i, j, k);
+                    if (mask_arr(current_cell, MaskComp) == cell_active ||
+                        phase_arr(current_cell) != phaseID) {
+                        return;
+                    }
+                    bool reached_by_neighbor = false;
+                    for (const auto& offset : offsets) {
+                        amrex::IntVect neighbor_cell = current_cell + offset;
+                        if (grownTileBox.contains(neighbor_cell)) {
+                            if (mask_arr(neighbor_cell, MaskComp) == cell_active) {
+                                reached_by_neighbor = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (reached_by_neighbor) {
+                        mask_arr(current_cell, MaskComp) = cell_active;
+                        changed_locally = true;
+                    }
+                });
+            }
+#ifdef AMREX_USE_OMP
+#pragma omp critical(flood_fill_crit)
+#endif
+            {
+                if (changed_locally) {
+                    changed_globally = true;
+                }
+            }
+        }
+        amrex::ParallelDescriptor::ReduceBoolOr(changed_globally);
+    }
 
-     if (iter >= max_flood_iter && changed_globally) {
-         amrex::Warning("TortuosityHypre::parallelFloodFill reached max iterations - flood fill might be incomplete.");
-     }
-     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-         amrex::Print() << "    Flood fill completed in " << iter << " iterations." << std::endl;
-     }
-     reachabilityMask.FillBoundary(m_geom.periodicity());
+    if (iter >= max_flood_iter && changed_globally) {
+        amrex::Warning("TortuosityHypre::parallelFloodFill reached max iterations - flood fill "
+                       "might be incomplete.");
+    }
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "    Flood fill completed in " << iter << " iterations." << std::endl;
+    }
+    reachabilityMask.FillBoundary(m_geom.periodicity());
 }
 
 
 // --- Generate Activity Mask ---
 // <<< CORRECTED sum call and fixed loop warnings >>>
-void OpenImpala::TortuosityHypre::generateActivityMask(
-    const amrex::iMultiFab& phaseFab,
-    int phaseID,
-    OpenImpala::Direction dir)
-{
-      BL_PROFILE("TortuosityHypre::generateActivityMask");
-      AMREX_ASSERT(phaseFab.nGrow() >= 1);
-      AMREX_ASSERT(phaseFab.nComp() > 0);
+void OpenImpala::TortuosityHypre::generateActivityMask(const amrex::iMultiFab& phaseFab,
+                                                       int phaseID, OpenImpala::Direction dir) {
+    BL_PROFILE("TortuosityHypre::generateActivityMask");
+    AMREX_ASSERT(phaseFab.nGrow() >= 1);
+    AMREX_ASSERT(phaseFab.nComp() > 0);
 
-      const amrex::Box& domain = m_geom.Domain();
-      const int idir = static_cast<int>(dir);
+    const amrex::Box& domain = m_geom.Domain();
+    const int idir = static_cast<int>(dir);
 
-      // Seed finding logic remains the same...
-      amrex::iMultiFab mf_reached_inlet(m_ba, m_dm, 1, 1);
-      amrex::iMultiFab mf_reached_outlet(m_ba, m_dm, 1, 1);
-      amrex::Vector<amrex::IntVect> local_inlet_seeds;
-      amrex::Vector<amrex::IntVect> local_outlet_seeds;
-      amrex::Box domain_lo_face = domain;
-      domain_lo_face.setBig(idir, domain.smallEnd(idir));
-      amrex::Box domain_hi_face = domain;
-      domain_hi_face.setSmall(idir, domain.bigEnd(idir));
+    // Seed finding logic remains the same...
+    amrex::iMultiFab mf_reached_inlet(m_ba, m_dm, 1, 1);
+    amrex::iMultiFab mf_reached_outlet(m_ba, m_dm, 1, 1);
+    amrex::Vector<amrex::IntVect> local_inlet_seeds;
+    amrex::Vector<amrex::IntVect> local_outlet_seeds;
+    amrex::Box domain_lo_face = domain;
+    domain_lo_face.setBig(idir, domain.smallEnd(idir));
+    amrex::Box domain_hi_face = domain;
+    domain_hi_face.setSmall(idir, domain.bigEnd(idir));
 
-      if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-         amrex::Print() << "    generateActivityMask: Searching for seeds on faces..." << std::endl;
-         amrex::Print() << "      Inlet Face Box: " << domain_lo_face << std::endl;
-         amrex::Print() << "      Outlet Face Box: " << domain_hi_face << std::endl;
-      }
-      #ifdef AMREX_USE_OMP
-      #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-      #endif
-      for (amrex::MFIter mfi(phaseFab); mfi.isValid(); ++mfi) {
-          const amrex::Box& validBox = mfi.validbox();
-          const auto phase_arr = phaseFab.const_array(mfi);
-          amrex::Box inlet_intersect = validBox & domain_lo_face;
-          if (!inlet_intersect.isEmpty()) {
-              amrex::LoopOnCpu(inlet_intersect, [&](int i, int j, int k) {
-                  if (phase_arr(i, j, k, 0) == phaseID) {
-                      #ifdef AMREX_USE_OMP
-                      #pragma omp critical (inlet_seed_crit)
-                      #endif
-                      local_inlet_seeds.push_back(amrex::IntVect(i,j,k));
-                  }
-              });
-          }
-          amrex::Box outlet_intersect = validBox & domain_hi_face;
-          if (!outlet_intersect.isEmpty()) {
-              amrex::LoopOnCpu(outlet_intersect, [&](int i, int j, int k) {
-                  if (phase_arr(i, j, k, 0) == phaseID) {
-                      #ifdef AMREX_USE_OMP
-                      #pragma omp critical (outlet_seed_crit)
-                      #endif
-                      local_outlet_seeds.push_back(amrex::IntVect(i,j,k));
-                  }
-              });
-          }
-      }
-      // Seed gathering logic
-      // <<< Address sign-compare warnings >>>
-      const size_t n_local_inlet_seeds = static_cast<size_t>(local_inlet_seeds.size());
-      std::vector<int> flat_local_inlet_seeds(n_local_inlet_seeds * AMREX_SPACEDIM);
-      for (size_t i = 0; i < n_local_inlet_seeds; ++i) {
-          for (int d=0; d<AMREX_SPACEDIM; ++d) flat_local_inlet_seeds[i*AMREX_SPACEDIM+d]=local_inlet_seeds[i][d];
-      }
-      const size_t n_local_outlet_seeds = static_cast<size_t>(local_outlet_seeds.size());
-      std::vector<int> flat_local_outlet_seeds(n_local_outlet_seeds * AMREX_SPACEDIM);
-      for (size_t i = 0; i < n_local_outlet_seeds; ++i) {
-          for (int d=0; d<AMREX_SPACEDIM; ++d) flat_local_outlet_seeds[i*AMREX_SPACEDIM+d]=local_outlet_seeds[i][d];
-      }
-      // MPI Allgather/v logic remains the same...
-      MPI_Comm comm = amrex::ParallelDescriptor::Communicator();
-      int mpi_size = amrex::ParallelDescriptor::NProcs();
-      int local_inlet_count = static_cast<int>(flat_local_inlet_seeds.size());
-      std::vector<int> recv_counts_inlet(mpi_size);
-      MPI_Allgather(&local_inlet_count, 1, MPI_INT, recv_counts_inlet.data(), 1, MPI_INT, comm);
-      int local_outlet_count = static_cast<int>(flat_local_outlet_seeds.size());
-      std::vector<int> recv_counts_outlet(mpi_size);
-      MPI_Allgather(&local_outlet_count, 1, MPI_INT, recv_counts_outlet.data(), 1, MPI_INT, comm);
-      std::vector<int> displacements_inlet(mpi_size, 0);
-      std::vector<int> displacements_outlet(mpi_size, 0);
-      int total_inlet_seeds = recv_counts_inlet[0];
-      int total_outlet_seeds = recv_counts_outlet[0];
-      for (int i = 1; i < mpi_size; ++i) {
-          displacements_inlet[i]=displacements_inlet[i-1]+recv_counts_inlet[i-1];
-          displacements_outlet[i]=displacements_outlet[i-1]+recv_counts_outlet[i-1];
-          total_inlet_seeds+=recv_counts_inlet[i];
-          total_outlet_seeds+=recv_counts_outlet[i];
-      }
-      std::vector<int> flat_inlet_seeds_gathered(total_inlet_seeds);
-      MPI_Allgatherv(flat_local_inlet_seeds.data(), local_inlet_count, MPI_INT, flat_inlet_seeds_gathered.data(), recv_counts_inlet.data(), displacements_inlet.data(), MPI_INT, comm);
-      std::vector<int> flat_outlet_seeds_gathered(total_outlet_seeds);
-      MPI_Allgatherv(flat_local_outlet_seeds.data(), local_outlet_count, MPI_INT, flat_outlet_seeds_gathered.data(), recv_counts_outlet.data(), displacements_outlet.data(), MPI_INT, comm);
-      amrex::Vector<amrex::IntVect> inlet_seeds;
-      inlet_seeds.reserve(total_inlet_seeds / AMREX_SPACEDIM);
-      for (size_t i = 0; i < flat_inlet_seeds_gathered.size(); i += AMREX_SPACEDIM) {
-          inlet_seeds.emplace_back(flat_inlet_seeds_gathered[i], flat_inlet_seeds_gathered[i+1], flat_inlet_seeds_gathered[i+2]);
-      }
-      amrex::Vector<amrex::IntVect> outlet_seeds;
-      outlet_seeds.reserve(total_outlet_seeds / AMREX_SPACEDIM);
-      for (size_t i = 0; i < flat_outlet_seeds_gathered.size(); i += AMREX_SPACEDIM) {
-          outlet_seeds.emplace_back(flat_outlet_seeds_gathered[i], flat_outlet_seeds_gathered[i+1], flat_outlet_seeds_gathered[i+2]);
-      }
-      // End seed gathering
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "    generateActivityMask: Searching for seeds on faces..." << std::endl;
+        amrex::Print() << "      Inlet Face Box: " << domain_lo_face << std::endl;
+        amrex::Print() << "      Outlet Face Box: " << domain_hi_face << std::endl;
+    }
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(phaseFab); mfi.isValid(); ++mfi) {
+        const amrex::Box& validBox = mfi.validbox();
+        const auto phase_arr = phaseFab.const_array(mfi);
+        amrex::Box inlet_intersect = validBox & domain_lo_face;
+        if (!inlet_intersect.isEmpty()) {
+            amrex::LoopOnCpu(inlet_intersect, [&](int i, int j, int k) {
+                if (phase_arr(i, j, k, 0) == phaseID) {
+#ifdef AMREX_USE_OMP
+#pragma omp critical(inlet_seed_crit)
+#endif
+                    local_inlet_seeds.push_back(amrex::IntVect(i, j, k));
+                }
+            });
+        }
+        amrex::Box outlet_intersect = validBox & domain_hi_face;
+        if (!outlet_intersect.isEmpty()) {
+            amrex::LoopOnCpu(outlet_intersect, [&](int i, int j, int k) {
+                if (phase_arr(i, j, k, 0) == phaseID) {
+#ifdef AMREX_USE_OMP
+#pragma omp critical(outlet_seed_crit)
+#endif
+                    local_outlet_seeds.push_back(amrex::IntVect(i, j, k));
+                }
+            });
+        }
+    }
+    // Seed gathering logic
+    // <<< Address sign-compare warnings >>>
+    const size_t n_local_inlet_seeds = static_cast<size_t>(local_inlet_seeds.size());
+    std::vector<int> flat_local_inlet_seeds(n_local_inlet_seeds * AMREX_SPACEDIM);
+    for (size_t i = 0; i < n_local_inlet_seeds; ++i) {
+        for (int d = 0; d < AMREX_SPACEDIM; ++d)
+            flat_local_inlet_seeds[i * AMREX_SPACEDIM + d] = local_inlet_seeds[i][d];
+    }
+    const size_t n_local_outlet_seeds = static_cast<size_t>(local_outlet_seeds.size());
+    std::vector<int> flat_local_outlet_seeds(n_local_outlet_seeds * AMREX_SPACEDIM);
+    for (size_t i = 0; i < n_local_outlet_seeds; ++i) {
+        for (int d = 0; d < AMREX_SPACEDIM; ++d)
+            flat_local_outlet_seeds[i * AMREX_SPACEDIM + d] = local_outlet_seeds[i][d];
+    }
+    // MPI Allgather/v logic remains the same...
+    MPI_Comm comm = amrex::ParallelDescriptor::Communicator();
+    int mpi_size = amrex::ParallelDescriptor::NProcs();
+    int local_inlet_count = static_cast<int>(flat_local_inlet_seeds.size());
+    std::vector<int> recv_counts_inlet(mpi_size);
+    MPI_Allgather(&local_inlet_count, 1, MPI_INT, recv_counts_inlet.data(), 1, MPI_INT, comm);
+    int local_outlet_count = static_cast<int>(flat_local_outlet_seeds.size());
+    std::vector<int> recv_counts_outlet(mpi_size);
+    MPI_Allgather(&local_outlet_count, 1, MPI_INT, recv_counts_outlet.data(), 1, MPI_INT, comm);
+    std::vector<int> displacements_inlet(mpi_size, 0);
+    std::vector<int> displacements_outlet(mpi_size, 0);
+    int total_inlet_seeds = recv_counts_inlet[0];
+    int total_outlet_seeds = recv_counts_outlet[0];
+    for (int i = 1; i < mpi_size; ++i) {
+        displacements_inlet[i] = displacements_inlet[i - 1] + recv_counts_inlet[i - 1];
+        displacements_outlet[i] = displacements_outlet[i - 1] + recv_counts_outlet[i - 1];
+        total_inlet_seeds += recv_counts_inlet[i];
+        total_outlet_seeds += recv_counts_outlet[i];
+    }
+    std::vector<int> flat_inlet_seeds_gathered(total_inlet_seeds);
+    MPI_Allgatherv(flat_local_inlet_seeds.data(), local_inlet_count, MPI_INT,
+                   flat_inlet_seeds_gathered.data(), recv_counts_inlet.data(),
+                   displacements_inlet.data(), MPI_INT, comm);
+    std::vector<int> flat_outlet_seeds_gathered(total_outlet_seeds);
+    MPI_Allgatherv(flat_local_outlet_seeds.data(), local_outlet_count, MPI_INT,
+                   flat_outlet_seeds_gathered.data(), recv_counts_outlet.data(),
+                   displacements_outlet.data(), MPI_INT, comm);
+    amrex::Vector<amrex::IntVect> inlet_seeds;
+    inlet_seeds.reserve(total_inlet_seeds / AMREX_SPACEDIM);
+    for (size_t i = 0; i < flat_inlet_seeds_gathered.size(); i += AMREX_SPACEDIM) {
+        inlet_seeds.emplace_back(flat_inlet_seeds_gathered[i], flat_inlet_seeds_gathered[i + 1],
+                                 flat_inlet_seeds_gathered[i + 2]);
+    }
+    amrex::Vector<amrex::IntVect> outlet_seeds;
+    outlet_seeds.reserve(total_outlet_seeds / AMREX_SPACEDIM);
+    for (size_t i = 0; i < flat_outlet_seeds_gathered.size(); i += AMREX_SPACEDIM) {
+        outlet_seeds.emplace_back(flat_outlet_seeds_gathered[i], flat_outlet_seeds_gathered[i + 1],
+                                  flat_outlet_seeds_gathered[i + 2]);
+    }
+    // End seed gathering
 
-      // Flood fill logic remains the same...
-      std::sort(inlet_seeds.begin(), inlet_seeds.end());
-      inlet_seeds.erase(std::unique(inlet_seeds.begin(), inlet_seeds.end()), inlet_seeds.end());
-      std::sort(outlet_seeds.begin(), outlet_seeds.end());
-      outlet_seeds.erase(std::unique(outlet_seeds.begin(), outlet_seeds.end()), outlet_seeds.end());
+    // Flood fill logic remains the same...
+    std::sort(inlet_seeds.begin(), inlet_seeds.end());
+    inlet_seeds.erase(std::unique(inlet_seeds.begin(), inlet_seeds.end()), inlet_seeds.end());
+    std::sort(outlet_seeds.begin(), outlet_seeds.end());
+    outlet_seeds.erase(std::unique(outlet_seeds.begin(), outlet_seeds.end()), outlet_seeds.end());
 
-      if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-          amrex::Print() << "    generateActivityMask: Found " << inlet_seeds.size() << " unique inlet seeds." << std::endl;
-          amrex::Print() << "    generateActivityMask: Found " << outlet_seeds.size() << " unique outlet seeds." << std::endl;
-      }
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "    generateActivityMask: Found " << inlet_seeds.size()
+                       << " unique inlet seeds." << std::endl;
+        amrex::Print() << "    generateActivityMask: Found " << outlet_seeds.size()
+                       << " unique outlet seeds." << std::endl;
+    }
 
-      if (inlet_seeds.empty() || outlet_seeds.empty()) {
-          amrex::Warning("TortuosityHypre::generateActivityMask: No percolating path found (zero seeds on inlet or outlet face for the specified phase). Mask will be empty.");
-          m_mf_active_mask.setVal(cell_inactive);
-          m_mf_active_mask.FillBoundary(m_geom.periodicity());
-          m_active_vf = 0.0;
-          return;
-      }
+    if (inlet_seeds.empty() || outlet_seeds.empty()) {
+        amrex::Warning(
+            "TortuosityHypre::generateActivityMask: No percolating path found (zero seeds on inlet "
+            "or outlet face for the specified phase). Mask will be empty.");
+        m_mf_active_mask.setVal(cell_inactive);
+        m_mf_active_mask.FillBoundary(m_geom.periodicity());
+        m_active_vf = 0.0;
+        return;
+    }
 
-      if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "  Performing flood fill from inlet..." << std::endl;
-      parallelFloodFill(mf_reached_inlet, phaseFab, phaseID, inlet_seeds);
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "  Performing flood fill from inlet..." << std::endl;
+    parallelFloodFill(mf_reached_inlet, phaseFab, phaseID, inlet_seeds);
 
-      if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "  Performing flood fill from outlet..." << std::endl;
-      parallelFloodFill(mf_reached_outlet, phaseFab, phaseID, outlet_seeds);
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+        amrex::Print() << "  Performing flood fill from outlet..." << std::endl;
+    parallelFloodFill(mf_reached_outlet, phaseFab, phaseID, outlet_seeds);
 
-      m_mf_active_mask.setVal(cell_inactive);
-  #ifdef AMREX_USE_OMP
-  #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-  #endif
-      for (amrex::MFIter mfi(m_mf_active_mask, true); mfi.isValid(); ++mfi) {
-          const amrex::Box& tileBox = mfi.tilebox();
-          auto mask_arr = m_mf_active_mask.array(mfi);
-          const auto inlet_reach_arr = mf_reached_inlet.const_array(mfi);
-          const auto outlet_reach_arr = mf_reached_outlet.const_array(mfi);
-          amrex::LoopOnCpu(tileBox, [&](int i, int j, int k) {
-              if (inlet_reach_arr(i, j, k, 0) == cell_active && outlet_reach_arr(i, j, k, 0) == cell_active) {
-                  mask_arr(i, j, k, MaskComp) = cell_active;
-              } else {
-                  mask_arr(i, j, k, MaskComp) = cell_inactive;
-              }
-          });
-      }
-      m_mf_active_mask.FillBoundary(m_geom.periodicity());
+    m_mf_active_mask.setVal(cell_inactive);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(m_mf_active_mask, true); mfi.isValid(); ++mfi) {
+        const amrex::Box& tileBox = mfi.tilebox();
+        auto mask_arr = m_mf_active_mask.array(mfi);
+        const auto inlet_reach_arr = mf_reached_inlet.const_array(mfi);
+        const auto outlet_reach_arr = mf_reached_outlet.const_array(mfi);
+        amrex::LoopOnCpu(tileBox, [&](int i, int j, int k) {
+            if (inlet_reach_arr(i, j, k, 0) == cell_active &&
+                outlet_reach_arr(i, j, k, 0) == cell_active) {
+                mask_arr(i, j, k, MaskComp) = cell_active;
+            } else {
+                mask_arr(i, j, k, MaskComp) = cell_inactive;
+            }
+        });
+    }
+    m_mf_active_mask.FillBoundary(m_geom.periodicity());
 
-      // Debug plotfile writing remains the same...
-      bool write_debug_mask = false;
-      amrex::ParmParse pp_debug("debug");
-      pp_debug.query("write_active_mask", write_debug_mask);
-      if (write_debug_mask) { /* ... plotfile code ... */ }
+    // Debug plotfile writing remains the same...
+    bool write_debug_mask = false;
+    amrex::ParmParse pp_debug("debug");
+    pp_debug.query("write_active_mask", write_debug_mask);
+    if (write_debug_mask) { /* ... plotfile code ... */
+    }
 
-      // <<< CORRECTED: Use correct iMultiFab::sum call >>>
-      // Sum the number of active cells (value=1) in the mask component globally over valid cells
-      long num_active = m_mf_active_mask.sum(MaskComp); 
-      // <<< END CORRECTION >>>
+    // <<< CORRECTED: Use correct iMultiFab::sum call >>>
+    // Sum the number of active cells (value=1) in the mask component globally over valid cells
+    long num_active = m_mf_active_mask.sum(MaskComp);
+    // <<< END CORRECTION >>>
 
-      long total_cells = m_geom.Domain().numPts();
-      m_active_vf = (total_cells > 0) ? static_cast<amrex::Real>(num_active) / total_cells : 0.0;
+    long total_cells = m_geom.Domain().numPts();
+    m_active_vf = (total_cells > 0) ? static_cast<amrex::Real>(num_active) / total_cells : 0.0;
 
-      if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-           amrex::Print() << "  Active Volume Fraction (percolating phase " << m_phase << "): " << m_active_vf << std::endl;
-      }
+    if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  Active Volume Fraction (percolating phase " << m_phase
+                       << "): " << m_active_vf << std::endl;
+    }
 }
 
 // --- setupMatrixEquation ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::setupMatrixEquation()
-{
+void OpenImpala::TortuosityHypre::setupMatrixEquation() {
     BL_PROFILE("TortuosityHypre::setupMatrixEquation");
     HYPRE_Int ierr = 0;
 
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupMatrixEq: Creating HYPRE Matrix/Vectors..." << std::endl; }
-    ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, m_grid, m_stencil, &m_A); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructMatrixInitialize(m_A); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_b); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorInitialize(m_b); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorSetConstantValues(m_b, 0.0); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_x); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorInitialize(m_x); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorSetConstantValues(m_x, 0.0); HYPRE_CHECK(ierr);
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupMatrixEq: Creating HYPRE Matrix/Vectors..." << std::endl;
+    }
+    ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, m_grid, m_stencil, &m_A);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructMatrixInitialize(m_A);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_b);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorInitialize(m_b);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorSetConstantValues(m_b, 0.0);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorCreate(MPI_COMM_WORLD, m_grid, &m_x);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorInitialize(m_x);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorSetConstantValues(m_x, 0.0);
+    HYPRE_CHECK(ierr);
 
     const amrex::Box& domain = m_geom.Domain();
-    int stencil_indices[stencil_size] = {istn_c, istn_mx, istn_px, istn_my, istn_py, istn_mz, istn_pz};
+    int stencil_indices[stencil_size] = {istn_c,  istn_mx, istn_px, istn_my,
+                                         istn_py, istn_mz, istn_pz};
     const int dir_int = static_cast<int>(m_dir);
     amrex::Array<amrex::Real, AMREX_SPACEDIM> dxinv_sq;
     const amrex::Real* dx = m_geom.CellSize();
-    for(int i=0; i<AMREX_SPACEDIM; ++i) { dxinv_sq[i] = (dx[i] > 0.0) ? (1.0/dx[i]) * (1.0/dx[i]) : 0.0; }
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+        dxinv_sq[i] = (dx[i] > 0.0) ? (1.0 / dx[i]) * (1.0 / dx[i]) : 0.0;
+    }
 
     m_mf_active_mask.FillBoundary(m_geom.periodicity());
     m_mf_phase.FillBoundary(m_geom.periodicity());
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  setupMatrixEq: Calling tortuosity_fillmtx Fortran routine (using mask)..." << std::endl;
+        amrex::Print()
+            << "  setupMatrixEq: Calling tortuosity_fillmtx Fortran routine (using mask)..."
+            << std::endl;
     }
 
     std::vector<amrex::Real> matrix_values;
@@ -593,13 +645,14 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation()
     std::vector<amrex::Real> initial_guess;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) \
-                 private(matrix_values, rhs_values, initial_guess)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(matrix_values, rhs_values,       \
+                                                                      initial_guess)
 #endif
     for (amrex::MFIter mfi(m_mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.tilebox();
         const int npts = static_cast<int>(bx.numPts());
-        if (npts == 0) continue;
+        if (npts == 0)
+            continue;
 
         matrix_values.resize(static_cast<size_t>(npts) * stencil_size);
         rhs_values.resize(npts);
@@ -613,39 +666,56 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation()
         const int* mask_ptr = mask_iab.dataPtr(MaskComp);
         const auto& mask_box = mask_iab.box();
 
-        tortuosity_fillmtx(matrix_values.data(), rhs_values.data(), initial_guess.data(),
-                           &npts,
-                           p_ptr, pbox.loVect(), pbox.hiVect(),
-                           mask_ptr, mask_box.loVect(), mask_box.hiVect(),
-                           bx.loVect(), bx.hiVect(),
-                           domain.loVect(), domain.hiVect(),
-                           dxinv_sq.data(), &m_vlo, &m_vhi, &m_phase, &dir_int,
+        tortuosity_fillmtx(matrix_values.data(), rhs_values.data(), initial_guess.data(), &npts,
+                           p_ptr, pbox.loVect(), pbox.hiVect(), mask_ptr, mask_box.loVect(),
+                           mask_box.hiVect(), bx.loVect(), bx.hiVect(), domain.loVect(),
+                           domain.hiVect(), dxinv_sq.data(), &m_vlo, &m_vhi, &m_phase, &dir_int,
                            &m_verbose);
 
         // NaN/Inf check remains the same...
         bool data_ok = true;
-        for(size_t i = 0; i < matrix_values.size(); ++i) { if (std::isnan(matrix_values[i]) || std::isinf(matrix_values[i])) data_ok = false; }
-        for(size_t i = 0; i < rhs_values.size(); ++i) { if (std::isnan(rhs_values[i]) || std::isinf(rhs_values[i])) data_ok = false; }
-        if (!data_ok) { amrex::Warning("NaN/Inf detected in Fortran output before HYPRE SetBoxValues!"); }
+        for (size_t i = 0; i < matrix_values.size(); ++i) {
+            if (std::isnan(matrix_values[i]) || std::isinf(matrix_values[i]))
+                data_ok = false;
+        }
+        for (size_t i = 0; i < rhs_values.size(); ++i) {
+            if (std::isnan(rhs_values[i]) || std::isinf(rhs_values[i]))
+                data_ok = false;
+        }
+        if (!data_ok) {
+            amrex::Warning("NaN/Inf detected in Fortran output before HYPRE SetBoxValues!");
+        }
 
 
         auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
         auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
 
-        ierr = HYPRE_StructMatrixSetBoxValues(m_A, hypre_lo.data(), hypre_hi.data(), stencil_size, stencil_indices, matrix_values.data());
+        ierr = HYPRE_StructMatrixSetBoxValues(m_A, hypre_lo.data(), hypre_hi.data(), stencil_size,
+                                              stencil_indices, matrix_values.data());
         HYPRE_CHECK(ierr);
-        ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(), rhs_values.data());
+        ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(),
+                                              rhs_values.data());
         HYPRE_CHECK(ierr);
-        ierr = HYPRE_StructVectorSetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(), initial_guess.data());
+        ierr = HYPRE_StructVectorSetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
+                                              initial_guess.data());
         HYPRE_CHECK(ierr);
     }
-    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupMatrixEq: Finished MFIter loop." << std::endl; }
+    if (m_verbose > 2 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupMatrixEq: Finished MFIter loop." << std::endl;
+    }
 
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupMatrixEq: Assembling HYPRE Matrix/Vectors..." << std::endl; }
-    ierr = HYPRE_StructMatrixAssemble(m_A); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorAssemble(m_b); HYPRE_CHECK(ierr);
-    ierr = HYPRE_StructVectorAssemble(m_x); HYPRE_CHECK(ierr);
-    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  setupMatrixEq: Assembly complete." << std::endl; }
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupMatrixEq: Assembling HYPRE Matrix/Vectors..." << std::endl;
+    }
+    ierr = HYPRE_StructMatrixAssemble(m_A);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorAssemble(m_b);
+    HYPRE_CHECK(ierr);
+    ierr = HYPRE_StructVectorAssemble(m_x);
+    HYPRE_CHECK(ierr);
+    if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  setupMatrixEq: Assembly complete." << std::endl;
+    }
 }
 
 
@@ -662,45 +732,68 @@ bool OpenImpala::TortuosityHypre::solve() {
 
     // --- Solver setup logic ---
     if (m_solvertype == SolverType::FlexGMRES) {
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "  Setting up HYPRE FlexGMRES Solver with SMG Preconditioner..." << std::endl;
-        ierr = HYPRE_StructFlexGMRESCreate(MPI_COMM_WORLD, &solver); HYPRE_CHECK(ierr);
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor())
+            amrex::Print() << "  Setting up HYPRE FlexGMRES Solver with SMG Preconditioner..."
+                           << std::endl;
+        ierr = HYPRE_StructFlexGMRESCreate(MPI_COMM_WORLD, &solver);
+        HYPRE_CHECK(ierr);
         HYPRE_StructFlexGMRESSetTol(solver, m_eps);
         HYPRE_StructFlexGMRESSetMaxIter(solver, m_maxiter);
         HYPRE_StructFlexGMRESSetPrintLevel(solver, m_verbose > 1 ? 3 : 0);
         precond = NULL;
-        ierr = HYPRE_StructSMGCreate(MPI_COMM_WORLD, &precond); HYPRE_CHECK(ierr);
+        ierr = HYPRE_StructSMGCreate(MPI_COMM_WORLD, &precond);
+        HYPRE_CHECK(ierr);
         HYPRE_StructSMGSetTol(precond, 0.0);
         HYPRE_StructSMGSetMaxIter(precond, 1);
         HYPRE_StructSMGSetNumPreRelax(precond, 1);
         HYPRE_StructSMGSetNumPostRelax(precond, 1);
         HYPRE_StructSMGSetPrintLevel(precond, 0);
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "    SMG Preconditioner created." << std::endl; }
-        HYPRE_StructFlexGMRESSetPrecond(solver, HYPRE_StructSMGSolve, HYPRE_StructSMGSetup, precond);
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "    FlexGMRES Preconditioner set." << std::endl; }
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  Running HYPRE_StructFlexGMRESSetup..." << std::endl; }
-        ierr = HYPRE_StructFlexGMRESSetup(solver, m_A, m_b, m_x); HYPRE_CHECK(ierr);
-        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  Running HYPRE_StructFlexGMRESSolve..." << std::endl; }
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "    SMG Preconditioner created." << std::endl;
+        }
+        HYPRE_StructFlexGMRESSetPrecond(solver, HYPRE_StructSMGSolve, HYPRE_StructSMGSetup,
+                                        precond);
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "    FlexGMRES Preconditioner set." << std::endl;
+        }
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Running HYPRE_StructFlexGMRESSetup..." << std::endl;
+        }
+        ierr = HYPRE_StructFlexGMRESSetup(solver, m_A, m_b, m_x);
+        HYPRE_CHECK(ierr);
+        if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Running HYPRE_StructFlexGMRESSolve..." << std::endl;
+        }
         ierr = HYPRE_StructFlexGMRESSolve(solver, m_A, m_b, m_x);
-        if (ierr != 0 && ierr != HYPRE_ERROR_CONV) { HYPRE_CHECK(ierr); }
+        if (ierr != 0 && ierr != HYPRE_ERROR_CONV) {
+            HYPRE_CHECK(ierr);
+        }
         HYPRE_StructFlexGMRESGetNumIterations(solver, &m_num_iterations);
         HYPRE_StructFlexGMRESGetFinalRelativeResidualNorm(solver, &m_final_res_norm);
         m_converged = !(std::isnan(m_final_res_norm) || std::isinf(m_final_res_norm));
         m_converged = m_converged && (m_final_res_norm >= 0.0) && (m_final_res_norm <= m_eps);
-        if (ierr == HYPRE_ERROR_CONV && !m_converged && m_verbose >= 0) { amrex::Warning("HYPRE FlexGMRES solver did not converge within tolerance!"); }
-        else if (ierr != 0 && m_verbose >=0) { amrex::Warning("HYPRE FlexGMRES solver returned error code: " + std::to_string(ierr)); }
+        if (ierr == HYPRE_ERROR_CONV && !m_converged && m_verbose >= 0) {
+            amrex::Warning("HYPRE FlexGMRES solver did not converge within tolerance!");
+        } else if (ierr != 0 && m_verbose >= 0) {
+            amrex::Warning("HYPRE FlexGMRES solver returned error code: " + std::to_string(ierr));
+        }
         HYPRE_StructFlexGMRESDestroy(solver);
-        if (precond) HYPRE_StructSMGDestroy(precond);
+        if (precond)
+            HYPRE_StructSMGDestroy(precond);
     }
     // --- Add other solver cases if needed ---
     else {
-        amrex::Abort("Unsupported solver type requested in TortuosityHypre::solve: " + std::to_string(static_cast<int>(m_solvertype)));
+        amrex::Abort("Unsupported solver type requested in TortuosityHypre::solve: " +
+                     std::to_string(static_cast<int>(m_solvertype)));
     }
 
     // --- Post-solve checks and plotfile writing ---
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
         amrex::Print() << "  HYPRE Solver iterations: " << m_num_iterations << std::endl;
-        amrex::Print() << "  HYPRE Final Relative Residual Norm: " << std::scientific << m_final_res_norm << std::defaultfloat << std::endl;
-        amrex::Print() << "  Solver Converged Status: " << (m_converged ? "Yes" : "No") << std::endl;
+        amrex::Print() << "  HYPRE Final Relative Residual Norm: " << std::scientific
+                       << m_final_res_norm << std::defaultfloat << std::endl;
+        amrex::Print() << "  Solver Converged Status: " << (m_converged ? "Yes" : "No")
+                       << std::endl;
     }
     if (std::isnan(m_final_res_norm) || std::isinf(m_final_res_norm)) {
         amrex::Warning("HYPRE solve resulted in NaN or Inf residual norm!");
@@ -709,48 +802,60 @@ bool OpenImpala::TortuosityHypre::solve() {
     // Plotfile writing remains the same...
     if (m_write_plotfile && m_converged) {
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "  Writing solution plotfile..." << std::endl;
-         }
-         amrex::MultiFab mf_plot(m_ba, m_dm, numComponentsPhi, 0);
-         amrex::MultiFab mf_soln_temp(m_ba, m_dm, 1, 0);
-         mf_soln_temp.setVal(0.0);
-         std::vector<double> soln_buffer;
-         #ifdef AMREX_USE_OMP
-         #pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(soln_buffer)
-         #endif
-         for (amrex::MFIter mfi(mf_soln_temp, false); mfi.isValid(); ++mfi) {
-             const amrex::Box& bx = mfi.validbox();
-             const int npts = static_cast<int>(bx.numPts());
-             if (npts == 0) continue;
-             soln_buffer.resize(npts);
-             auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
-             auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
-             HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer.data());
-             if (get_ierr != 0) { amrex::Warning("HYPRE_StructVectorGetBoxValues failed during plotfile writing!"); }
-             amrex::Array4<amrex::Real> const soln_arr = mf_soln_temp.array(mfi);
-             long long k_lin_idx = 0;
-             amrex::LoopOnCpu(bx, [&](int ii, int jj, int kk) {
-                 if (k_lin_idx < npts) { soln_arr(ii,jj,kk, 0) = static_cast<amrex::Real>(soln_buffer[k_lin_idx]); }
-                 else { amrex::Warning("Buffer overrun detected during HYPRE GetBoxValues copy!"); }
-                 k_lin_idx++;
-             });
-            if (k_lin_idx != npts) { amrex::Warning("Point count mismatch during HYPRE GetBoxValues copy!"); }
-         }
-         amrex::MultiFab mf_mask_temp(m_ba, m_dm, 1, 0);
-         amrex::Copy(mf_mask_temp, m_mf_active_mask, MaskComp, 0, 1, 0);
-         amrex::MultiFab mf_phase_temp(m_ba, m_dm, 1, 0);
-         amrex::Copy(mf_phase_temp, m_mf_phase, 0, 0, 1, 0);
-         amrex::Copy(mf_plot, mf_soln_temp,   0, 0, 1, 0);
-         amrex::Copy(mf_plot, mf_phase_temp,  0, 1, 1, 0);
-         amrex::Copy(mf_plot, mf_mask_temp,   0, 2, 1, 0);
-         std::string plotfilename = m_resultspath + "/tortuosity_solution_" + std::to_string(static_cast<int>(m_dir));
-         amrex::Vector<std::string> varnames = {"solution_potential", "phase_id", "active_mask"};
-         amrex::WriteSingleLevelPlotfile(plotfilename, mf_plot, varnames, m_geom, 0.0, 0);
-         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "  Plotfile written to " << plotfilename << std::endl;}
-     } else if (m_write_plotfile && !m_converged) {
-         if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Warning("Skipping plotfile write because solver did not converge.");
-         }
+            amrex::Print() << "  Writing solution plotfile..." << std::endl;
+        }
+        amrex::MultiFab mf_plot(m_ba, m_dm, numComponentsPhi, 0);
+        amrex::MultiFab mf_soln_temp(m_ba, m_dm, 1, 0);
+        mf_soln_temp.setVal(0.0);
+        std::vector<double> soln_buffer;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(soln_buffer)
+#endif
+        for (amrex::MFIter mfi(mf_soln_temp, false); mfi.isValid(); ++mfi) {
+            const amrex::Box& bx = mfi.validbox();
+            const int npts = static_cast<int>(bx.numPts());
+            if (npts == 0)
+                continue;
+            soln_buffer.resize(npts);
+            auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
+            auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
+            HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(
+                m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer.data());
+            if (get_ierr != 0) {
+                amrex::Warning("HYPRE_StructVectorGetBoxValues failed during plotfile writing!");
+            }
+            amrex::Array4<amrex::Real> const soln_arr = mf_soln_temp.array(mfi);
+            long long k_lin_idx = 0;
+            amrex::LoopOnCpu(bx, [&](int ii, int jj, int kk) {
+                if (k_lin_idx < npts) {
+                    soln_arr(ii, jj, kk, 0) = static_cast<amrex::Real>(soln_buffer[k_lin_idx]);
+                } else {
+                    amrex::Warning("Buffer overrun detected during HYPRE GetBoxValues copy!");
+                }
+                k_lin_idx++;
+            });
+            if (k_lin_idx != npts) {
+                amrex::Warning("Point count mismatch during HYPRE GetBoxValues copy!");
+            }
+        }
+        amrex::MultiFab mf_mask_temp(m_ba, m_dm, 1, 0);
+        amrex::Copy(mf_mask_temp, m_mf_active_mask, MaskComp, 0, 1, 0);
+        amrex::MultiFab mf_phase_temp(m_ba, m_dm, 1, 0);
+        amrex::Copy(mf_phase_temp, m_mf_phase, 0, 0, 1, 0);
+        amrex::Copy(mf_plot, mf_soln_temp, 0, 0, 1, 0);
+        amrex::Copy(mf_plot, mf_phase_temp, 0, 1, 1, 0);
+        amrex::Copy(mf_plot, mf_mask_temp, 0, 2, 1, 0);
+        std::string plotfilename =
+            m_resultspath + "/tortuosity_solution_" + std::to_string(static_cast<int>(m_dir));
+        amrex::Vector<std::string> varnames = {"solution_potential", "phase_id", "active_mask"};
+        amrex::WriteSingleLevelPlotfile(plotfilename, mf_plot, varnames, m_geom, 0.0, 0);
+        if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Plotfile written to " << plotfilename << std::endl;
+        }
+    } else if (m_write_plotfile && !m_converged) {
+        if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Warning("Skipping plotfile write because solver did not converge.");
+        }
     }
     return m_converged;
 }
@@ -758,8 +863,7 @@ bool OpenImpala::TortuosityHypre::solve() {
 
 // --- Calculate Tortuosity Value (Calls Solve if needed) ---
 // <<< MODIFIED to use ACTIVE volume fraction >>>
-amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
-{
+amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh) {
     // If active VF is zero (checked in constructor), return NaN immediately.
     if (m_active_vf <= std::numeric_limits<amrex::Real>::epsilon() && !m_first_call) {
         return std::numeric_limits<amrex::Real>::quiet_NaN(); // Or Inf
@@ -768,19 +872,27 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
     if (m_first_call || refresh) {
         // Check again in case constructor exited early
         if (m_active_vf <= std::numeric_limits<amrex::Real>::epsilon()) {
-             if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                 amrex::Print() << "WARNING: Active volume fraction is zero. Tortuosity is NaN or Inf." << std::endl;
-             }
-             m_value = std::numeric_limits<amrex::Real>::quiet_NaN(); // Or Inf
-             m_first_call = false;
-             return m_value;
+            if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print()
+                    << "WARNING: Active volume fraction is zero. Tortuosity is NaN or Inf."
+                    << std::endl;
+            }
+            m_value = std::numeric_limits<amrex::Real>::quiet_NaN(); // Or Inf
+            m_first_call = false;
+            return m_value;
         }
 
-        if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "Calculating Tortuosity (solve required)..." << std::endl; }
+        if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "Calculating Tortuosity (solve required)..." << std::endl;
+        }
         bool solve_converged = solve(); // Call solve, which now sets m_converged
 
         if (!solve_converged) {
-            if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "WARNING: Solver did not converge or failed. Tortuosity calculation skipped, returning NaN." << std::endl; }
+            if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "WARNING: Solver did not converge or failed. Tortuosity "
+                                  "calculation skipped, returning NaN."
+                               << std::endl;
+            }
             m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
             m_first_call = false;
             return m_value;
@@ -794,7 +906,7 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
         constexpr amrex::Real flux_tol = 1.0e-6;
         bool flux_conserved = true;
         amrex::Real rel_diff = 0.0;
-        amrex::Real flux_mag_in  = std::abs(m_flux_in);
+        amrex::Real flux_mag_in = std::abs(m_flux_in);
         amrex::Real flux_mag_out = std::abs(m_flux_out);
         amrex::Real flux_mag_avg = 0.5 * (flux_mag_in + flux_mag_out);
         if (flux_mag_avg > tiny_flux_threshold) {
@@ -807,18 +919,26 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
             rel_diff = 0.0;
         }
         if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-             amrex::Print() << "  Flux Conservation Check (|in|-|out|) / avg(|in|,|out|):\n";
-             amrex::Print() << "    Flux In  = " << std::fixed << std::setprecision(8) << m_flux_in << "\n";
-             amrex::Print() << "    Flux Out = " << std::fixed << std::setprecision(8) << m_flux_out << "\n";
-             amrex::Print() << "    Relative Difference = " << std::scientific << rel_diff << std::defaultfloat << " (Tolerance = " << flux_tol << ")\n";
-             if (!flux_conserved) { amrex::Warning("Flux conservation check failed!"); }
-             else { amrex::Print() << "    Conservation Check Status: PASS\n"; }
+            amrex::Print() << "  Flux Conservation Check (|in|-|out|) / avg(|in|,|out|):\n";
+            amrex::Print() << "    Flux In  = " << std::fixed << std::setprecision(8) << m_flux_in
+                           << "\n";
+            amrex::Print() << "    Flux Out = " << std::fixed << std::setprecision(8) << m_flux_out
+                           << "\n";
+            amrex::Print() << "    Relative Difference = " << std::scientific << rel_diff
+                           << std::defaultfloat << " (Tolerance = " << flux_tol << ")\n";
+            if (!flux_conserved) {
+                amrex::Warning("Flux conservation check failed!");
+            } else {
+                amrex::Print() << "    Conservation Check Status: PASS\n";
+            }
         }
 
         // --- Calculate Tortuosity only if flux is conserved ---
         if (!flux_conserved) {
             if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "WARNING: Flux not conserved. Tortuosity calculation skipped, returning NaN." << std::endl;
+                amrex::Print()
+                    << "WARNING: Flux not conserved. Tortuosity calculation skipped, returning NaN."
+                    << std::endl;
             }
             m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
         } else {
@@ -831,12 +951,17 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
             amrex::Real L = m_geom.ProbLength(static_cast<int>(m_dir));
             amrex::Real A = 1.0;
             if (AMREX_SPACEDIM == 3) {
-                if (m_dir == OpenImpala::Direction::X) A = m_geom.ProbLength(1) * m_geom.ProbLength(2);
-                else if (m_dir == OpenImpala::Direction::Y) A = m_geom.ProbLength(0) * m_geom.ProbLength(2);
-                else A = m_geom.ProbLength(0) * m_geom.ProbLength(1);
+                if (m_dir == OpenImpala::Direction::X)
+                    A = m_geom.ProbLength(1) * m_geom.ProbLength(2);
+                else if (m_dir == OpenImpala::Direction::Y)
+                    A = m_geom.ProbLength(0) * m_geom.ProbLength(2);
+                else
+                    A = m_geom.ProbLength(0) * m_geom.ProbLength(1);
             } else if (AMREX_SPACEDIM == 2) {
-                 if (m_dir == OpenImpala::Direction::X) A = m_geom.ProbLength(1);
-                 else A = m_geom.ProbLength(0);
+                if (m_dir == OpenImpala::Direction::X)
+                    A = m_geom.ProbLength(1);
+                else
+                    A = m_geom.ProbLength(0);
             }
             amrex::Real gradPhi = (m_vhi - m_vlo) / L; // Assumes L > 0
             amrex::Real Deff = 0.0;
@@ -845,32 +970,39 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
             // Handle edge cases
             if (avg_flux_mag < tiny_flux_threshold) {
                 if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                    amrex::Print() << "WARNING: Average flux magnitude is near zero (" << avg_flux_mag << "). Tortuosity set to Inf (or NaN if ActiveVF=0)." << std::endl;
+                    amrex::Print()
+                        << "WARNING: Average flux magnitude is near zero (" << avg_flux_mag
+                        << "). Tortuosity set to Inf (or NaN if ActiveVF=0)." << std::endl;
                 }
                 // <<< CHANGE: Check vf_for_calc (active_vf) here >>>
-                m_value = (vf_for_calc > std::numeric_limits<amrex::Real>::epsilon()) ? std::numeric_limits<amrex::Real>::infinity() : std::numeric_limits<amrex::Real>::quiet_NaN();
+                m_value = (vf_for_calc > std::numeric_limits<amrex::Real>::epsilon())
+                              ? std::numeric_limits<amrex::Real>::infinity()
+                              : std::numeric_limits<amrex::Real>::quiet_NaN();
             }
             // <<< CHANGE: Check vf_for_calc (active_vf) here >>>
             else if (vf_for_calc <= std::numeric_limits<amrex::Real>::epsilon()) {
                 if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                    amrex::Print() << "WARNING: Active volume fraction is zero. Tortuosity set to NaN." << std::endl;
+                    amrex::Print()
+                        << "WARNING: Active volume fraction is zero. Tortuosity set to NaN."
+                        << std::endl;
                 }
                 m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
-            }
-            else if (std::abs(gradPhi) < tiny_flux_threshold) {
+            } else if (std::abs(gradPhi) < tiny_flux_threshold) {
                 if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                    amrex::Print() << "WARNING: Potential gradient is zero (vlo=vhi). Tortuosity set to Inf." << std::endl;
+                    amrex::Print()
+                        << "WARNING: Potential gradient is zero (vlo=vhi). Tortuosity set to Inf."
+                        << std::endl;
                 }
                 m_value = std::numeric_limits<amrex::Real>::infinity();
-            }
-            else {
+            } else {
                 // Calculate Deff using average flux magnitude
                 Deff = (avg_flux_mag / A) / std::abs(gradPhi);
                 if (std::abs(Deff) < tiny_flux_threshold) {
-                     if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                         amrex::Print() << "WARNING: Effective Diffusivity (Deff) is near zero (" << Deff << "). Tortuosity set to Inf." << std::endl;
-                     }
-                     m_value = std::numeric_limits<amrex::Real>::infinity();
+                    if (m_verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print() << "WARNING: Effective Diffusivity (Deff) is near zero ("
+                                       << Deff << "). Tortuosity set to Inf." << std::endl;
+                    }
+                    m_value = std::numeric_limits<amrex::Real>::infinity();
                 } else {
                     // <<< CHANGE: This calculation now uses active VF >>>
                     m_value = vf_for_calc / Deff;
@@ -879,9 +1011,11 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
 
             if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
                 // <<< CHANGE: Update print statement label >>>
-                amrex::Print() << "  Calculation Details: ActiveVf=" << vf_for_calc << ", L=" << L << ", A=" << A
-                               << ", gradPhi=" << gradPhi << ", AvgFluxMag=" << avg_flux_mag << ", Deff=" << Deff << std::endl;
-                amrex::Print() << "  Calculated Tortuosity (using Active Vf): " << m_value << std::endl;
+                amrex::Print() << "  Calculation Details: ActiveVf=" << vf_for_calc << ", L=" << L
+                               << ", A=" << A << ", gradPhi=" << gradPhi
+                               << ", AvgFluxMag=" << avg_flux_mag << ", Deff=" << Deff << std::endl;
+                amrex::Print() << "  Calculated Tortuosity (using Active Vf): " << m_value
+                               << std::endl;
             }
         } // End if flux_conserved
     } // End if m_first_call or refresh
@@ -896,87 +1030,160 @@ amrex::Real OpenImpala::TortuosityHypre::value(const bool refresh)
 bool OpenImpala::TortuosityHypre::checkMatrixProperties() {
     BL_PROFILE("TortuosityHypre::checkMatrixProperties");
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "TortuosityHypre: Checking assembled matrix/vector properties..." << std::endl;
+        amrex::Print() << "TortuosityHypre: Checking assembled matrix/vector properties..."
+                       << std::endl;
     }
     HYPRE_Int ierr = 0;
     bool checks_passed_local = true;
     const double tol = 1.e-14;
     HYPRE_Int hypre_stencil_size = stencil_size;
     HYPRE_Int stencil_indices_hypre[stencil_size];
-    for(int i=0; i<stencil_size; ++i) stencil_indices_hypre[i] = i;
+    for (int i = 0; i < stencil_size; ++i)
+        stencil_indices_hypre[i] = i;
     const int center_stencil_index = istn_c;
     const amrex::Box& domain = m_geom.Domain();
     const int idir = static_cast<int>(m_dir);
     std::vector<double> matrix_buffer;
     std::vector<double> rhs_buffer;
     m_mf_active_mask.FillBoundary(m_geom.periodicity());
-    #ifdef AMREX_USE_OMP
-    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) \
-                     reduction(&:checks_passed_local) \
-                     private(matrix_buffer, rhs_buffer)
-    #endif
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())                                          \
+    reduction(& : checks_passed_local) private(matrix_buffer, rhs_buffer)
+#endif
     for (amrex::MFIter mfi(m_mf_active_mask, true); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.tilebox();
         const int npts = static_cast<int>(bx.numPts());
-        if (npts == 0) continue;
+        if (npts == 0)
+            continue;
         matrix_buffer.resize(static_cast<size_t>(npts) * stencil_size);
         rhs_buffer.resize(npts);
         auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
         auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
         bool hypre_get_ok = true;
-        ierr = HYPRE_StructMatrixGetBoxValues(m_A, hypre_lo.data(), hypre_hi.data(), stencil_size, stencil_indices_hypre, matrix_buffer.data());
-        if (ierr != 0) { hypre_get_ok = false; }
-        ierr = HYPRE_StructVectorGetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(), rhs_buffer.data());
-        if (ierr != 0) { hypre_get_ok = false; }
+        ierr = HYPRE_StructMatrixGetBoxValues(m_A, hypre_lo.data(), hypre_hi.data(), stencil_size,
+                                              stencil_indices_hypre, matrix_buffer.data());
+        if (ierr != 0) {
+            hypre_get_ok = false;
+        }
+        ierr = HYPRE_StructVectorGetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(),
+                                              rhs_buffer.data());
+        if (ierr != 0) {
+            hypre_get_ok = false;
+        }
         if (!hypre_get_ok) {
             checks_passed_local = false;
-            if (m_verbose > 0) amrex::Print() << "CHECK FAILED: HYPRE_GetBoxValues error on rank " << amrex::ParallelDescriptor::MyProc() << " for box " << bx << std::endl;
+            if (m_verbose > 0)
+                amrex::Print() << "CHECK FAILED: HYPRE_GetBoxValues error on rank "
+                               << amrex::ParallelDescriptor::MyProc() << " for box " << bx
+                               << std::endl;
             continue;
         }
         const amrex::IArrayBox& mask_fab = m_mf_active_mask[mfi];
         amrex::Array4<const int> const mask_arr = mask_fab.const_array();
         long long linear_idx = 0;
-        amrex::LoopOnCpu(bx, [&](int i, int j, int k)
-        {
+        amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
             amrex::IntVect current_cell(i, j, k);
             size_t matrix_start_idx = linear_idx * stencil_size;
             double rhs_val = rhs_buffer[linear_idx];
             double diag_val = matrix_buffer[matrix_start_idx + center_stencil_index];
             bool has_nan_inf = std::isnan(rhs_val) || std::isinf(rhs_val);
-            for (int s = 0; s < stencil_size; ++s) { has_nan_inf = has_nan_inf || std::isnan(matrix_buffer[matrix_start_idx + s]) || std::isinf(matrix_buffer[matrix_start_idx + s]); }
-            if (has_nan_inf) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: NaN/Inf found at cell " << current_cell << std::endl; checks_passed_local = false; }
+            for (int s = 0; s < stencil_size; ++s) {
+                has_nan_inf = has_nan_inf || std::isnan(matrix_buffer[matrix_start_idx + s]) ||
+                              std::isinf(matrix_buffer[matrix_start_idx + s]);
+            }
+            if (has_nan_inf) {
+                if (m_verbose > 0)
+                    amrex::Print()
+                        << "CHECK FAILED: NaN/Inf found at cell " << current_cell << std::endl;
+                checks_passed_local = false;
+            }
             int cell_status = mask_arr(current_cell, MaskComp);
             bool is_dirichlet = false;
             if (cell_status == cell_active) {
                 if ((idir == 0 && (i == domain.smallEnd(0) || i == domain.bigEnd(0))) ||
                     (idir == 1 && (j == domain.smallEnd(1) || j == domain.bigEnd(1))) ||
                     (idir == 2 && (k == domain.smallEnd(2) || k == domain.bigEnd(2)))) {
-                     is_dirichlet = true;
+                    is_dirichlet = true;
                 }
             }
             if (cell_status == cell_inactive) {
-                if (std::abs(diag_val - 1.0) > tol || std::abs(rhs_val) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Inactive cell check fail at " << current_cell << " (Aii=" << diag_val << ", b=" << rhs_val << ")" << std::endl; checks_passed_local = false; }
-                for (int s=0; s<stencil_size; ++s) { if (s != center_stencil_index && std::abs(matrix_buffer[matrix_start_idx + s]) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Non-zero off-diag [" << s << "] at inactive cell " << current_cell << " (Aij=" << matrix_buffer[matrix_start_idx + s] << ")" << std::endl; checks_passed_local = false; }}
-            }
-            else if (is_dirichlet) {
-                double expected_rhs = ((idir == 0 && i == domain.smallEnd(0)) || (idir == 1 && j == domain.smallEnd(1)) || (idir == 2 && k == domain.smallEnd(2))) ? m_vlo : m_vhi;
-                if (std::abs(diag_val - 1.0) > tol || std::abs(rhs_val - expected_rhs) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Dirichlet cell check fail at " << current_cell << " (Aii=" << diag_val << ", b=" << rhs_val << ", exp_b=" << expected_rhs << ")" << std::endl; checks_passed_local = false; }
-                for (int s=0; s<stencil_size; ++s) { if (s != center_stencil_index && std::abs(matrix_buffer[matrix_start_idx + s]) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Non-zero off-diag [" << s << "] at Dirichlet cell " << current_cell << " (Aij=" << matrix_buffer[matrix_start_idx + s] << ")" << std::endl; checks_passed_local = false; }}
-            }
-            else { // Active Interior
-                if (diag_val <= tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Non-positive diagonal at active interior cell " << current_cell << " (Aii=" << diag_val << ")" << std::endl; checks_passed_local = false; }
-                if (std::abs(rhs_val) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Non-zero RHS at active interior cell " << current_cell << " (b=" << rhs_val << ")" << std::endl; checks_passed_local = false; }
+                if (std::abs(diag_val - 1.0) > tol || std::abs(rhs_val) > tol) {
+                    if (m_verbose > 0)
+                        amrex::Print()
+                            << "CHECK FAILED: Inactive cell check fail at " << current_cell
+                            << " (Aii=" << diag_val << ", b=" << rhs_val << ")" << std::endl;
+                    checks_passed_local = false;
+                }
+                for (int s = 0; s < stencil_size; ++s) {
+                    if (s != center_stencil_index &&
+                        std::abs(matrix_buffer[matrix_start_idx + s]) > tol) {
+                        if (m_verbose > 0)
+                            amrex::Print()
+                                << "CHECK FAILED: Non-zero off-diag [" << s << "] at inactive cell "
+                                << current_cell << " (Aij=" << matrix_buffer[matrix_start_idx + s]
+                                << ")" << std::endl;
+                        checks_passed_local = false;
+                    }
+                }
+            } else if (is_dirichlet) {
+                double expected_rhs = ((idir == 0 && i == domain.smallEnd(0)) ||
+                                       (idir == 1 && j == domain.smallEnd(1)) ||
+                                       (idir == 2 && k == domain.smallEnd(2)))
+                                          ? m_vlo
+                                          : m_vhi;
+                if (std::abs(diag_val - 1.0) > tol || std::abs(rhs_val - expected_rhs) > tol) {
+                    if (m_verbose > 0)
+                        amrex::Print() << "CHECK FAILED: Dirichlet cell check fail at "
+                                       << current_cell << " (Aii=" << diag_val << ", b=" << rhs_val
+                                       << ", exp_b=" << expected_rhs << ")" << std::endl;
+                    checks_passed_local = false;
+                }
+                for (int s = 0; s < stencil_size; ++s) {
+                    if (s != center_stencil_index &&
+                        std::abs(matrix_buffer[matrix_start_idx + s]) > tol) {
+                        if (m_verbose > 0)
+                            amrex::Print() << "CHECK FAILED: Non-zero off-diag [" << s
+                                           << "] at Dirichlet cell " << current_cell
+                                           << " (Aij=" << matrix_buffer[matrix_start_idx + s] << ")"
+                                           << std::endl;
+                        checks_passed_local = false;
+                    }
+                }
+            } else { // Active Interior
+                if (diag_val <= tol) {
+                    if (m_verbose > 0)
+                        amrex::Print()
+                            << "CHECK FAILED: Non-positive diagonal at active interior cell "
+                            << current_cell << " (Aii=" << diag_val << ")" << std::endl;
+                    checks_passed_local = false;
+                }
+                if (std::abs(rhs_val) > tol) {
+                    if (m_verbose > 0)
+                        amrex::Print() << "CHECK FAILED: Non-zero RHS at active interior cell "
+                                       << current_cell << " (b=" << rhs_val << ")" << std::endl;
+                    checks_passed_local = false;
+                }
                 double row_sum = 0.0;
-                for (int s = 0; s < stencil_size; ++s) { row_sum += matrix_buffer[matrix_start_idx + s]; }
-                if (std::abs(row_sum) > tol) { if (m_verbose > 0) amrex::Print() << "CHECK FAILED: Non-zero row sum at active interior cell " << current_cell << " (sum=" << row_sum << ")" << std::endl; checks_passed_local = false; }
+                for (int s = 0; s < stencil_size; ++s) {
+                    row_sum += matrix_buffer[matrix_start_idx + s];
+                }
+                if (std::abs(row_sum) > tol) {
+                    if (m_verbose > 0)
+                        amrex::Print() << "CHECK FAILED: Non-zero row sum at active interior cell "
+                                       << current_cell << " (sum=" << row_sum << ")" << std::endl;
+                    checks_passed_local = false;
+                }
             }
             linear_idx++;
         });
     }
     amrex::ParallelDescriptor::ReduceBoolAnd(checks_passed_local);
     if (m_verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) {
-        if (checks_passed_local) { amrex::Print() << "TortuosityHypre: Matrix/vector property checks passed." << std::endl; }
-        else { amrex::Print() << "TortuosityHypre: Matrix/vector property checks FAILED." << std::endl; }
+        if (checks_passed_local) {
+            amrex::Print() << "TortuosityHypre: Matrix/vector property checks passed." << std::endl;
+        } else {
+            amrex::Print() << "TortuosityHypre: Matrix/vector property checks FAILED." << std::endl;
+        }
     }
     return checks_passed_local;
 }
@@ -984,7 +1191,7 @@ bool OpenImpala::TortuosityHypre::checkMatrixProperties() {
 
 // --- getSolution ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::getSolution (amrex::MultiFab& soln, int ncomp) {
+void OpenImpala::TortuosityHypre::getSolution(amrex::MultiFab& soln, int ncomp) {
     amrex::Abort("TortuosityHypre::getSolution not fully implemented yet!");
 }
 
@@ -997,8 +1204,7 @@ void OpenImpala::TortuosityHypre::getCellTypes(amrex::MultiFab& phi, int ncomp) 
 
 // --- global_fluxes ---
 // Remains the same...
-void OpenImpala::TortuosityHypre::global_fluxes()
-{
+void OpenImpala::TortuosityHypre::global_fluxes() {
     BL_PROFILE("TortuosityHypre::global_fluxes");
     m_flux_in = 0.0;
     m_flux_out = 0.0;
@@ -1010,25 +1216,33 @@ void OpenImpala::TortuosityHypre::global_fluxes()
     amrex::MultiFab mf_soln_temp(m_ba, m_dm, 1, 1);
     mf_soln_temp.setVal(0.0);
     std::vector<double> soln_buffer;
-    #ifdef AMREX_USE_OMP
-    #pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(soln_buffer)
-    #endif
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) private(soln_buffer)
+#endif
     for (amrex::MFIter mfi(mf_soln_temp, false); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.validbox();
         const int npts = static_cast<int>(bx.numPts());
-        if (npts == 0) continue;
+        if (npts == 0)
+            continue;
         soln_buffer.resize(npts);
         auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
         auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
-        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer.data());
-        if (get_ierr != 0) { amrex::Warning("HYPRE_StructVectorGetBoxValues failed during flux calculation copy!"); }
+        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
+                                                            soln_buffer.data());
+        if (get_ierr != 0) {
+            amrex::Warning("HYPRE_StructVectorGetBoxValues failed during flux calculation copy!");
+        }
         amrex::Array4<amrex::Real> const soln_arr = mf_soln_temp.array(mfi);
         long long k_lin_idx = 0;
         amrex::LoopOnCpu(bx, [&](int ii, int jj, int kk) {
-             if (k_lin_idx < npts) { soln_arr(ii,jj,kk,0) = static_cast<amrex::Real>(soln_buffer[k_lin_idx]); }
-             k_lin_idx++;
+            if (k_lin_idx < npts) {
+                soln_arr(ii, jj, kk, 0) = static_cast<amrex::Real>(soln_buffer[k_lin_idx]);
+            }
+            k_lin_idx++;
         });
-        if (k_lin_idx != npts) { amrex::Warning("Point count mismatch during flux calc copy!"); }
+        if (k_lin_idx != npts) {
+            amrex::Warning("Point count mismatch during flux calc copy!");
+        }
     }
     mf_soln_temp.FillBoundary(m_geom.periodicity());
     m_mf_active_mask.FillBoundary(m_geom.periodicity());
@@ -1039,7 +1253,8 @@ void OpenImpala::TortuosityHypre::global_fluxes()
     amrex::Real local_active_cells_in = 0.0;
     amrex::Real local_active_cells_out = 0.0;
     const amrex::Real dx_dir = dx[idir];
-    if (dx_dir <= 0.0) amrex::Abort("Zero cell size in flux calculation direction!");
+    if (dx_dir <= 0.0)
+        amrex::Abort("Zero cell size in flux calculation direction!");
     amrex::IntVect shift = amrex::IntVect::TheDimensionVector(idir);
     if (amrex::ParallelDescriptor::IOProcessor() && m_verbose >= 3) {
         amrex::Print() << "\n--- START LIMITED DEBUG_FLUX (global_fluxes, verbose>=3) ---\n";
@@ -1047,10 +1262,10 @@ void OpenImpala::TortuosityHypre::global_fluxes()
     }
     const int max_debug_prints_per_tile = 5;
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion()) reduction(+:local_fxin, local_fxout, local_active_cells_in, local_active_cells_out)
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())                                          \
+    reduction(+ : local_fxin, local_fxout, local_active_cells_in, local_active_cells_out)
 #endif
-    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
+    for (amrex::MFIter mfi(m_mf_active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         int debug_print_count_in = 0;
         int debug_print_count_out = 0;
         const amrex::Box& tileBox = mfi.tilebox();
@@ -1065,13 +1280,13 @@ void OpenImpala::TortuosityHypre::global_fluxes()
 
         if (!lobox_face.isEmpty()) {
             amrex::LoopOnCpu(lobox_face, [&](int i, int j, int k) {
-                amrex::IntVect iv(i,j,k);
+                amrex::IntVect iv(i, j, k);
                 if (mask(iv) == cell_active) {
                     local_active_cells_in += 1.0;
                     amrex::IntVect iv_inner = iv + shift;
                     if (mask(iv_inner) == cell_active) {
                         amrex::Real val_bnd = soln(iv);
-                        amrex::Real val_in  = soln(iv_inner);
+                        amrex::Real val_in = soln(iv_inner);
                         amrex::Real grad = (val_in - val_bnd) / dx_dir;
                         amrex::Real flux = -grad;
                         local_fxin += flux;
@@ -1083,8 +1298,8 @@ void OpenImpala::TortuosityHypre::global_fluxes()
             });
         }
         if (!hibox_face.isEmpty()) {
-             amrex::LoopOnCpu(hibox_face, [&](int i, int j, int k) {
-                amrex::IntVect iv(i,j,k);
+            amrex::LoopOnCpu(hibox_face, [&](int i, int j, int k) {
+                amrex::IntVect iv(i, j, k);
                 int mask_val = mask(iv);
                 if (mask_val == cell_active) {
                     local_active_cells_out += 1.0;
@@ -1113,21 +1328,30 @@ void OpenImpala::TortuosityHypre::global_fluxes()
     long global_active_out = static_cast<long>(local_active_cells_out);
     if (amrex::ParallelDescriptor::IOProcessor()) {
         if (m_verbose > 1) {
-             amrex::Print() << "  Active boundary cell counts: In=" << global_active_in << ", Out=" << global_active_out << "\n";
+            amrex::Print() << "  Active boundary cell counts: In=" << global_active_in
+                           << ", Out=" << global_active_out << "\n";
         }
         if (m_verbose >= 3) {
-             amrex::Print() << "DEBUG_FLUX: After reduction: Summed_fxin=" << local_fxin << " Summed_fxout=" << local_fxout << "\n";
-             amrex::Print() << "--- END LIMITED DEBUG_FLUX (global_fluxes, verbose>=3) ---\n\n";
+            amrex::Print() << "DEBUG_FLUX: After reduction: Summed_fxin=" << local_fxin
+                           << " Summed_fxout=" << local_fxout << "\n";
+            amrex::Print() << "--- END LIMITED DEBUG_FLUX (global_fluxes, verbose>=3) ---\n\n";
         }
     }
     amrex::Real face_area_element = 1.0;
     if (AMREX_SPACEDIM == 3) {
-        if (idir == 0) { face_area_element = dx[1] * dx[2]; }
-        else if (idir == 1) { face_area_element = dx[0] * dx[2]; }
-        else { face_area_element = dx[0] * dx[1]; }
+        if (idir == 0) {
+            face_area_element = dx[1] * dx[2];
+        } else if (idir == 1) {
+            face_area_element = dx[0] * dx[2];
+        } else {
+            face_area_element = dx[0] * dx[1];
+        }
     } else if (AMREX_SPACEDIM == 2) {
-        if (idir == 0) { face_area_element = dx[1]; }
-        else { face_area_element = dx[0]; }
+        if (idir == 0) {
+            face_area_element = dx[1];
+        } else {
+            face_area_element = dx[0];
+        }
     }
     m_flux_in = local_fxin * face_area_element;
     m_flux_out = local_fxout * face_area_element;

--- a/src/props/TortuosityHypreFill_F.H
+++ b/src/props/TortuosityHypreFill_F.H
@@ -20,51 +20,48 @@ extern "C" {
  * to flow (Dirichlet). Uses grid spacing provided via 'dxinv'. Inactive cells
  * are decoupled (Aii=1, Aij=0, bi=0, xinit=0).
  *
- * @param[out]  a           Pointer to matrix coefficient array (size nval*7, flattened). Stencil: C,W,E,S,N,B,T assumed.
+ * @param[out]  a           Pointer to matrix coefficient array (size nval*7, flattened). Stencil:
+ * C,W,E,S,N,B,T assumed.
  * @param[out]  rhs         Pointer to RHS array (size nval).
  * @param[out]  xinit       Pointer to initial guess array (size nval).
- * @param[in]   nval        Pointer to number of points in the box (*bxlo to *bxhi). Passed by reference.
- * @param[in]   p           Pointer to phase data array (INTEGER). Accessed as 4D in Fortran. (May be optional if mask is sufficient).
+ * @param[in]   nval        Pointer to number of points in the box (*bxlo to *bxhi). Passed by
+ * reference.
+ * @param[in]   p           Pointer to phase data array (INTEGER). Accessed as 4D in Fortran. (May
+ * be optional if mask is sufficient).
  * @param[in]   p_lo        Pointer to lower bound of p array (Fortran indexing).
  * @param[in]   p_hi        Pointer to upper bound of p array (Fortran indexing, incl. ghosts).
  * @param[in]   active_mask Pointer to activity mask array (INTEGER, 1=active, 0=inactive). <<< NEW
  * @param[in]   mask_lo     Pointer to lower bound of active_mask array (Fortran indexing). <<< NEW
- * @param[in]   mask_hi     Pointer to upper bound of active_mask array (Fortran indexing, incl. ghosts). <<< NEW
+ * @param[in]   mask_hi     Pointer to upper bound of active_mask array (Fortran indexing, incl.
+ * ghosts). <<< NEW
  * @param[in]   bxlo        Pointer to lower bound of current box (Fortran indexing).
  * @param[in]   bxhi        Pointer to upper bound of current box (Fortran indexing).
  * @param[in]   domlo       Pointer to lower bound of domain (Fortran indexing).
  * @param[in]   domhi       Pointer to upper bound of domain (Fortran indexing).
- * @param[in]   dxinv       Pointer to array[3] of inverse grid spacing squared [1/dx^2, 1/dy^2, 1/dz^2].
+ * @param[in]   dxinv       Pointer to array[3] of inverse grid spacing squared [1/dx^2, 1/dy^2,
+ * 1/dz^2].
  * @param[in]   vlo         Pointer to low boundary value (Dirichlet BC). Passed by reference.
  * @param[in]   vhi         Pointer to high boundary value (Dirichlet BC). Passed by reference.
- * @param[in]   phase_unused Pointer to phase ID considered conductive (Now potentially unused by Fortran, as mask dictates activity). Passed by reference.
+ * @param[in]   phase_unused Pointer to phase ID considered conductive (Now potentially unused by
+ * Fortran, as mask dictates activity). Passed by reference.
  * @param[in]   dir         Pointer to direction index (0=X, 1=Y, 2=Z). Passed by reference.
  *
- * @warning Assumes Fortran uses 1-based indexing for components when accessing 'p' and 'active_mask'.
+ * @warning Assumes Fortran uses 1-based indexing for components when accessing 'p' and
+ * 'active_mask'.
  * @warning Ensure 'nval' matches the number of points in the box bxlo:bxhi.
- * @warning Assumed HYPRE stencil convention: Center,W,E,S,N,B,T matches Fortran indices 1..7 in calculation. Verify this!
+ * @warning Assumed HYPRE stencil convention: Center,W,E,S,N,B,T matches Fortran indices 1..7 in
+ * calculation. Verify this!
  */
-void tortuosity_fillmtx (
-    amrex_real* a,
-    amrex_real* rhs,
-    amrex_real* xinit,
-    const int* nval,
-    const int* p,
-    const int* p_lo,
-    const int* p_hi,
-    const int* active_mask, // <<< NEW
-    const int* mask_lo,     // <<< NEW
-    const int* mask_hi,     // <<< NEW
-    const int* bxlo,
-    const int* bxhi,
-    const int* domlo,
-    const int* domhi,
-    const amrex_real* dxinv,
-    const amrex_real* vlo,
-    const amrex_real* vhi,
-    const int* phase_unused, // <<< Renamed
-    const int* dir,
-    const int* debug_print_level // <<< ADDED THIS LINE
+void tortuosity_fillmtx(amrex_real* a, amrex_real* rhs, amrex_real* xinit, const int* nval,
+                        const int* p, const int* p_lo, const int* p_hi,
+                        const int* active_mask, // <<< NEW
+                        const int* mask_lo,     // <<< NEW
+                        const int* mask_hi,     // <<< NEW
+                        const int* bxlo, const int* bxhi, const int* domlo, const int* domhi,
+                        const amrex_real* dxinv, const amrex_real* vlo, const amrex_real* vhi,
+                        const int* phase_unused, // <<< Renamed
+                        const int* dir,
+                        const int* debug_print_level // <<< ADDED THIS LINE
 );
 
 #ifdef __cplusplus

--- a/src/props/Tortuosity_filcc_F.H
+++ b/src/props/Tortuosity_filcc_F.H
@@ -31,18 +31,19 @@ extern "C" {
  * @param[in]    q_lo   Pointer to lower corner of the q array Fortran bounds (incl. ghosts).
  * @param[in]    q_hi   Pointer to upper corner of the q array Fortran bounds (incl. ghosts).
  * @param[in]    q_ncomp Pointer to the number of components in array q.
- * @param[in]    p      Pointer to the input phase array data (INTEGER). Component comp_phase is read.
+ * @param[in]    p      Pointer to the input phase array data (INTEGER). Component comp_phase is
+ * read.
  * @param[in]    p_lo   Pointer to lower corner of the p array Fortran bounds (incl. ghosts).
  * @param[in]    p_hi   Pointer to upper corner of the p array Fortran bounds (incl. ghosts).
  * @param[in]    p_ncomp Pointer to the number of components in array p.
  * @param[in]    domlo  Pointer to the domain lower corner indices (Fortran indexing).
  * @param[in]    domhi  Pointer to the domain upper corner indices (Fortran indexing).
- * @param[in]    phase  Pointer to the integer ID of the phase considered 'free'. (Passed by reference).
+ * @param[in]    phase  Pointer to the integer ID of the phase considered 'free'. (Passed by
+ * reference).
  */
 void tortuosity_filct(amrex_real* q, const int* q_lo, const int* q_hi, const int* q_ncomp,
                       const int* p, const int* p_lo, const int* p_hi, const int* p_ncomp,
-                      const int* domlo, const int* domhi,
-                      const int* phase);
+                      const int* domlo, const int* domhi, const int* phase);
 
 /**
  * @brief Removes isolated single cells (islands) from a phase field.
@@ -53,7 +54,8 @@ void tortuosity_filct(amrex_real* q, const int* q_lo, const int* q_hi, const int
  * Uses -1 to denote neighbors outside the physical domain defined by domlo/domhi.
  * Assumes Fortran 1-based component indexing (comp_phase=1).
  *
- * @param[in,out] q      Pointer to the phase array data (INTEGER). Component comp_phase is modified.
+ * @param[in,out] q      Pointer to the phase array data (INTEGER). Component comp_phase is
+ * modified.
  * @param[in]    q_lo   Pointer to lower corner of the q array Fortran bounds (incl. ghosts).
  * @param[in]    q_hi   Pointer to upper corner of the q array Fortran bounds (incl. ghosts).
  * @param[in]    ncomp  Pointer to the number of components in array q.
@@ -62,9 +64,8 @@ void tortuosity_filct(amrex_real* q, const int* q_lo, const int* q_hi, const int
  * @param[in]    domlo  Pointer to the physical domain lower corner indices.
  * @param[in]    domhi  Pointer to the physical domain upper corner indices.
  */
-void tortuosity_remspot(int* q, const int* q_lo, const int* q_hi, const int* ncomp,
-                        const int* bxlo, const int* bxhi,
-                        const int* domlo, const int* domhi);
+void tortuosity_remspot(int* q, const int* q_lo, const int* q_hi, const int* ncomp, const int* bxlo,
+                        const int* bxhi, const int* domlo, const int* domhi);
 
 
 //-----------------------------------------------------------------------
@@ -87,12 +88,12 @@ void tortuosity_remspot(int* q, const int* q_lo, const int* q_hi, const int* nco
  * @param[in]    domhi  Pointer to the domain upper corner indices.
  * @param[in]    vlo    Pointer to the boundary value for low faces. (Passed by reference).
  * @param[in]    vhi    Pointer to the boundary value for high faces. (Passed by reference).
- * @param[in]    bc     Pointer to the boundary condition flags array [Fortran: bc(amrex_spacedim, 2)].
+ * @param[in]    bc     Pointer to the boundary condition flags array [Fortran: bc(amrex_spacedim,
+ * 2)].
  */
 void tortuosity_filbc(amrex_real* q, const int* q_lo, const int* q_hi, const int* ncomp,
-                      const int* domlo, const int* domhi,
-                      const amrex_real* vlo, const amrex_real* vhi,
-                      const int* bc);
+                      const int* domlo, const int* domhi, const amrex_real* vlo,
+                      const amrex_real* vhi, const int* bc);
 
 /**
  * @brief Fills the initial condition for the potential field in array 'q'.
@@ -107,7 +108,8 @@ void tortuosity_filbc(amrex_real* q, const int* q_lo, const int* q_hi, const int
  * @param[in]    q_lo   Pointer to lower corner of the q array Fortran bounds.
  * @param[in]    q_hi   Pointer to upper corner of the q array Fortran bounds.
  * @param[in]    ncomp  Pointer to the number of components in array q.
- * @param[in]    p      Pointer to the input phase array data (INTEGER). Component comp_phase is read.
+ * @param[in]    p      Pointer to the input phase array data (INTEGER). Component comp_phase is
+ * read.
  * @param[in]    p_lo   Pointer to lower corner of the p array Fortran bounds.
  * @param[in]    p_hi   Pointer to upper corner of the p array Fortran bounds.
  * @param[in]    p_ncomp Pointer to the number of components in array p.
@@ -115,17 +117,18 @@ void tortuosity_filbc(amrex_real* q, const int* q_lo, const int* q_hi, const int
  * @param[in]    hi     Pointer to upper corner of the valid box indices to fill.
  * @param[in]    domlo  Pointer to the domain lower corner indices.
  * @param[in]    domhi  Pointer to the domain upper corner indices.
- * @param[in]    vlo    Pointer to the boundary value at the low end for interpolation. (Passed by reference).
- * @param[in]    vhi    Pointer to the boundary value at the high end for interpolation. (Passed by reference).
+ * @param[in]    vlo    Pointer to the boundary value at the low end for interpolation. (Passed by
+ * reference).
+ * @param[in]    vhi    Pointer to the boundary value at the high end for interpolation. (Passed by
+ * reference).
  * @param[in]    phase  Pointer to the integer ID of the phase to initialize. (Passed by reference).
- * @param[in]    dir    Pointer to the direction index (0=X, 1=Y, 2=Z) for interpolation. (Passed by reference).
+ * @param[in]    dir    Pointer to the direction index (0=X, 1=Y, 2=Z) for interpolation. (Passed by
+ * reference).
  */
 void tortuosity_filic(amrex_real* q, const int* q_lo, const int* q_hi, const int* ncomp,
                       const int* p, const int* p_lo, const int* p_hi, const int* p_ncomp,
-                      const int* lo, const int* hi,
-                      const int* domlo, const int* domhi,
-                      const amrex_real* vlo, const amrex_real* vhi,
-                      const int* phase,
+                      const int* lo, const int* hi, const int* domlo, const int* domhi,
+                      const amrex_real* vlo, const amrex_real* vhi, const int* phase,
                       const int* dir);
 
 

--- a/src/props/Tortuosity_poisson_3d_F.H
+++ b/src/props/Tortuosity_poisson_3d_F.H
@@ -34,17 +34,19 @@ extern "C" {
  * @param[out] fz    Pointer to the Z-face flux array data (output).
  * @param[in] fzlo   Pointer to lower corner of the fz array Fortran bounds.
  * @param[in] fzhi   Pointer to upper corner of the fz array Fortran bounds.
- * @param[in] sol    Pointer to the input solution array data (contains phi at Fortran comp 1, cell type at Fortran comp 2).
- * @param[in] slo    Pointer to lower corner of the sol array Fortran bounds (including ghost cells).
- * @param[in] shi    Pointer to upper corner of the sol array Fortran bounds (including ghost cells).
+ * @param[in] sol    Pointer to the input solution array data (contains phi at Fortran comp 1, cell
+ * type at Fortran comp 2).
+ * @param[in] slo    Pointer to lower corner of the sol array Fortran bounds (including ghost
+ * cells).
+ * @param[in] shi    Pointer to upper corner of the sol array Fortran bounds (including ghost
+ * cells).
  * @param[in] dxinv  Pointer to array[3] of inverse cell sizes (1/dx, 1/dy, 1/dz).
  */
-void tortuosity_poisson_flux (const int* lo, const int* hi,
-                              amrex_real* fx, const int* fxlo, const int* fxhi,
-                              amrex_real* fy, const int* fylo, const int* fyhi,
-                              amrex_real* fz, const int* fzlo, const int* fzhi,
-                              const amrex_real* sol, const int* slo, const int* shi,
-                              const amrex_real* dxinv);
+void tortuosity_poisson_flux(const int* lo, const int* hi, amrex_real* fx, const int* fxlo,
+                             const int* fxhi, amrex_real* fy, const int* fylo, const int* fyhi,
+                             amrex_real* fz, const int* fzlo, const int* fzhi,
+                             const amrex_real* sol, const int* slo, const int* shi,
+                             const amrex_real* dxinv);
 
 
 //-----------------------------------------------------------------------
@@ -75,18 +77,19 @@ void tortuosity_poisson_flux (const int* lo, const int* hi,
  * @param[in] fz     Pointer to the Z-face flux array data (input).
  * @param[in] fzlo   Pointer to lower corner of the fz array Fortran bounds.
  * @param[in] fzhi   Pointer to upper corner of the fz array Fortran bounds.
- * @param[in] ncomp  Pointer to the number of components in p and n arrays. Passed by reference. <<< ADDED >>>
+ * @param[in] ncomp  Pointer to the number of components in p and n arrays. Passed by reference. <<<
+ * ADDED >>>
  * @param[in] dxinv  Pointer to array[3] of inverse cell sizes (1/dx, 1/dy, 1/dz).
- * @param[in] dt     Pointer to the time step (or relaxation factor). Passed by reference from Fortran default bind(c).
+ * @param[in] dt     Pointer to the time step (or relaxation factor). Passed by reference from
+ * Fortran default bind(c).
  */
-void tortuosity_poisson_update (const int* lo, const int* hi,
-                                const amrex_real* p, const int* plo, const int* phi,
-                                amrex_real* n, const int* nlo, const int* nhi,
-                                const amrex_real* fx, const int* fxlo, const int* fxhi,
-                                const amrex_real* fy, const int* fylo, const int* fyhi,
-                                const amrex_real* fz, const int* fzlo, const int* fzhi,
-                                const int* ncomp, // <<< ADDED ncomp argument >>>
-                                const amrex_real* dxinv, const amrex_real* dt);
+void tortuosity_poisson_update(const int* lo, const int* hi, const amrex_real* p, const int* plo,
+                               const int* phi, amrex_real* n, const int* nlo, const int* nhi,
+                               const amrex_real* fx, const int* fxlo, const int* fxhi,
+                               const amrex_real* fy, const int* fylo, const int* fyhi,
+                               const amrex_real* fz, const int* fzlo, const int* fzhi,
+                               const int* ncomp, // <<< ADDED ncomp argument >>>
+                               const amrex_real* dxinv, const amrex_real* dt);
 
 
 //-----------------------------------------------------------------------
@@ -112,15 +115,15 @@ void tortuosity_poisson_update (const int* lo, const int* hi,
  * @param[in] fz       Pointer to the Z-face flux array data (input).
  * @param[in] fzlo     Pointer to lower corner of the fz array Fortran bounds.
  * @param[in] fzhi     Pointer to upper corner of the fz array Fortran bounds.
- * @param[in] dir      Pointer to the direction index (0=X, 1=Y, 2=Z). Passed by reference from Fortran default bind(c).
+ * @param[in] dir      Pointer to the direction index (0=X, 1=Y, 2=Z). Passed by reference from
+ * Fortran default bind(c).
  * @param[out] flux_in Pointer to store the total flux entering on the low face (output).
  * @param[out] flux_out Pointer to store the total flux exiting on the high face (output).
  */
-void tortuosity_poisson_fio (const int* lo, const int* hi,
-                             const amrex_real* fx, const int* fxlo, const int* fxhi,
-                             const amrex_real* fy, const int* fylo, const int* fyhi,
-                             const amrex_real* fz, const int* fzlo, const int* fzhi,
-                             const int* dir, amrex_real* flux_in, amrex_real* flux_out);
+void tortuosity_poisson_fio(const int* lo, const int* hi, const amrex_real* fx, const int* fxlo,
+                            const int* fxhi, const amrex_real* fy, const int* fylo, const int* fyhi,
+                            const amrex_real* fz, const int* fzlo, const int* fzhi, const int* dir,
+                            amrex_real* flux_in, amrex_real* flux_out);
 
 
 #ifdef __cplusplus

--- a/src/props/VolumeFraction.H
+++ b/src/props/VolumeFraction.H
@@ -7,88 +7,89 @@
 
 namespace OpenImpala // Add appropriate namespace
 {
+/**
+ * @brief Computes the volume fraction of a specific phase within an amrex::iMultiFab.
+ *
+ * This class takes a reference to an integer MultiFab containing phase information
+ * (where phases are indicated by integer values) and provides a method to
+ * calculate the volume fraction of a specified phase.
+ *
+ * @note The calculation uses the valid regions of the input iMultiFab; ghost cells are ignored.
+ * @warning The user must ensure the iMultiFab passed to the constructor remains valid
+ * for the entire lifetime of the VolumeFraction object, as only a reference is stored.
+ */
+class VolumeFraction {
+public:
     /**
-     * @brief Computes the volume fraction of a specific phase within an amrex::iMultiFab.
+     * @brief Constructs a new VolumeFraction property calculator.
      *
-     * This class takes a reference to an integer MultiFab containing phase information
-     * (where phases are indicated by integer values) and provides a method to
-     * calculate the volume fraction of a specified phase.
+     * This constructor creates a VolumeFraction object linked to the provided phase data.
+     * The constructor itself performs minimal work.
      *
-     * @note The calculation uses the valid regions of the input iMultiFab; ghost cells are ignored.
-     * @warning The user must ensure the iMultiFab passed to the constructor remains valid
-     * for the entire lifetime of the VolumeFraction object, as only a reference is stored.
+     * @param fm The amrex::iMultiFab containing the phase information. Must remain valid for the
+     * lifetime of this object.
+     * @param phase The integer ID of the phase to calculate the volume fraction for.
+     * @param comp The component index within 'fm' containing the phase IDs (default: 0).
      */
-    class VolumeFraction
-    {
-      public:
-        /**
-         * @brief Constructs a new VolumeFraction property calculator.
-         *
-         * This constructor creates a VolumeFraction object linked to the provided phase data.
-         * The constructor itself performs minimal work.
-         *
-         * @param fm The amrex::iMultiFab containing the phase information. Must remain valid for the lifetime of this object.
-         * @param phase The integer ID of the phase to calculate the volume fraction for.
-         * @param comp The component index within 'fm' containing the phase IDs (default: 0).
-         */
-        explicit VolumeFraction(const amrex::iMultiFab& fm, const int phase = 0, int comp = 0);
+    explicit VolumeFraction(const amrex::iMultiFab& fm, const int phase = 0, int comp = 0);
 
-        // --- Rule of Five/Six: Prevent copying, allow default move/destruction ---
+    // --- Rule of Five/Six: Prevent copying, allow default move/destruction ---
 
-        /** @brief Deleted copy constructor (due to reference member). */
-        VolumeFraction(const VolumeFraction&) = delete;
+    /** @brief Deleted copy constructor (due to reference member). */
+    VolumeFraction(const VolumeFraction&) = delete;
 
-        /** @brief Deleted copy assignment operator (due to reference member). */
-        VolumeFraction& operator=(const VolumeFraction&) = delete;
+    /** @brief Deleted copy assignment operator (due to reference member). */
+    VolumeFraction& operator=(const VolumeFraction&) = delete;
 
-        /** @brief Default move constructor. */
-        VolumeFraction(VolumeFraction&&) = default;
+    /** @brief Default move constructor. */
+    VolumeFraction(VolumeFraction&&) = default;
 
-        /** @brief Default move assignment operator. */
-        VolumeFraction& operator=(VolumeFraction&&) = default;
+    /** @brief Default move assignment operator. */
+    VolumeFraction& operator=(VolumeFraction&&) = default;
 
-        /** @brief Default virtual destructor (safer if inherited from). */
-        virtual ~VolumeFraction() = default;
+    /** @brief Default virtual destructor (safer if inherited from). */
+    virtual ~VolumeFraction() = default;
 
-        // --- Computation Method ---
+    // --- Computation Method ---
 
-        /**
-         * @brief Computes the count of the specified phase and the total cell count.
-         *
-         * Iterates over the valid cells of the stored iMultiFab, counts cells matching
-         * the specified phase ID, and counts the total number of valid cells.
-         * Performs parallel reduction across MPI ranks unless 'local' is true.
-         * This operation can be costly depending on the grid size.
-         *
-         * @param[out] phase_count The number of cells belonging to the specified phase (local or global).
-         * @param[out] total_count The total number of cells considered (local or global).
-         * @param[in] local If true, compute counts using only data local to the current MPI rank
-         * (skips MPI reduction). If false (default), compute the global counts
-         * across all ranks.
-         */
-        void value(long long& phase_count, long long& total_count, bool local = false) const;
+    /**
+     * @brief Computes the count of the specified phase and the total cell count.
+     *
+     * Iterates over the valid cells of the stored iMultiFab, counts cells matching
+     * the specified phase ID, and counts the total number of valid cells.
+     * Performs parallel reduction across MPI ranks unless 'local' is true.
+     * This operation can be costly depending on the grid size.
+     *
+     * @param[out] phase_count The number of cells belonging to the specified phase (local or
+     * global).
+     * @param[out] total_count The total number of cells considered (local or global).
+     * @param[in] local If true, compute counts using only data local to the current MPI rank
+     * (skips MPI reduction). If false (default), compute the global counts
+     * across all ranks.
+     */
+    void value(long long& phase_count, long long& total_count, bool local = false) const;
 
-        // --- Optional: Convenience method to get VF directly ---
-        amrex::Real value_vf(bool local = false) const {
-           long long pc, tc;
-           value(pc, tc, local); // Call the method that returns counts
-           return (tc > 0) ? static_cast<amrex::Real>(pc) / tc : 0.0;
-        }
+    // --- Optional: Convenience method to get VF directly ---
+    amrex::Real value_vf(bool local = false) const {
+        long long pc, tc;
+        value(pc, tc, local); // Call the method that returns counts
+        return (tc > 0) ? static_cast<amrex::Real>(pc) / tc : 0.0;
+    }
 
-      private:
-        /** @brief Reference to the MultiFab with phase information (lifetime managed externally!). */
-        const amrex::iMultiFab& m_mf;
+private:
+    /** @brief Reference to the MultiFab with phase information (lifetime managed externally!). */
+    const amrex::iMultiFab& m_mf;
 
-        /** @brief Phase index to calculate the volume fraction for. */
-        const int m_phase;
+    /** @brief Phase index to calculate the volume fraction for. */
+    const int m_phase;
 
-        /** @brief Component index within m_mf containing phase data. */
-        const int m_comp;
+    /** @brief Component index within m_mf containing phase data. */
+    const int m_comp;
 
-        // Note: Constructor implementation (in .cpp or inline if desired) MUST use
-        // an initializer list:
-        // VolumeFraction::VolumeFraction(...) : m_mf(fm), m_phase(phase), m_comp(comp) {}
-    };
+    // Note: Constructor implementation (in .cpp or inline if desired) MUST use
+    // an initializer list:
+    // VolumeFraction::VolumeFraction(...) : m_mf(fm), m_phase(phase), m_comp(comp) {}
+};
 
 } // namespace OpenImpala
 

--- a/src/props/VolumeFraction.cpp
+++ b/src/props/VolumeFraction.cpp
@@ -7,20 +7,17 @@
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX.H>
 
-namespace OpenImpala
-{
+namespace OpenImpala {
 
 // Constructor remains the same...
 VolumeFraction::VolumeFraction(const amrex::iMultiFab& fm, const int phase, int comp)
-  : m_mf(fm), m_phase(phase), m_comp(comp)
-{
+    : m_mf(fm), m_phase(phase), m_comp(comp) {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_comp >= 0 && m_comp < m_mf.nComp(),
                                      "VolumeFraction: Component index out of bounds.");
 }
 
 // --- value() Method --- MODIFIED SIGNATURE
-void VolumeFraction::value(long long& phase_count, long long& total_count, bool local) const
-{
+void VolumeFraction::value(long long& phase_count, long long& total_count, bool local) const {
     // Use long long for counts to avoid overflow and for portability with MPI reductions
     long long local_phase_count = 0;
     long long local_total_count = 0;
@@ -30,26 +27,25 @@ void VolumeFraction::value(long long& phase_count, long long& total_count, bool 
     const int phase_comp = m_comp;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:local_phase_count, local_total_count)
+#pragma omp parallel reduction(+ : local_phase_count, local_total_count)
 #endif
-    for (amrex::MFIter mfi(m_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const amrex::Box& bx = mfi.tilebox(); // Use tilebox for potential OMP tiling
+    for (amrex::MFIter mfi(m_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();                // Use tilebox for potential OMP tiling
         const auto& fab = m_mf.const_array(mfi, phase_comp); // Get Array4 for the correct component
 
-        amrex::Loop(bx, [&] (int i, int j, int k) // Capture locals by reference for OMP reduction
-        {
-            if (fab(i, j, k) == target_phase) {
-                local_phase_count += 1; // Directly increment thread-local sum (OMP handles reduction)
-            }
-        });
+        amrex::Loop(bx, [&](int i, int j, int k) // Capture locals by reference for OMP reduction
+                    {
+                        if (fab(i, j, k) == target_phase) {
+                            local_phase_count +=
+                                1; // Directly increment thread-local sum (OMP handles reduction)
+                        }
+                    });
 
         local_total_count += bx.numPts(); // Add number of cells in this tilebox
     }
 
     // Perform parallel reduction across MPI ranks if global value is requested
-    if (!local)
-    {
+    if (!local) {
         // Use ParallelAllReduce to sum across all ranks into rank 0, then broadcast
         // Or simply sum across all ranks and leave the result on all ranks
         // ParallelAllReduce::Sum sums on all ranks.

--- a/src/props/hypre_test.cpp
+++ b/src/props/hypre_test.cpp
@@ -7,27 +7,29 @@
 #include <stdlib.h>
 
 // Simple HYPRE error checking macro
-#define HYPRE_CHECK_MSG(msg, ierr) do { \
-    if (ierr != 0) { \
-        char hypre_error_msg[256]; \
-        HYPRE_DescribeError(ierr, hypre_error_msg); \
-        fprintf(stderr, "FAIL: %s\n", msg); \
-        fprintf(stderr, "  HYPRE Error: %s (Code: %d)\n", hypre_error_msg, ierr); \
-        fflush(stderr); /* Ensure error message is printed */ \
-        MPI_Abort(MPI_COMM_WORLD, ierr); \
-    } else { \
-        /* Optional: Print PASS message only if needed, commented out by default */ \
-        /* printf("PASS: %s\n", msg); */ \
-    } \
-} while (0)
+#define HYPRE_CHECK_MSG(msg, ierr)                                                                 \
+    do {                                                                                           \
+        if (ierr != 0) {                                                                           \
+            char hypre_error_msg[256];                                                             \
+            HYPRE_DescribeError(ierr, hypre_error_msg);                                            \
+            fprintf(stderr, "FAIL: %s\n", msg);                                                    \
+            fprintf(stderr, "  HYPRE Error: %s (Code: %d)\n", hypre_error_msg, ierr);              \
+            fflush(stderr); /* Ensure error message is printed */                                  \
+            MPI_Abort(MPI_COMM_WORLD, ierr);                                                       \
+        } else {                                                                                   \
+            /* Optional: Print PASS message only if needed, commented out by default */            \
+            /* printf("PASS: %s\n", msg); */                                                       \
+        }                                                                                          \
+    } while (0)
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     int myid, num_procs;
     int ierr = 0;
     int final_exit_code = 0; // Use to track overall success/failure
 
     // Initialize MPI
-    printf("Calling MPI_Init...\n"); fflush(stdout);
+    printf("Calling MPI_Init...\n");
+    fflush(stdout);
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &myid);
     MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
@@ -42,10 +44,12 @@ int main(int argc, char *argv[]) {
     fflush(stdout); // Ensure output is flushed
 
     // Initialize HYPRE
-    printf("[%d] Calling HYPRE_Init...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_Init...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_Init();
     HYPRE_CHECK_MSG("HYPRE_Init", ierr);
-    printf("[%d] PASS: HYPRE_Init\n", myid); fflush(stdout);
+    printf("[%d] PASS: HYPRE_Init\n", myid);
+    fflush(stdout);
 
     // Declare HYPRE objects
     HYPRE_StructGrid grid = NULL;
@@ -54,10 +58,12 @@ int main(int argc, char *argv[]) {
 
     // --- Grid Setup ---
     const int ndim = 3;
-    printf("[%d] Calling HYPRE_StructGridCreate...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_StructGridCreate...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_StructGridCreate(MPI_COMM_WORLD, ndim, &grid);
     HYPRE_CHECK_MSG("HYPRE_StructGridCreate", ierr);
-    printf("[%d] PASS: HYPRE_StructGridCreate\n", myid); fflush(stdout);
+    printf("[%d] PASS: HYPRE_StructGridCreate\n", myid);
+    fflush(stdout);
 
     HYPRE_Int ilower[ndim] = {0, 0, 0};
     HYPRE_Int iupper[ndim] = {9, 9, 9}; // 10 points in each dim: 0..9
@@ -65,48 +71,61 @@ int main(int argc, char *argv[]) {
     // Assuming single process test - Rank 0 sets extents
     // For multi-process, each rank would set its own extents
     // if (myid == 0) { // For multi-process, remove this conditional
-        printf("[%d] Calling HYPRE_StructGridSetExtents...\n", myid); fflush(stdout);
-        ierr = HYPRE_StructGridSetExtents(grid, ilower, iupper);
-        HYPRE_CHECK_MSG("HYPRE_StructGridSetExtents", ierr);
-        printf("[%d] PASS: HYPRE_StructGridSetExtents\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_StructGridSetExtents...\n", myid);
+    fflush(stdout);
+    ierr = HYPRE_StructGridSetExtents(grid, ilower, iupper);
+    HYPRE_CHECK_MSG("HYPRE_StructGridSetExtents", ierr);
+    printf("[%d] PASS: HYPRE_StructGridSetExtents\n", myid);
+    fflush(stdout);
     // }
 
     // Barrier before assembling grid
-    printf("[%d] Calling MPI_Barrier before GridAssemble...\n", myid); fflush(stdout);
+    printf("[%d] Calling MPI_Barrier before GridAssemble...\n", myid);
+    fflush(stdout);
     MPI_Barrier(MPI_COMM_WORLD);
 
     // Assemble the grid
-    printf("[%d] Calling HYPRE_StructGridAssemble...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_StructGridAssemble...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_StructGridAssemble(grid);
     HYPRE_CHECK_MSG("HYPRE_StructGridAssemble", ierr);
-    printf("[%d] PASS: HYPRE_StructGridAssemble\n", myid); fflush(stdout);
+    printf("[%d] PASS: HYPRE_StructGridAssemble\n", myid);
+    fflush(stdout);
 
     // --- Stencil Setup ---
     const int stencil_size = 1;
-    printf("[%d] Calling HYPRE_StructStencilCreate...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_StructStencilCreate...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_StructStencilCreate(ndim, stencil_size, &stencil);
     HYPRE_CHECK_MSG("HYPRE_StructStencilCreate", ierr);
-    printf("[%d] PASS: HYPRE_StructStencilCreate\n", myid); fflush(stdout);
+    printf("[%d] PASS: HYPRE_StructStencilCreate\n", myid);
+    fflush(stdout);
 
     HYPRE_Int offsets[stencil_size][ndim] = {{0, 0, 0}}; // Center point only
     for (int j = 0; j < stencil_size; ++j) {
-        printf("[%d] Calling HYPRE_StructStencilSetElement (element %d)...\n", myid, j); fflush(stdout);
+        printf("[%d] Calling HYPRE_StructStencilSetElement (element %d)...\n", myid, j);
+        fflush(stdout);
         ierr = HYPRE_StructStencilSetElement(stencil, j, offsets[j]);
         HYPRE_CHECK_MSG("HYPRE_StructStencilSetElement", ierr);
-        printf("[%d] PASS: HYPRE_StructStencilSetElement (element %d)\n", myid, j); fflush(stdout);
+        printf("[%d] PASS: HYPRE_StructStencilSetElement (element %d)\n", myid, j);
+        fflush(stdout);
     }
 
     // --- Matrix Create and Initialize ---
-    printf("[%d] Calling HYPRE_StructMatrixCreate...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_StructMatrixCreate...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_StructMatrixCreate(MPI_COMM_WORLD, grid, stencil, &matrix);
     if (ierr == 0) {
-        printf("[%d] PASS: HYPRE_StructMatrixCreate\n", myid); fflush(stdout);
+        printf("[%d] PASS: HYPRE_StructMatrixCreate\n", myid);
+        fflush(stdout);
 
         // *** Initialize the matrix ***
-        printf("[%d] Calling HYPRE_StructMatrixInitialize...\n", myid); fflush(stdout);
+        printf("[%d] Calling HYPRE_StructMatrixInitialize...\n", myid);
+        fflush(stdout);
         ierr = HYPRE_StructMatrixInitialize(matrix);
         HYPRE_CHECK_MSG("HYPRE_StructMatrixInitialize", ierr); // Will abort if init fails
-        printf("[%d] PASS: HYPRE_StructMatrixInitialize\n", myid); fflush(stdout);
+        printf("[%d] PASS: HYPRE_StructMatrixInitialize\n", myid);
+        fflush(stdout);
 
         // If we reach here, Create and Initialize succeeded
         // We don't Assemble or SetValues in this simple test
@@ -120,44 +139,55 @@ int main(int argc, char *argv[]) {
     // --- Cleanup ---
     // Destroy Matrix only if it was successfully created and initialized
     if (matrix != NULL) { // Check handle is not NULL
-         printf("[%d] Calling HYPRE_StructMatrixDestroy...\n", myid); fflush(stdout);
-         ierr = HYPRE_StructMatrixDestroy(matrix);
-         HYPRE_CHECK_MSG("HYPRE_StructMatrixDestroy", ierr);
-         printf("[%d] PASS: HYPRE_StructMatrixDestroy\n", myid); fflush(stdout);
+        printf("[%d] Calling HYPRE_StructMatrixDestroy...\n", myid);
+        fflush(stdout);
+        ierr = HYPRE_StructMatrixDestroy(matrix);
+        HYPRE_CHECK_MSG("HYPRE_StructMatrixDestroy", ierr);
+        printf("[%d] PASS: HYPRE_StructMatrixDestroy\n", myid);
+        fflush(stdout);
     }
 
     // Destroy Stencil
     if (stencil != NULL) { // Check handle is not NULL
-        printf("[%d] Calling HYPRE_StructStencilDestroy...\n", myid); fflush(stdout);
+        printf("[%d] Calling HYPRE_StructStencilDestroy...\n", myid);
+        fflush(stdout);
         ierr = HYPRE_StructStencilDestroy(stencil);
         HYPRE_CHECK_MSG("HYPRE_StructStencilDestroy", ierr);
-        printf("[%d] PASS: HYPRE_StructStencilDestroy\n", myid); fflush(stdout);
+        printf("[%d] PASS: HYPRE_StructStencilDestroy\n", myid);
+        fflush(stdout);
     }
 
     // Destroy Grid
     if (grid != NULL) { // Check handle is not NULL
-        printf("[%d] Calling HYPRE_StructGridDestroy...\n", myid); fflush(stdout);
+        printf("[%d] Calling HYPRE_StructGridDestroy...\n", myid);
+        fflush(stdout);
         ierr = HYPRE_StructGridDestroy(grid);
         HYPRE_CHECK_MSG("HYPRE_StructGridDestroy", ierr);
-        printf("[%d] PASS: HYPRE_StructGridDestroy\n", myid); fflush(stdout);
+        printf("[%d] PASS: HYPRE_StructGridDestroy\n", myid);
+        fflush(stdout);
     }
 
     // Finalize HYPRE
-    printf("[%d] Calling HYPRE_Finalize...\n", myid); fflush(stdout);
+    printf("[%d] Calling HYPRE_Finalize...\n", myid);
+    fflush(stdout);
     ierr = HYPRE_Finalize();
     // Cannot use HYPRE_CHECK_MSG after Finalize as HYPRE error handling might be gone
     if (ierr != 0) {
-         fprintf(stderr, "[%d] Warning: HYPRE_Finalize returned error code %d\n", myid, ierr);
-         if (final_exit_code == 0) final_exit_code = 1; // Record error if none before
+        fprintf(stderr, "[%d] Warning: HYPRE_Finalize returned error code %d\n", myid, ierr);
+        if (final_exit_code == 0)
+            final_exit_code = 1; // Record error if none before
     } else {
-        printf("[%d] PASS: HYPRE_Finalize\n", myid); fflush(stdout);
+        printf("[%d] PASS: HYPRE_Finalize\n", myid);
+        fflush(stdout);
     }
 
     // Finalize MPI
-    printf("[%d] Calling MPI_Finalize...\n", myid); fflush(stdout);
+    printf("[%d] Calling MPI_Finalize...\n", myid);
+    fflush(stdout);
     MPI_Finalize();
 
     // Exit with appropriate code
-    printf("[%d] Exiting with code %d\n", myid, final_exit_code); fflush(stdout);
+    printf("[%d] Exiting with code %d\n", myid, final_exit_code);
+    fflush(stdout);
     return final_exit_code;
 }

--- a/src/props/tEffectiveDiffusivity.cpp
+++ b/src/props/tEffectiveDiffusivity.cpp
@@ -26,57 +26,65 @@
 
 namespace { // Anonymous namespace for test-local helpers
 
-    OpenImpala::Direction stringToDirection(const std::string& dir_str) {
-        std::string lower_dir_str = dir_str;
-        std::transform(lower_dir_str.begin(), lower_dir_str.end(), lower_dir_str.begin(),
-                       [](unsigned char c){ return std::tolower(c); });
-        if (lower_dir_str == "x") return OpenImpala::Direction::X;
-        if (lower_dir_str == "y") return OpenImpala::Direction::Y;
-        if (lower_dir_str == "z") return OpenImpala::Direction::Z;
-        amrex::Abort("Invalid direction string: " + dir_str + ". Use X, Y, or Z.");
-        return OpenImpala::Direction::X; 
-    }
+OpenImpala::Direction stringToDirection(const std::string& dir_str) {
+    std::string lower_dir_str = dir_str;
+    std::transform(lower_dir_str.begin(), lower_dir_str.end(), lower_dir_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_dir_str == "x")
+        return OpenImpala::Direction::X;
+    if (lower_dir_str == "y")
+        return OpenImpala::Direction::Y;
+    if (lower_dir_str == "z")
+        return OpenImpala::Direction::Z;
+    amrex::Abort("Invalid direction string: " + dir_str + ". Use X, Y, or Z.");
+    return OpenImpala::Direction::X;
+}
 
-    OpenImpala::EffectiveDiffusivityHypre::SolverType stringToSolverType(const std::string& solver_str) {
-        std::string lower_solver_str = solver_str;
-        std::transform(lower_solver_str.begin(), lower_solver_str.end(), lower_solver_str.begin(),
-                       [](unsigned char c){ return std::tolower(c); });
-        if (lower_solver_str == "jacobi") return OpenImpala::EffectiveDiffusivityHypre::SolverType::Jacobi;
-        if (lower_solver_str == "gmres") return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES;
-        if (lower_solver_str == "flexgmres") return OpenImpala::EffectiveDiffusivityHypre::SolverType::FlexGMRES;
-        if (lower_solver_str == "pcg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::PCG;
-        if (lower_solver_str == "bicgstab") return OpenImpala::EffectiveDiffusivityHypre::SolverType::BiCGSTAB;
-        if (lower_solver_str == "smg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::SMG;
-        if (lower_solver_str == "pfmg") return OpenImpala::EffectiveDiffusivityHypre::SolverType::PFMG;
-        amrex::Abort("Invalid solver string: '" + solver_str + "'.");
-        return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES; 
-    }
+OpenImpala::EffectiveDiffusivityHypre::SolverType
+stringToSolverType(const std::string& solver_str) {
+    std::string lower_solver_str = solver_str;
+    std::transform(lower_solver_str.begin(), lower_solver_str.end(), lower_solver_str.begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_solver_str == "jacobi")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::Jacobi;
+    if (lower_solver_str == "gmres")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES;
+    if (lower_solver_str == "flexgmres")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::FlexGMRES;
+    if (lower_solver_str == "pcg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::PCG;
+    if (lower_solver_str == "bicgstab")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::BiCGSTAB;
+    if (lower_solver_str == "smg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::SMG;
+    if (lower_solver_str == "pfmg")
+        return OpenImpala::EffectiveDiffusivityHypre::SolverType::PFMG;
+    amrex::Abort("Invalid solver string: '" + solver_str + "'.");
+    return OpenImpala::EffectiveDiffusivityHypre::SolverType::GMRES;
+}
 
-    void calculate_Deff_tensor_homogenization(
-    amrex::Real Deff_tensor[AMREX_SPACEDIM][AMREX_SPACEDIM],
-    const amrex::MultiFab& mf_chi_x_in,
-    const amrex::MultiFab& mf_chi_y_in,
-    const amrex::MultiFab& mf_chi_z_in,
-    const amrex::iMultiFab& active_mask, 
-    const amrex::Geometry& geom,
-    int verbose_level)
-{
-    BL_PROFILE("calculate_Deff_tensor_homogenization_reverted_omp"); 
+void calculate_Deff_tensor_homogenization(amrex::Real Deff_tensor[AMREX_SPACEDIM][AMREX_SPACEDIM],
+                                          const amrex::MultiFab& mf_chi_x_in,
+                                          const amrex::MultiFab& mf_chi_y_in,
+                                          const amrex::MultiFab& mf_chi_z_in,
+                                          const amrex::iMultiFab& active_mask,
+                                          const amrex::Geometry& geom, int verbose_level) {
+    BL_PROFILE("calculate_Deff_tensor_homogenization_reverted_omp");
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         for (int j = 0; j < AMREX_SPACEDIM; ++j) {
             Deff_tensor[i][j] = 0.0;
         }
     }
-    AMREX_ASSERT(mf_chi_x_in.nGrow() >= 1); 
+    AMREX_ASSERT(mf_chi_x_in.nGrow() >= 1);
     AMREX_ASSERT(mf_chi_y_in.nGrow() >= 1);
     if (AMREX_SPACEDIM == 3) {
-        AMREX_ASSERT(mf_chi_z_in.isDefined() && mf_chi_z_in.nGrow() >= 1); 
+        AMREX_ASSERT(mf_chi_z_in.isDefined() && mf_chi_z_in.nGrow() >= 1);
     }
-    AMREX_ASSERT(active_mask.nGrow() == 0); 
+    AMREX_ASSERT(active_mask.nGrow() == 0);
 
     const amrex::Real* dx_arr = geom.CellSize();
     amrex::Real inv_2dx[AMREX_SPACEDIM];
-    for (int i=0; i<AMREX_SPACEDIM; ++i) {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
         inv_2dx[i] = 1.0 / (2.0 * dx_arr[i]);
     }
 
@@ -88,55 +96,64 @@ namespace { // Anonymous namespace for test-local helpers
     }
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:sum_integrand_tensor_comp_local)
+#pragma omp parallel reduction(+ : sum_integrand_tensor_comp_local)
 #endif
-    for (amrex::MFIter mfi(active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const amrex::Box& bx = mfi.tilebox(); 
+    for (amrex::MFIter mfi(active_mask, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
         amrex::Array4<const int> const mask_arr = active_mask.const_array(mfi);
         amrex::Array4<const amrex::Real> const chi_x_arr = mf_chi_x_in.const_array(mfi);
         amrex::Array4<const amrex::Real> const chi_y_arr = mf_chi_y_in.const_array(mfi);
-        amrex::Array4<const amrex::Real> const chi_z_arr = (AMREX_SPACEDIM == 3 && mf_chi_z_in.isDefined()) ? 
-                                                           mf_chi_z_in.const_array(mfi) :
-                                                           mf_chi_x_in.const_array(mfi); 
+        amrex::Array4<const amrex::Real> const chi_z_arr =
+            (AMREX_SPACEDIM == 3 && mf_chi_z_in.isDefined()) ? mf_chi_z_in.const_array(mfi)
+                                                             : mf_chi_x_in.const_array(mfi);
 
-        amrex::LoopOnCpu(bx, [=, &sum_integrand_tensor_comp_local] (int i, int j, int k) noexcept
-        {
-            if (mask_arr(i,j,k,0) == 1) { 
+        amrex::LoopOnCpu(bx, [=, &sum_integrand_tensor_comp_local](int i, int j, int k) noexcept {
+            if (mask_arr(i, j, k, 0) == 1) {
                 amrex::Real grad_chi_x[AMREX_SPACEDIM] = {0.0};
                 amrex::Real grad_chi_y[AMREX_SPACEDIM] = {0.0};
                 amrex::Real grad_chi_z[AMREX_SPACEDIM] = {0.0};
 
-                grad_chi_x[0] = (chi_x_arr(i+1,j,k,0) - chi_x_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                grad_chi_x[1] = (chi_x_arr(i,j+1,k,0) - chi_x_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                if (AMREX_SPACEDIM == 3) grad_chi_x[2] = (chi_x_arr(i,j,k+1,0) - chi_x_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                grad_chi_x[0] =
+                    (chi_x_arr(i + 1, j, k, 0) - chi_x_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                grad_chi_x[1] =
+                    (chi_x_arr(i, j + 1, k, 0) - chi_x_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                if (AMREX_SPACEDIM == 3)
+                    grad_chi_x[2] =
+                        (chi_x_arr(i, j, k + 1, 0) - chi_x_arr(i, j, k - 1, 0)) * inv_2dx[2];
 
-                grad_chi_y[0] = (chi_y_arr(i+1,j,k,0) - chi_y_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                grad_chi_y[1] = (chi_y_arr(i,j+1,k,0) - chi_y_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                if (AMREX_SPACEDIM == 3) grad_chi_y[2] = (chi_y_arr(i,j,k+1,0) - chi_y_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                grad_chi_y[0] =
+                    (chi_y_arr(i + 1, j, k, 0) - chi_y_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                grad_chi_y[1] =
+                    (chi_y_arr(i, j + 1, k, 0) - chi_y_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                if (AMREX_SPACEDIM == 3)
+                    grad_chi_y[2] =
+                        (chi_y_arr(i, j, k + 1, 0) - chi_y_arr(i, j, k - 1, 0)) * inv_2dx[2];
 
                 if (AMREX_SPACEDIM == 3) {
-                    grad_chi_z[0] = (chi_z_arr(i+1,j,k,0) - chi_z_arr(i-1,j,k,0)) * inv_2dx[0]; 
-                    grad_chi_z[1] = (chi_z_arr(i,j+1,k,0) - chi_z_arr(i,j-1,k,0)) * inv_2dx[1]; 
-                    grad_chi_z[2] = (chi_z_arr(i,j,k+1,0) - chi_z_arr(i,j,k-1,0)) * inv_2dx[2]; 
+                    grad_chi_z[0] =
+                        (chi_z_arr(i + 1, j, k, 0) - chi_z_arr(i - 1, j, k, 0)) * inv_2dx[0];
+                    grad_chi_z[1] =
+                        (chi_z_arr(i, j + 1, k, 0) - chi_z_arr(i, j - 1, k, 0)) * inv_2dx[1];
+                    grad_chi_z[2] =
+                        (chi_z_arr(i, j, k + 1, 0) - chi_z_arr(i, j, k - 1, 0)) * inv_2dx[2];
                 }
 
-                sum_integrand_tensor_comp_local[0][0] += (1.0 - grad_chi_x[0]); 
-                sum_integrand_tensor_comp_local[0][1] += (    - grad_chi_y[0]); 
-                sum_integrand_tensor_comp_local[1][0] += (    - grad_chi_x[1]); 
-                sum_integrand_tensor_comp_local[1][1] += (1.0 - grad_chi_y[1]); 
+                sum_integrand_tensor_comp_local[0][0] += (1.0 - grad_chi_x[0]);
+                sum_integrand_tensor_comp_local[0][1] += (-grad_chi_y[0]);
+                sum_integrand_tensor_comp_local[1][0] += (-grad_chi_x[1]);
+                sum_integrand_tensor_comp_local[1][1] += (1.0 - grad_chi_y[1]);
 
                 if (AMREX_SPACEDIM == 3) {
-                    sum_integrand_tensor_comp_local[0][2] += (    - grad_chi_z[0]); 
-                    sum_integrand_tensor_comp_local[2][0] += (    - grad_chi_x[2]); 
-                    sum_integrand_tensor_comp_local[1][2] += (    - grad_chi_z[1]); 
-                    sum_integrand_tensor_comp_local[2][1] += (    - grad_chi_y[2]); 
-                    sum_integrand_tensor_comp_local[2][2] += (1.0 - grad_chi_z[2]); 
+                    sum_integrand_tensor_comp_local[0][2] += (-grad_chi_z[0]);
+                    sum_integrand_tensor_comp_local[2][0] += (-grad_chi_x[2]);
+                    sum_integrand_tensor_comp_local[1][2] += (-grad_chi_z[1]);
+                    sum_integrand_tensor_comp_local[2][1] += (-grad_chi_y[2]);
+                    sum_integrand_tensor_comp_local[2][2] += (1.0 - grad_chi_z[2]);
                 }
             }
         });
     }
-    
+
     for (int r = 0; r < AMREX_SPACEDIM; ++r) {
         for (int c = 0; c < AMREX_SPACEDIM; ++c) {
             amrex::ParallelDescriptor::ReduceRealSum(sum_integrand_tensor_comp_local[r][c]);
@@ -147,24 +164,25 @@ namespace { // Anonymous namespace for test-local helpers
     if (N_total_cells_in_domain > 0) {
         for (int l_idx = 0; l_idx < AMREX_SPACEDIM; ++l_idx) {
             for (int m_idx = 0; m_idx < AMREX_SPACEDIM; ++m_idx) {
-                Deff_tensor[l_idx][m_idx] = sum_integrand_tensor_comp_local[l_idx][m_idx] / static_cast<amrex::Real>(N_total_cells_in_domain);
+                Deff_tensor[l_idx][m_idx] = sum_integrand_tensor_comp_local[l_idx][m_idx] /
+                                            static_cast<amrex::Real>(N_total_cells_in_domain);
             }
         }
     } else {
-         if (amrex::ParallelDescriptor::IOProcessor() && verbose_level > 0) {
+        if (amrex::ParallelDescriptor::IOProcessor() && verbose_level > 0) {
             amrex::Warning("Total cells in domain is zero, D_eff cannot be calculated.");
-         }
+        }
     }
 
-     if (verbose_level > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-         amrex::Print() << "  [TestCalcDeff SIGN CORRECTED] Raw summed (1-dchi_x_dx): " << sum_integrand_tensor_comp_local[0][0]
-                        << ", N_total_cells: " << N_total_cells_in_domain << std::endl;
+    if (verbose_level > 1 && amrex::ParallelDescriptor::IOProcessor()) {
+        amrex::Print() << "  [TestCalcDeff SIGN CORRECTED] Raw summed (1-dchi_x_dx): "
+                       << sum_integrand_tensor_comp_local[0][0]
+                       << ", N_total_cells: " << N_total_cells_in_domain << std::endl;
     }
 }
 } // end anonymous namespace
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
     int hypre_ierr = HYPRE_Init();
     if (hypre_ierr != 0) {
         fprintf(stderr, "FATAL ERROR: HYPRE_Init() failed with code %d\n", hypre_ierr);
@@ -206,110 +224,123 @@ int main (int argc, char* argv[])
             amrex::Print() << "  Threshold Value:   " << threshold_val << "\n";
             amrex::Print() << "  Solver:            " << solver_str << "\n";
             amrex::Print() << "  Box Size:          " << box_size << "\n";
-            amrex::Print() << "  Write Plotfile:    " << (write_plotfile != 0 ? "Yes" : "No") << "\n";
+            amrex::Print() << "  Write Plotfile:    " << (write_plotfile != 0 ? "Yes" : "No")
+                           << "\n";
             amrex::Print() << "  Verbose Level:     " << verbose << "\n";
             amrex::Print() << "----------------------------------------------\n\n";
         }
 
         // --- FillBoundary Test Block (Commented out as it served its purpose) ---
         /*
-        amrex::Geometry geom_orig_periodic; 
-        amrex::BoxArray ba_fb_test;       
-        amrex::DistributionMapping dm_fb_test; 
+        amrex::Geometry geom_orig_periodic;
+        amrex::BoxArray ba_fb_test;
+        amrex::DistributionMapping dm_fb_test;
 
-        OpenImpala::TiffReader reader_fb_test(tifffile); 
+        OpenImpala::TiffReader reader_fb_test(tifffile);
         const amrex::Box domain_box_fb_test = reader_fb_test.box();
         amrex::RealBox rb_fb_test({AMREX_D_DECL(0.0, 0.0, 0.0)},
                                   {AMREX_D_DECL(amrex::Real(domain_box_fb_test.length(0)),
                                                 amrex::Real(domain_box_fb_test.length(1)),
                                                 amrex::Real(domain_box_fb_test.length(2)))});
-        amrex::Array<int, AMREX_SPACEDIM> is_periodic_fb_test{AMREX_D_DECL(1, 1, 1)}; 
+        amrex::Array<int, AMREX_SPACEDIM> is_periodic_fb_test{AMREX_D_DECL(1, 1, 1)};
         geom_orig_periodic.define(domain_box_fb_test, &rb_fb_test, 0, is_periodic_fb_test.data());
 
         ba_fb_test.define(domain_box_fb_test);
-        ba_fb_test.maxSize(box_size); 
+        ba_fb_test.maxSize(box_size);
         dm_fb_test.define(ba_fb_test);
 
-        amrex::iMultiFab mf_fb_test(ba_fb_test, dm_fb_test, 1, 1); 
-        mf_fb_test.setVal(0); 
+        amrex::iMultiFab mf_fb_test(ba_fb_test, dm_fb_test, 1, 1);
+        mf_fb_test.setVal(0);
 
         long calculated_expected_sum_fb_test = 0;
         for (amrex::MFIter mfi(mf_fb_test); mfi.isValid(); ++mfi) {
             const amrex::Box& vbox = mfi.validbox();
             amrex::Array4<int> const arr = mf_fb_test.array(mfi);
-            long local_s = 0; 
+            long local_s = 0;
             amrex::LoopOnCpu(vbox, [&](int i, int j, int k) {
-                if ((i + j + k) % 2 == 0) { 
-                    arr(i,j,k) = 1; 
+                if ((i + j + k) % 2 == 0) {
+                    arr(i,j,k) = 1;
                     local_s++;
                 } else {
-                    arr(i,j,k) = 0; 
+                    arr(i,j,k) = 0;
                 }
             });
-            calculated_expected_sum_fb_test += local_s; 
+            calculated_expected_sum_fb_test += local_s;
         }
         amrex::ParallelDescriptor::ReduceLongSum(calculated_expected_sum_fb_test);
         if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "DEBUG FillBoundary Test: Calculated sum of 1s in valid cells (manual loop) = " << calculated_expected_sum_fb_test << std::endl;
+            amrex::Print() << "DEBUG FillBoundary Test: Calculated sum of 1s in valid cells (manual
+        loop) = " << calculated_expected_sum_fb_test << std::endl;
         }
 
-        long sum_before_fb_mfsum = mf_fb_test.sum(0,true); 
+        long sum_before_fb_mfsum = mf_fb_test.sum(0,true);
         amrex::ParallelDescriptor::ReduceLongSum(sum_before_fb_mfsum);
         if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "DEBUG FillBoundary Test: Sum of valid cells BEFORE FillBoundary (using mf.sum())= " << sum_before_fb_mfsum << std::endl;
+            amrex::Print() << "DEBUG FillBoundary Test: Sum of valid cells BEFORE FillBoundary
+        (using mf.sum())= " << sum_before_fb_mfsum << std::endl;
         }
-         if (sum_before_fb_mfsum != calculated_expected_sum_fb_test && amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Warning("DEBUG FillBoundary Test: mf.sum() BEFORE FillBoundary MISMATCHES manual sum!");
+         if (sum_before_fb_mfsum != calculated_expected_sum_fb_test &&
+        amrex::ParallelDescriptor::IOProcessor()) { amrex::Warning("DEBUG FillBoundary Test:
+        mf.sum() BEFORE FillBoundary MISMATCHES manual sum!");
         }
 
         mf_fb_test.FillBoundary(geom_orig_periodic.periodicity());
 
-        long sum_after_fb_mfsum = mf_fb_test.sum(0,true); 
+        long sum_after_fb_mfsum = mf_fb_test.sum(0,true);
         amrex::ParallelDescriptor::ReduceLongSum(sum_after_fb_mfsum);
         if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "DEBUG FillBoundary Test: Sum of valid cells AFTER FillBoundary (using mf.sum())= " << sum_after_fb_mfsum << std::endl;
+            amrex::Print() << "DEBUG FillBoundary Test: Sum of valid cells AFTER FillBoundary (using
+        mf.sum())= " << sum_after_fb_mfsum << std::endl;
         }
 
-        long manual_sum_after_fb = ::ManualSumIMultiFab(mf_fb_test, 0, 1); // Use helper in anon namespace
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            amrex::Print() << "DEBUG FillBoundary Test: Manual sum of valid cells AFTER FillBoundary = " << manual_sum_after_fb << std::endl;
-            if (sum_after_fb_mfsum != manual_sum_after_fb) {
-                 amrex::Warning("DEBUG FillBoundary Test: mf.sum() AFTER FillBoundary MISMATCHES manual sum!");
+        long manual_sum_after_fb = ::ManualSumIMultiFab(mf_fb_test, 0, 1); // Use helper in anon
+        namespace if (amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "DEBUG
+        FillBoundary Test: Manual sum of valid cells AFTER FillBoundary = " << manual_sum_after_fb
+        << std::endl; if (sum_after_fb_mfsum != manual_sum_after_fb) { amrex::Warning("DEBUG
+        FillBoundary Test: mf.sum() AFTER FillBoundary MISMATCHES manual sum!");
             }
-            if (manual_sum_after_fb != calculated_expected_sum_fb_test) { 
-                amrex::Warning("DEBUG FillBoundary Test: Manual sum of VALID cells CHANGED by FillBoundary!");
-            } else {
-                 amrex::Print() << "DEBUG FillBoundary Test: Manual sum of valid cells UNCHANGED by FillBoundary." << std::endl;
+            if (manual_sum_after_fb != calculated_expected_sum_fb_test) {
+                amrex::Warning("DEBUG FillBoundary Test: Manual sum of VALID cells CHANGED by
+        FillBoundary!"); } else { amrex::Print() << "DEBUG FillBoundary Test: Manual sum of valid
+        cells UNCHANGED by FillBoundary." << std::endl;
             }
         }
-        // if (amrex::ParallelDescriptor::IOProcessor()) amrex::Abort("Stopping after FillBoundary test");
+        // if (amrex::ParallelDescriptor::IOProcessor()) amrex::Abort("Stopping after FillBoundary
+        test");
         */
         // --- End of FillBoundary Test Block ---
 
 
         // --- Actual Simulation Setup ---
-        OpenImpala::EffectiveDiffusivityHypre::SolverType solver_type = stringToSolverType(solver_str);
-        amrex::Geometry geom_main_sim; 
+        OpenImpala::EffectiveDiffusivityHypre::SolverType solver_type =
+            stringToSolverType(solver_str);
+        amrex::Geometry geom_main_sim;
         amrex::BoxArray ba_main_sim;
         amrex::DistributionMapping dm_main_sim;
         amrex::iMultiFab mf_phase_input;
 
         try {
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Reading metadata from " << tifffile << "...\n";
-            OpenImpala::TiffReader reader_main(tifffile); 
-            if (!reader_main.isRead()) { throw std::runtime_error("TiffReader failed to read metadata."); }
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Reading metadata from " << tifffile << "...\n";
+            OpenImpala::TiffReader reader_main(tifffile);
+            if (!reader_main.isRead()) {
+                throw std::runtime_error("TiffReader failed to read metadata.");
+            }
             const amrex::Box domain_box_main = reader_main.box();
-            if (domain_box_main.isEmpty()) { throw std::runtime_error("TiffReader returned empty domain box."); }
+            if (domain_box_main.isEmpty()) {
+                throw std::runtime_error("TiffReader returned empty domain box.");
+            }
             amrex::RealBox rb_main({AMREX_D_DECL(0.0, 0.0, 0.0)},
-                              {AMREX_D_DECL(amrex::Real(domain_box_main.length(0)),
-                                            amrex::Real(domain_box_main.length(1)),
-                                            amrex::Real(domain_box_main.length(2)))});
-            
-            amrex::Array<int, AMREX_SPACEDIM> is_periodic_sim{AMREX_D_DECL(1, 1, 1)}; // Main sim is periodic
-            
-            if (amrex::ParallelDescriptor::IOProcessor() && verbose > 1) { 
-                 amrex::Print() << "  MAIN SIM: Setting geom to be "
-                                << (is_periodic_sim[0] ? "PERIODIC" : "NON-PERIODIC") << std::endl;
+                                   {AMREX_D_DECL(amrex::Real(domain_box_main.length(0)),
+                                                 amrex::Real(domain_box_main.length(1)),
+                                                 amrex::Real(domain_box_main.length(2)))});
+
+            amrex::Array<int, AMREX_SPACEDIM> is_periodic_sim{
+                AMREX_D_DECL(1, 1, 1)}; // Main sim is periodic
+
+            if (amrex::ParallelDescriptor::IOProcessor() && verbose > 1) {
+                amrex::Print() << "  MAIN SIM: Setting geom to be "
+                               << (is_periodic_sim[0] ? "PERIODIC" : "NON-PERIODIC") << std::endl;
             }
             geom_main_sim.define(domain_box_main, &rb_main, 0, is_periodic_sim.data());
 
@@ -319,11 +350,15 @@ int main (int argc, char* argv[])
 
             mf_phase_input.define(ba_main_sim, dm_main_sim, 1, 1);
             amrex::iMultiFab mf_temp_no_ghost(ba_main_sim, dm_main_sim, 1, 0);
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << " Thresholding data...\n"; }
-            reader_main.threshold(threshold_val, phase_id_param, (phase_id_param == 0 ? 1 : 0), mf_temp_no_ghost);
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Thresholding data...\n";
+            }
+            reader_main.threshold(threshold_val, phase_id_param, (phase_id_param == 0 ? 1 : 0),
+                                  mf_temp_no_ghost);
             amrex::Copy(mf_phase_input, mf_temp_no_ghost, 0, 0, 1, 0);
             mf_phase_input.FillBoundary(geom_main_sim.periodicity());
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Grid and phase data setup complete.\n";
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Grid and phase data setup complete.\n";
 
         } catch (const std::exception& e) {
             amrex::Print() << "Error during TiffReader/grid setup: " << e.what() << std::endl;
@@ -338,83 +373,95 @@ int main (int argc, char* argv[])
         amrex::MultiFab mf_chi_x(ba_main_sim, dm_main_sim, 1, 1);
         amrex::MultiFab mf_chi_y(ba_main_sim, dm_main_sim, 1, 1);
         amrex::MultiFab mf_chi_z;
-        if (AMREX_SPACEDIM == 3) mf_chi_z.define(ba_main_sim, dm_main_sim, 1, 1);
+        if (AMREX_SPACEDIM == 3)
+            mf_chi_z.define(ba_main_sim, dm_main_sim, 1, 1);
 
-        std::vector<OpenImpala::Direction> directions_to_solve = {
-            OpenImpala::Direction::X, OpenImpala::Direction::Y
-        };
+        std::vector<OpenImpala::Direction> directions_to_solve = {OpenImpala::Direction::X,
+                                                                  OpenImpala::Direction::Y};
         if (AMREX_SPACEDIM == 3) {
             directions_to_solve.push_back(OpenImpala::Direction::Z);
         }
 
         for (const auto& dir_k : directions_to_solve) {
-            std::string dir_k_str = (dir_k == OpenImpala::Direction::X) ? "X" :
-                                    (dir_k == OpenImpala::Direction::Y) ? "Y" : "Z";
+            std::string dir_k_str = (dir_k == OpenImpala::Direction::X)   ? "X"
+                                    : (dir_k == OpenImpala::Direction::Y) ? "Y"
+                                                                          : "Z";
             if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "\n--- Solving for Corrector Function chi_" << dir_k_str << " ---\n";
+                amrex::Print() << "\n--- Solving for Corrector Function chi_" << dir_k_str
+                               << " ---\n";
             }
             std::unique_ptr<OpenImpala::EffectiveDiffusivityHypre> eff_diff_solver;
             try {
                 eff_diff_solver = std::make_unique<OpenImpala::EffectiveDiffusivityHypre>(
-                    geom_main_sim, ba_main_sim, dm_main_sim, mf_phase_input,
-                    phase_id_param, dir_k, solver_type, resultsdir,
-                    verbose, (write_plotfile != 0)
-                );
+                    geom_main_sim, ba_main_sim, dm_main_sim, mf_phase_input, phase_id_param, dir_k,
+                    solver_type, resultsdir, verbose, (write_plotfile != 0));
                 if (!eff_diff_solver->solve()) {
-                     if (verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
-                        amrex::Print() << "  WARNING: Solver for chi_" << dir_k_str << " DID NOT CONVERGE.\n";
+                    if (verbose >= 0 && amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print()
+                            << "  WARNING: Solver for chi_" << dir_k_str << " DID NOT CONVERGE.\n";
                     }
                     all_solves_converged = false;
-                    if (dir_k == OpenImpala::Direction::X) mf_chi_x.setVal(0.0);
-                    else if (dir_k == OpenImpala::Direction::Y) mf_chi_y.setVal(0.0);
-                    else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z) mf_chi_z.setVal(0.0);
+                    if (dir_k == OpenImpala::Direction::X)
+                        mf_chi_x.setVal(0.0);
+                    else if (dir_k == OpenImpala::Direction::Y)
+                        mf_chi_y.setVal(0.0);
+                    else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z)
+                        mf_chi_z.setVal(0.0);
                 } else {
-                     if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                    if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
                         amrex::Print() << "  Solver for chi_" << dir_k_str << " CONVERGED.\n";
                     }
-                    if (dir_k == OpenImpala::Direction::X) eff_diff_solver->getChiSolution(mf_chi_x);
-                    else if (dir_k == OpenImpala::Direction::Y) eff_diff_solver->getChiSolution(mf_chi_y);
-                    else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z) eff_diff_solver->getChiSolution(mf_chi_z);
+                    if (dir_k == OpenImpala::Direction::X)
+                        eff_diff_solver->getChiSolution(mf_chi_x);
+                    else if (dir_k == OpenImpala::Direction::Y)
+                        eff_diff_solver->getChiSolution(mf_chi_y);
+                    else if (AMREX_SPACEDIM == 3 && dir_k == OpenImpala::Direction::Z)
+                        eff_diff_solver->getChiSolution(mf_chi_z);
                 }
             } catch (const std::exception& e) {
-                amrex::Print() << "  ERROR during EffectiveDiffusivityHypre construction or solve for chi_"
-                               << dir_k_str << ": " << e.what() << std::endl;
+                amrex::Print()
+                    << "  ERROR during EffectiveDiffusivityHypre construction or solve for chi_"
+                    << dir_k_str << ": " << e.what() << std::endl;
                 all_solves_converged = false;
-                 test_passed_overall = false; 
+                test_passed_overall = false;
             }
         }
 
         amrex::Real Deff_tensor_vals[AMREX_SPACEDIM][AMREX_SPACEDIM];
-        for(int r=0; r<AMREX_SPACEDIM; ++r) for(int c=0; c<AMREX_SPACEDIM; ++c) Deff_tensor_vals[r][c] = 0.0;
+        for (int r = 0; r < AMREX_SPACEDIM; ++r)
+            for (int c = 0; c < AMREX_SPACEDIM; ++c)
+                Deff_tensor_vals[r][c] = 0.0;
 
         if (all_solves_converged) {
             if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
                 amrex::Print() << "\n--- Calculating D_eff Tensor from Converged Chi Fields ---\n";
             }
 
-            amrex::iMultiFab active_mask_for_deff(ba_main_sim, dm_main_sim, 1, 0); 
-            #ifdef AMREX_USE_OMP
-            #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-            #endif
-            for (amrex::MFIter mfi(active_mask_for_deff, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::iMultiFab active_mask_for_deff(ba_main_sim, dm_main_sim, 1, 0);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(active_mask_for_deff, amrex::TilingIfNotGPU()); mfi.isValid();
+                 ++mfi) {
                 const amrex::Box& tilebox = mfi.tilebox();
                 amrex::Array4<int> const mask_arr = active_mask_for_deff.array(mfi);
                 amrex::Array4<const int> const phase_arr = mf_phase_input.const_array(mfi);
-                amrex::LoopOnCpu(tilebox, [=] (int i, int j, int k) noexcept {
-                    mask_arr(i,j,k,0) = (phase_arr(i,j,k,0) == phase_id_param) ? 1 : 0;
+                amrex::LoopOnCpu(tilebox, [=](int i, int j, int k) noexcept {
+                    mask_arr(i, j, k, 0) = (phase_arr(i, j, k, 0) == phase_id_param) ? 1 : 0;
                 });
             }
 
-            calculate_Deff_tensor_homogenization(Deff_tensor_vals,
-                                                 mf_chi_x, mf_chi_y, mf_chi_z,
+            calculate_Deff_tensor_homogenization(Deff_tensor_vals, mf_chi_x, mf_chi_y, mf_chi_z,
                                                  active_mask_for_deff, geom_main_sim, verbose);
 
             if (amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "Effective Diffusivity Tensor D_eff / D_material (D_material=1 assumed):\n";
+                amrex::Print()
+                    << "Effective Diffusivity Tensor D_eff / D_material (D_material=1 assumed):\n";
                 for (int i_row = 0; i_row < AMREX_SPACEDIM; ++i_row) {
                     amrex::Print() << "  [";
                     for (int j_col = 0; j_col < AMREX_SPACEDIM; ++j_col) {
-                        amrex::Print() << std::scientific << std::setprecision(8) << Deff_tensor_vals[i_row][j_col]
+                        amrex::Print() << std::scientific << std::setprecision(8)
+                                       << Deff_tensor_vals[i_row][j_col]
                                        << (j_col == AMREX_SPACEDIM - 1 ? "" : ", ");
                     }
                     amrex::Print() << "]\n";
@@ -423,53 +470,69 @@ int main (int argc, char* argv[])
                 bool symmetry_ok = true;
                 amrex::Real sym_tol = 1e-7;
 
-                if (std::abs(Deff_tensor_vals[0][1] - Deff_tensor_vals[1][0]) > sym_tol) symmetry_ok = false;
+                if (std::abs(Deff_tensor_vals[0][1] - Deff_tensor_vals[1][0]) > sym_tol)
+                    symmetry_ok = false;
                 if (AMREX_SPACEDIM == 3) {
-                    if (std::abs(Deff_tensor_vals[0][2] - Deff_tensor_vals[2][0]) > sym_tol) symmetry_ok = false;
-                    if (std::abs(Deff_tensor_vals[1][2] - Deff_tensor_vals[2][1]) > sym_tol) symmetry_ok = false;
+                    if (std::abs(Deff_tensor_vals[0][2] - Deff_tensor_vals[2][0]) > sym_tol)
+                        symmetry_ok = false;
+                    if (std::abs(Deff_tensor_vals[1][2] - Deff_tensor_vals[2][1]) > sym_tol)
+                        symmetry_ok = false;
                 }
 
                 if (!symmetry_ok) {
                     amrex::Warning("D_eff tensor is not symmetric within tolerance!");
                     test_passed_overall = false;
                 } else {
-                    if (verbose >=1) amrex::Print() << "  D_eff tensor symmetry check: PASS\n";
+                    if (verbose >= 1)
+                        amrex::Print() << "  D_eff tensor symmetry check: PASS\n";
                 }
 
-                for (int d=0; d < AMREX_SPACEDIM; ++d) {
-                    if (Deff_tensor_vals[d][d] < 0.0) { 
-                        amrex::Warning("D_eff diagonal component D_" + std::to_string(d) + std::to_string(d) +
+                for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                    if (Deff_tensor_vals[d][d] < 0.0) {
+                        amrex::Warning("D_eff diagonal component D_" + std::to_string(d) +
+                                       std::to_string(d) +
                                        " is negative: " + std::to_string(Deff_tensor_vals[d][d]));
-                         test_passed_overall = false; 
-                    } else if (Deff_tensor_vals[d][d] >= 1.0 && verbose > 0) { // Only warn if verbose
-                        amrex::Print() << "  INFO: D_eff diagonal component D_" + std::to_string(d) + std::to_string(d) +
-                                       " is >= 1.0: " + std::to_string(Deff_tensor_vals[d][d]) + 
-                                       " (This might be plausible depending on definition and problem scale)." << std::endl;
+                        test_passed_overall = false;
+                    } else if (Deff_tensor_vals[d][d] >= 1.0 &&
+                               verbose > 0) { // Only warn if verbose
+                        amrex::Print()
+                            << "  INFO: D_eff diagonal component D_" + std::to_string(d) +
+                                   std::to_string(d) +
+                                   " is >= 1.0: " + std::to_string(Deff_tensor_vals[d][d]) +
+                                   " (This might be plausible depending on definition and problem "
+                                   "scale)."
+                            << std::endl;
                     }
                 }
             }
         } else {
             if (amrex::ParallelDescriptor::IOProcessor()) {
-                amrex::Print() << "Skipping D_eff tensor calculation due to chi_k solver non-convergence.\n";
+                amrex::Print()
+                    << "Skipping D_eff tensor calculation due to chi_k solver non-convergence.\n";
             }
             test_passed_overall = false;
         }
 
         amrex::Real stop_time = amrex::second() - strt_time;
-        amrex::ParallelDescriptor::ReduceRealMax(stop_time, amrex::ParallelDescriptor::IOProcessorNumber());
+        amrex::ParallelDescriptor::ReduceRealMax(stop_time,
+                                                 amrex::ParallelDescriptor::IOProcessorNumber());
 
         if (amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "\n--- Effective Diffusivity Test Summary ---\n";
             amrex::Print() << "  Total Run Time: " << stop_time << " sec\n";
             if (test_passed_overall && all_solves_converged) {
                 amrex::Print() << "  All chi_k solver instances converged.\n";
-                amrex::Print() << "  TEST RESULT: PASS (Execution, solver convergence, and basic D_eff checks where applicable)\n";
+                amrex::Print() << "  TEST RESULT: PASS (Execution, solver convergence, and basic "
+                                  "D_eff checks where applicable)\n";
             } else if (!all_solves_converged) {
-                amrex::Print() << "  One or more chi_k solver instances FAILED to converge or encountered an error.\n";
+                amrex::Print() << "  One or more chi_k solver instances FAILED to converge or "
+                                  "encountered an error.\n";
                 amrex::Print() << "  TEST RESULT: FAIL (Check logs for solver issues)\n";
-            } else { 
-                 amrex::Print() << "  Chi_k solves converged, but some D_eff validation checks may have failed (see warnings).\n";
-                 amrex::Print() << "  TEST RESULT: WARNING/FAIL (Review D_eff tensor values and warnings)\n";
+            } else {
+                amrex::Print() << "  Chi_k solves converged, but some D_eff validation checks may "
+                                  "have failed (see warnings).\n";
+                amrex::Print()
+                    << "  TEST RESULT: WARNING/FAIL (Review D_eff tensor values and warnings)\n";
             }
             amrex::Print() << "-----------------------------------------\n";
         }
@@ -477,7 +540,6 @@ int main (int argc, char* argv[])
         if (!test_passed_overall || !all_solves_converged) {
             amrex::Abort("EffectiveDiffusivity Test FAILED.");
         }
-
     }
     amrex::Finalize();
 

--- a/src/props/tTortuosity.cpp
+++ b/src/props/tTortuosity.cpp
@@ -34,10 +34,13 @@
 OpenImpala::Direction stringToDirection(const std::string& dir_str) {
     std::string lower_dir_str = dir_str;
     std::transform(lower_dir_str.begin(), lower_dir_str.end(), lower_dir_str.begin(),
-                   [](unsigned char c){ return std::tolower(c); });
-    if (lower_dir_str == "x") return OpenImpala::Direction::X;
-    if (lower_dir_str == "y") return OpenImpala::Direction::Y;
-    if (lower_dir_str == "z") return OpenImpala::Direction::Z;
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_dir_str == "x")
+        return OpenImpala::Direction::X;
+    if (lower_dir_str == "y")
+        return OpenImpala::Direction::Y;
+    if (lower_dir_str == "z")
+        return OpenImpala::Direction::Z;
     amrex::Abort("Invalid direction string: " + dir_str + ". Use X, Y, or Z.");
     return OpenImpala::Direction::X; // Should not reach here
 }
@@ -45,15 +48,23 @@ OpenImpala::Direction stringToDirection(const std::string& dir_str) {
 OpenImpala::TortuosityHypre::SolverType stringToSolverType(const std::string& solver_str) {
     std::string lower_solver_str = solver_str;
     std::transform(lower_solver_str.begin(), lower_solver_str.end(), lower_solver_str.begin(),
-                   [](unsigned char c){ return std::tolower(c); });
-    if (lower_solver_str == "jacobi") return OpenImpala::TortuosityHypre::SolverType::Jacobi;
-    if (lower_solver_str == "gmres") return OpenImpala::TortuosityHypre::SolverType::GMRES;
-    if (lower_solver_str == "flexgmres") return OpenImpala::TortuosityHypre::SolverType::FlexGMRES;
-    if (lower_solver_str == "pcg") return OpenImpala::TortuosityHypre::SolverType::PCG;
-    if (lower_solver_str == "bicgstab") return OpenImpala::TortuosityHypre::SolverType::BiCGSTAB;
-    if (lower_solver_str == "smg") return OpenImpala::TortuosityHypre::SolverType::SMG;
-    if (lower_solver_str == "pfmg") return OpenImpala::TortuosityHypre::SolverType::PFMG;
-    amrex::Abort("Invalid solver string: '" + solver_str + "'. Supported: Jacobi, GMRES, FlexGMRES, PCG, BiCGSTAB, SMG, PFMG");
+                   [](unsigned char c) { return std::tolower(c); });
+    if (lower_solver_str == "jacobi")
+        return OpenImpala::TortuosityHypre::SolverType::Jacobi;
+    if (lower_solver_str == "gmres")
+        return OpenImpala::TortuosityHypre::SolverType::GMRES;
+    if (lower_solver_str == "flexgmres")
+        return OpenImpala::TortuosityHypre::SolverType::FlexGMRES;
+    if (lower_solver_str == "pcg")
+        return OpenImpala::TortuosityHypre::SolverType::PCG;
+    if (lower_solver_str == "bicgstab")
+        return OpenImpala::TortuosityHypre::SolverType::BiCGSTAB;
+    if (lower_solver_str == "smg")
+        return OpenImpala::TortuosityHypre::SolverType::SMG;
+    if (lower_solver_str == "pfmg")
+        return OpenImpala::TortuosityHypre::SolverType::PFMG;
+    amrex::Abort("Invalid solver string: '" + solver_str +
+                 "'. Supported: Jacobi, GMRES, FlexGMRES, PCG, BiCGSTAB, SMG, PFMG");
     return OpenImpala::TortuosityHypre::SolverType::GMRES; // Should not reach here
 }
 
@@ -75,24 +86,25 @@ struct TestStatus {
 
     void printSummary() {
         if (passed) {
-            if(amrex::ParallelDescriptor::IOProcessor()) {
+            if (amrex::ParallelDescriptor::IOProcessor()) {
                 amrex::Print() << "\n----------------------------------------\n";
                 amrex::Print() << "--- TEST RESULT: PASS (Programmatic Checks) ---\n";
                 if (manual_checks_required) {
-                     amrex::Print() << "*** IMPORTANT: Manual checks required! ***\n";
-                     amrex::Print() << "  Please verify solver convergence details and\n";
-                     amrex::Print() << "  'Flux conservation check' messages in the log output above.\n";
+                    amrex::Print() << "*** IMPORTANT: Manual checks required! ***\n";
+                    amrex::Print() << "  Please verify solver convergence details and\n";
+                    amrex::Print()
+                        << "  'Flux conservation check' messages in the log output above.\n";
                 }
                 amrex::Print() << "----------------------------------------\n";
             }
         } else {
-            if(amrex::ParallelDescriptor::IOProcessor()) {
+            if (amrex::ParallelDescriptor::IOProcessor()) {
                 amrex::Print() << "\n-------------------------\n";
                 amrex::Print() << "--- TEST RESULT: FAIL ---\n";
                 for (const auto& reason : fail_reasons) {
                     amrex::Print() << "  Reason: " << reason << "\n";
                 }
-                 amrex::Print() << "-------------------------\n";
+                amrex::Print() << "-------------------------\n";
             }
             // Ensure abort happens after printing reasons
             amrex::Abort("Tortuosity Test FAILED programmatic checks.");
@@ -101,8 +113,7 @@ struct TestStatus {
 };
 
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
     // Initialize HYPRE First
     int hypre_ierr = HYPRE_Init();
     if (hypre_ierr != 0) {
@@ -140,14 +151,17 @@ int main (int argc, char* argv[])
             if (!pp.query("resultsdir", resultsdir)) {
                 const char* homeDir_cstr = getenv("HOME");
                 if (!homeDir_cstr) {
-                    amrex::Warning("Cannot determine default results directory: 'resultsdir' not in inputs and $HOME not set. Using './tortuosity_results'");
+                    amrex::Warning("Cannot determine default results directory: 'resultsdir' not "
+                                   "in inputs and $HOME not set. Using './tortuosity_results'");
                     resultsdir = "./tortuosity_results";
                 } else {
                     std::string homeDir = homeDir_cstr;
                     resultsdir = homeDir + "/openimpalaresults";
                 }
-                 if(amrex::ParallelDescriptor::IOProcessor())
-                    amrex::Print() << " Parameter 'resultsdir' not specified, using default: " << resultsdir << "\n";
+                if (amrex::ParallelDescriptor::IOProcessor())
+                    amrex::Print()
+                        << " Parameter 'resultsdir' not specified, using default: " << resultsdir
+                        << "\n";
             }
             pp.query("phase_id", phase_id);
             pp.query("direction", direction_str);
@@ -179,7 +193,8 @@ int main (int argc, char* argv[])
             amrex::Print() << "  Box Size:          " << box_size << "\n";
             amrex::Print() << "  Threshold Value:   " << threshold_val << "\n";
             amrex::Print() << "  Boundary Values:   " << v_lo << " (lo), " << v_hi << " (hi)\n";
-            amrex::Print() << "  Write Plotfile:    " << (write_plotfile != 0 ? "Yes" : "No") << "\n";
+            amrex::Print() << "  Write Plotfile:    " << (write_plotfile != 0 ? "Yes" : "No")
+                           << "\n";
             amrex::Print() << "  Verbose Level:     " << verbose << "\n";
             if (expected_tau >= 0.0) {
                 amrex::Print() << "  Expected Tau:      " << expected_tau << "\n";
@@ -189,7 +204,8 @@ int main (int argc, char* argv[])
                 amrex::Print() << "  Expected VF:       " << expected_vf << "\n";
                 amrex::Print() << "  VF Tolerance:      " << vf_tolerance << "\n";
             }
-            amrex::Print() << "  Flux Tolerance:    (Manual Check Needed)\n"; // Acknowledge limitation
+            amrex::Print()
+                << "  Flux Tolerance:    (Manual Check Needed)\n"; // Acknowledge limitation
             amrex::Print() << "------------------------------------\n\n";
         }
 
@@ -201,58 +217,81 @@ int main (int argc, char* argv[])
         amrex::iMultiFab mf_phase_with_ghost;
 
         try {
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Reading metadata from " << tifffile << "...\n";
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Reading metadata from " << tifffile << "...\n";
             OpenImpala::TiffReader reader(tifffile);
-            if (!reader.isRead()) { throw std::runtime_error("Reader failed to read metadata."); }
+            if (!reader.isRead()) {
+                throw std::runtime_error("Reader failed to read metadata.");
+            }
             const amrex::Box domain_box = reader.box();
-            if (domain_box.isEmpty()) { throw std::runtime_error("Reader returned empty domain box."); }
-            amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)}, {AMREX_D_DECL(amrex::Real(domain_box.length(0)), amrex::Real(domain_box.length(1)), amrex::Real(domain_box.length(2)))});
-            amrex::Array<int,AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
+            if (domain_box.isEmpty()) {
+                throw std::runtime_error("Reader returned empty domain box.");
+            }
+            amrex::RealBox rb(
+                {AMREX_D_DECL(0.0, 0.0, 0.0)},
+                {AMREX_D_DECL(amrex::Real(domain_box.length(0)), amrex::Real(domain_box.length(1)),
+                              amrex::Real(domain_box.length(2)))});
+            amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
             geom.define(domain_box, &rb, 0, is_periodic.data());
             ba_original.define(domain_box);
             ba_original.maxSize(box_size);
             dm_original.define(ba_original);
             amrex::iMultiFab mf_phase_no_ghost(ba_original, dm_original, 1, 0);
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << " Thresholding data...\n"; }
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Thresholding data...\n";
+            }
             reader.threshold(threshold_val, 1, 0, mf_phase_no_ghost);
             int min_phase_tmp = mf_phase_no_ghost.min(0);
             int max_phase_tmp = mf_phase_no_ghost.max(0);
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) { amrex::Print() << "   Temporary phase field min/max: " << min_phase_tmp << " / " << max_phase_tmp << "\n"; }
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << "   Temporary phase field min/max: " << min_phase_tmp << " / "
+                               << max_phase_tmp << "\n";
+            }
             if (min_phase_tmp == max_phase_tmp && ba_original.numPts() > 0) {
-                 test_status.recordFail("Phase field uniform after thresholding.");
+                test_status.recordFail("Phase field uniform after thresholding.");
             }
             const int required_ghost_cells = 1;
             mf_phase_with_ghost.define(ba_original, dm_original, 1, required_ghost_cells);
             amrex::Copy(mf_phase_with_ghost, mf_phase_no_ghost, 0, 0, 1, 0);
             mf_phase_with_ghost.FillBoundary(geom.periodicity());
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Grid and phase data setup complete.\n";
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Grid and phase data setup complete.\n";
         } catch (const std::exception& e) {
             test_status.recordFail("Error during TiffReader/grid setup: " + std::string(e.what()));
             test_status.printSummary(); // Print summary and exit
-            amrex::Finalize(); HYPRE_Finalize(); return 1;
+            amrex::Finalize();
+            HYPRE_Finalize();
+            return 1;
         }
 
         // --- Calculate and Check Volume Fraction ---
         amrex::Real actual_vf = 0.0;
         if (test_status.passed) {
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculating Volume Fraction...\n";
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Calculating Volume Fraction...\n";
             try {
                 OpenImpala::VolumeFraction vf_calc(mf_phase_with_ghost, phase_id);
                 actual_vf = vf_calc.value_vf(false);
-                if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculated Volume Fraction (Phase " << phase_id << "): " << actual_vf << "\n";
+                if (amrex::ParallelDescriptor::IOProcessor())
+                    amrex::Print() << " Calculated Volume Fraction (Phase " << phase_id
+                                   << "): " << actual_vf << "\n";
                 if (expected_vf >= 0.0) {
-                     if (std::abs(actual_vf - expected_vf) > vf_tolerance) {
-                        test_status.recordFail("Volume fraction mismatch. Expected: " + std::to_string(expected_vf) +
-                                               ", Calculated: " + std::to_string(actual_vf) +
-                                               ", Tolerance: " + std::to_string(vf_tolerance));
-                     } else {
-                         if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Volume Fraction Check:      PASS\n";
-                     }
+                    if (std::abs(actual_vf - expected_vf) > vf_tolerance) {
+                        test_status.recordFail(
+                            "Volume fraction mismatch. Expected: " + std::to_string(expected_vf) +
+                            ", Calculated: " + std::to_string(actual_vf) +
+                            ", Tolerance: " + std::to_string(vf_tolerance));
+                    } else {
+                        if (amrex::ParallelDescriptor::IOProcessor())
+                            amrex::Print() << " Volume Fraction Check:      PASS\n";
+                    }
                 } else {
-                     if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Volume Fraction Check:      SKIPPED\n";
+                    if (amrex::ParallelDescriptor::IOProcessor())
+                        amrex::Print() << " Volume Fraction Check:      SKIPPED\n";
                 }
             } catch (const std::exception& e) {
-                test_status.recordFail("Error during Volume Fraction calculation: " + std::string(e.what()));
+                test_status.recordFail("Error during Volume Fraction calculation: " +
+                                       std::string(e.what()));
             }
         }
 
@@ -261,100 +300,123 @@ int main (int argc, char* argv[])
         std::unique_ptr<OpenImpala::TortuosityHypre> tortuosity_ptr;
 
         // Only proceed if previous steps passed and VF is non-zero
-        if (test_status.passed && actual_vf > std::numeric_limits<amrex::Real>::epsilon())
-        {
-            if (!resultsdir.empty()) { amrex::UtilCreateDirectory(resultsdir, 0755); }
+        if (test_status.passed && actual_vf > std::numeric_limits<amrex::Real>::epsilon()) {
+            if (!resultsdir.empty()) {
+                amrex::UtilCreateDirectory(resultsdir, 0755);
+            }
             amrex::ParallelDescriptor::Barrier();
 
-            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Constructing TortuosityHypre object...\n";
+            if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Constructing TortuosityHypre object...\n";
             try {
-                 tortuosity_ptr = std::make_unique<OpenImpala::TortuosityHypre>(
-                     geom, ba_original, dm_original, mf_phase_with_ghost,
-                     actual_vf, phase_id, direction, solver_type, resultsdir,
-                     v_lo, v_hi, verbose, (write_plotfile != 0)
-                 );
+                tortuosity_ptr = std::make_unique<OpenImpala::TortuosityHypre>(
+                    geom, ba_original, dm_original, mf_phase_with_ghost, actual_vf, phase_id,
+                    direction, solver_type, resultsdir, v_lo, v_hi, verbose, (write_plotfile != 0));
             } catch (const std::exception& stdExc) {
-                 test_status.recordFail("TortuosityHypre construction failed: " + std::string(stdExc.what()));
-                 tortuosity_ptr.reset();
+                test_status.recordFail("TortuosityHypre construction failed: " +
+                                       std::string(stdExc.what()));
+                tortuosity_ptr.reset();
             } catch (...) {
-                 test_status.recordFail("Unknown exception during TortuosityHypre construction.");
-                 tortuosity_ptr.reset();
+                test_status.recordFail("Unknown exception during TortuosityHypre construction.");
+                tortuosity_ptr.reset();
             }
 
-            // Check Matrix Properties (already aborts on fail internally via HYPRE_CHECK/amrex::Abort)
+            // Check Matrix Properties (already aborts on fail internally via
+            // HYPRE_CHECK/amrex::Abort)
             if (test_status.passed && tortuosity_ptr) {
-                if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Performing mathematical checks on the assembled matrix...\n";
+                if (amrex::ParallelDescriptor::IOProcessor())
+                    amrex::Print()
+                        << " Performing mathematical checks on the assembled matrix...\n";
                 // This call might abort internally if it fails, otherwise it prints success/fail
                 bool matrix_checks_ok = tortuosity_ptr->checkMatrixProperties();
                 if (!matrix_checks_ok) {
-                     // The function likely aborted already, but record failure just in case.
-                     test_status.recordFail("Assembled matrix/vector failed property checks (check log).");
+                    // The function likely aborted already, but record failure just in case.
+                    test_status.recordFail(
+                        "Assembled matrix/vector failed property checks (check log).");
                 } else {
-                    if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Matrix property checks:     (Completed by TortuosityHypre)\n";
+                    if (amrex::ParallelDescriptor::IOProcessor())
+                        amrex::Print()
+                            << " Matrix property checks:     (Completed by TortuosityHypre)\n";
                 }
             }
 
             // Calculate Tortuosity Value (calls solve and global_fluxes internally)
             if (test_status.passed && tortuosity_ptr) {
-                 if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Calculating Tortuosity value...\n";
-                 try {
-                     actual_tau = tortuosity_ptr->value(); // Call the main method
+                if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor())
+                    amrex::Print() << " Calculating Tortuosity value...\n";
+                try {
+                    actual_tau = tortuosity_ptr->value(); // Call the main method
 
-                     // --- Check if calculation resulted in NaN/Inf ---
-                     if (std::isnan(actual_tau) || std::isinf(actual_tau)) {
-                         test_status.recordFail("Calculated tortuosity is NaN or Inf! Indicates potential solver or calculation failure.");
-                     } else {
-                         if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Value Calculation Check:    PASS (Result is finite)\n";
-                     }
+                    // --- Check if calculation resulted in NaN/Inf ---
+                    if (std::isnan(actual_tau) || std::isinf(actual_tau)) {
+                        test_status.recordFail("Calculated tortuosity is NaN or Inf! Indicates "
+                                               "potential solver or calculation failure.");
+                    } else {
+                        if (amrex::ParallelDescriptor::IOProcessor())
+                            amrex::Print()
+                                << " Value Calculation Check:    PASS (Result is finite)\n";
+                    }
 
-                     // --- Add note about manual checks ---
-                     test_status.requireManualChecks();
-                     if (amrex::ParallelDescriptor::IOProcessor()) {
-                        amrex::Print() << " Solver Conv./Flux Check:  REQUIRES MANUAL LOG INSPECTION\n";
-                        amrex::Print() << "   (Check 'HYPRE Final Relative Residual Norm' & 'Flux conservation check' messages above)\n";
-                     }
+                    // --- Add note about manual checks ---
+                    test_status.requireManualChecks();
+                    if (amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print()
+                            << " Solver Conv./Flux Check:  REQUIRES MANUAL LOG INSPECTION\n";
+                        amrex::Print() << "   (Check 'HYPRE Final Relative Residual Norm' & 'Flux "
+                                          "conservation check' messages above)\n";
+                    }
 
-                 } catch (const std::exception& stdExc) {
-                    test_status.recordFail("Exception during Tortuosity calculation: " + std::string(stdExc.what()));
-                 } catch (...) {
+                } catch (const std::exception& stdExc) {
+                    test_status.recordFail("Exception during Tortuosity calculation: " +
+                                           std::string(stdExc.what()));
+                } catch (...) {
                     test_status.recordFail("Unknown exception during Tortuosity calculation.");
-                 }
+                }
             }
 
             // --- Check Final Tortuosity Value against Expected ---
             // Only if previous steps passed AND the calculated value is valid
             if (test_status.passed && !(std::isnan(actual_tau) || std::isinf(actual_tau))) {
-                 if(amrex::ParallelDescriptor::IOProcessor()) {
-                    amrex::Print() << " Final Calculated Tortuosity: " << std::fixed << std::setprecision(8) << actual_tau << "\n";
-                 }
-                 if (expected_tau >= 0.0) {
-                     if (amrex::ParallelDescriptor::IOProcessor()) {
-                         amrex::Print() << " Expected Tortuosity:       " << std::fixed << std::setprecision(8) << expected_tau << "\n";
-                     }
-                     if (std::abs(actual_tau - expected_tau) > tau_tolerance) {
-                         test_status.recordFail("Tortuosity mismatch. Diff: " +
-                                                std::to_string(std::abs(actual_tau - expected_tau)) +
-                                                " > Tolerance: " + std::to_string(tau_tolerance));
-                     } else {
-                         if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Tortuosity Value Check:    PASS\n";
-                     }
-                 } else {
-                      if (amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << " Tortuosity Value Check:    SKIPPED\n";
-                 }
+                if (amrex::ParallelDescriptor::IOProcessor()) {
+                    amrex::Print() << " Final Calculated Tortuosity: " << std::fixed
+                                   << std::setprecision(8) << actual_tau << "\n";
+                }
+                if (expected_tau >= 0.0) {
+                    if (amrex::ParallelDescriptor::IOProcessor()) {
+                        amrex::Print() << " Expected Tortuosity:       " << std::fixed
+                                       << std::setprecision(8) << expected_tau << "\n";
+                    }
+                    if (std::abs(actual_tau - expected_tau) > tau_tolerance) {
+                        test_status.recordFail("Tortuosity mismatch. Diff: " +
+                                               std::to_string(std::abs(actual_tau - expected_tau)) +
+                                               " > Tolerance: " + std::to_string(tau_tolerance));
+                    } else {
+                        if (amrex::ParallelDescriptor::IOProcessor())
+                            amrex::Print() << " Tortuosity Value Check:    PASS\n";
+                    }
+                } else {
+                    if (amrex::ParallelDescriptor::IOProcessor())
+                        amrex::Print() << " Tortuosity Value Check:    SKIPPED\n";
+                }
             } // End check tortuosity value
 
         } else if (test_status.passed) { // VF is zero, but setup was okay
-             if (verbose >= 0 && amrex::ParallelDescriptor::IOProcessor())
-                amrex::Print() << " Skipping Tortuosity calculation because Volume Fraction is effectively zero (" << actual_vf << ").\n";
-             if (expected_tau >= 0.0) {
-                 test_status.recordFail("Volume Fraction is zero, but an expected_tau > 0 was provided.");
-             }
+            if (verbose >= 0 && amrex::ParallelDescriptor::IOProcessor())
+                amrex::Print() << " Skipping Tortuosity calculation because Volume Fraction is "
+                                  "effectively zero ("
+                               << actual_vf << ").\n";
+            if (expected_tau >= 0.0) {
+                test_status.recordFail(
+                    "Volume Fraction is zero, but an expected_tau > 0 was provided.");
+            }
         }
 
         // --- Final Verdict ---
         amrex::Real stop_time = amrex::second() - strt_time;
-        amrex::ParallelDescriptor::ReduceRealMax(stop_time, amrex::ParallelDescriptor::IOProcessorNumber());
-         if(amrex::ParallelDescriptor::IOProcessor()) amrex::Print() << "\n Run time = " << stop_time << " sec\n";
+        amrex::ParallelDescriptor::ReduceRealMax(stop_time,
+                                                 amrex::ParallelDescriptor::IOProcessorNumber());
+        if (amrex::ParallelDescriptor::IOProcessor())
+            amrex::Print() << "\n Run time = " << stop_time << " sec\n";
 
         test_status.printSummary(); // Prints PASS/FAIL details and aborts on FAIL
 
@@ -363,10 +425,10 @@ int main (int argc, char* argv[])
 
     // Finalize HYPRE
     hypre_ierr = HYPRE_Finalize();
-     if (hypre_ierr != 0) {
+    if (hypre_ierr != 0) {
         fprintf(stderr, "ERROR: HYPRE_Finalize() failed with code %d\n", hypre_ierr);
         return 1;
-     }
+    }
 
     return 0;
 }

--- a/src/props/tVolumeFraction.cpp
+++ b/src/props/tVolumeFraction.cpp
@@ -5,36 +5,36 @@
 // summation using AMReX tools, and reports PASS/FAIL.
 // Configuration is handled via ParmParse inputs.
 
-#include "../io/TiffReader.H"  // Assuming defines OpenImpala::TiffReader
-#include "VolumeFraction.H"    // Assuming defines OpenImpala::VolumeFraction
+#include "../io/TiffReader.H" // Assuming defines OpenImpala::TiffReader
+#include "VolumeFraction.H"   // Assuming defines OpenImpala::VolumeFraction
 
 #include <cstdlib>
 #include <string>
 #include <vector>
-#include <stdexcept>      // For std::runtime_error
-#include <fstream>        // For std::ifstream check
-#include <iomanip>        // For std::setprecision, std::setw, std::setfill
-#include <cmath>          // For std::abs
-#include <limits>         // For std::numeric_limits
-#include <memory>         // For std::unique_ptr
-#include <iostream>       // <<< ADDED for std::flush >>>
+#include <stdexcept> // For std::runtime_error
+#include <fstream>   // For std::ifstream check
+#include <iomanip>   // For std::setprecision, std::setw, std::setfill
+#include <cmath>     // For std::abs
+#include <limits>    // For std::numeric_limits
+#include <memory>    // For std::unique_ptr
+#include <iostream>  // <<< ADDED for std::flush >>>
 
 #include <AMReX.H>
-#include <AMReX_ParmParse.H>          // For reading parameters
-#include <AMReX_Utility.H>            // For amrex::UtilCreateDirectory (optional for output)
+#include <AMReX_ParmParse.H> // For reading parameters
+#include <AMReX_Utility.H>   // For amrex::UtilCreateDirectory (optional for output)
 #include <AMReX_Array.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_IArrayBox.H>
 #include <AMReX_iMultiFab.H>
-#include <AMReX_MultiFabUtil.H>    // For amrex::Loop, Array4
+#include <AMReX_MultiFabUtil.H>       // For amrex::Loop, Array4
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor, Barrier, Reduce*
-#include <AMReX_ParallelReduce.H>    // For ParallelAllReduce
+#include <AMReX_ParallelReduce.H>     // For ParallelAllReduce
 // #include <AMReX_Reduce.H>             // <<< REMOVED: Not using Reduce::Sum anymore >>>
-#include <AMReX_Random.H>             // For potential synthetic data later
-#include <AMReX_MFIter.H>             // Include MFIter explicitly
-#include <AMReX_GpuQualifiers.H>   // <<< ADDED for AMREX_GPU_DEVICE >>>
+#include <AMReX_Random.H>        // For potential synthetic data later
+#include <AMReX_MFIter.H>        // Include MFIter explicitly
+#include <AMReX_GpuQualifiers.H> // <<< ADDED for AMREX_GPU_DEVICE >>>
 
 
 // --- Default Test Parameters ---
@@ -52,54 +52,52 @@ constexpr int default_height = 100;
 constexpr int default_depth = 100;
 // Default threshold value (e.g., halfway for UINT8 [0-255])
 constexpr double default_threshold_value = 0.5;
-constexpr int default_phase0_id = 0; // ID assigned to values <= threshold
-constexpr int default_phase1_id = 1; // ID assigned to values > threshold
-constexpr int default_comp = 0;      // Component index in iMultiFab for phase data
+constexpr int default_phase0_id = 0;            // ID assigned to values <= threshold
+constexpr int default_phase1_id = 1;            // ID assigned to values > threshold
+constexpr int default_comp = 0;                 // Component index in iMultiFab for phase data
 constexpr amrex::Real default_tolerance = 1e-9; // Tolerance for checking sums/results
-constexpr int default_box_size = 32; // Max grid size for BoxArray
+constexpr int default_box_size = 32;            // Max grid size for BoxArray
 
 namespace // Anonymous namespace for internal helpers
 {
-    // Helper function to calculate VF directly using AMReX loops and reductions
-    // --- MODIFIED to return counts ---
-    void calculate_counts_direct(const amrex::iMultiFab& mf, int phase_id, int comp,
-                                 long long& phase_count, long long& total_count)
-    {
-        long long local_phase_count = 0;
-        long long local_total_count = 0;
+// Helper function to calculate VF directly using AMReX loops and reductions
+// --- MODIFIED to return counts ---
+void calculate_counts_direct(const amrex::iMultiFab& mf, int phase_id, int comp,
+                             long long& phase_count, long long& total_count) {
+    long long local_phase_count = 0;
+    long long local_total_count = 0;
 
 #ifdef AMREX_USE_OMP
-#pragma omp parallel reduction(+:local_phase_count, local_total_count)
+#pragma omp parallel reduction(+ : local_phase_count, local_total_count)
 #endif
-        // Use tiling iterator (true argument)
-        for (amrex::MFIter mfi(mf, true); mfi.isValid(); ++mfi)
-        {
-            const amrex::Box& bx = mfi.tilebox();
-            const auto& fab = mf.const_array(mfi, comp); // Use specified component
+    // Use tiling iterator (true argument)
+    for (amrex::MFIter mfi(mf, true); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        const auto& fab = mf.const_array(mfi, comp); // Use specified component
 
-            amrex::Loop(bx, [&] (int i, int j, int k) // Capture locals by reference for OMP reduction
-            {
-                if (fab(i, j, k) == phase_id) {
-                    local_phase_count += 1; // Directly increment thread-local sum (OMP handles reduction)
-                }
-            });
+        amrex::Loop(bx, [&](int i, int j, int k) // Capture locals by reference for OMP reduction
+                    {
+                        if (fab(i, j, k) == phase_id) {
+                            local_phase_count +=
+                                1; // Directly increment thread-local sum (OMP handles reduction)
+                        }
+                    });
 
-            local_total_count += bx.numPts();
-        }
-
-        // Reduce across MPI ranks
-        amrex::ParallelAllReduce::Sum(local_phase_count, amrex::ParallelContext::CommunicatorSub());
-        amrex::ParallelAllReduce::Sum(local_total_count, amrex::ParallelContext::CommunicatorSub());
-
-        // Assign to output parameters
-        phase_count = local_phase_count;
-        total_count = local_total_count;
+        local_total_count += bx.numPts();
     }
+
+    // Reduce across MPI ranks
+    amrex::ParallelAllReduce::Sum(local_phase_count, amrex::ParallelContext::CommunicatorSub());
+    amrex::ParallelAllReduce::Sum(local_total_count, amrex::ParallelContext::CommunicatorSub());
+
+    // Assign to output parameters
+    phase_count = local_phase_count;
+    total_count = local_total_count;
+}
 } // namespace
 
 
-int main (int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
     amrex::Initialize(argc, argv);
 
     // Use a block for AMReX object lifetimes
@@ -140,22 +138,28 @@ int main (int argc, char* argv[])
         {
             std::ifstream test_ifs(tifffile);
             if (!test_ifs) {
-                 amrex::Abort("Error: Cannot open input tifffile: " + tifffile);
+                amrex::Abort("Error: Cannot open input tifffile: " + tifffile);
             }
         }
 
         if (verbose > 0) {
             amrex::Print() << "\n--- VolumeFraction Test Configuration ---\n";
             amrex::Print() << " TIF File:                " << tifffile << "\n";
-            amrex::Print() << " Phase IDs:               " << phase0_id << " (<= T), " << phase1_id << " (> T)\n";
+            amrex::Print() << " Phase IDs:               " << phase0_id << " (<= T), " << phase1_id
+                           << " (> T)\n";
             amrex::Print() << " Phase Component:         " << phase_comp << "\n";
             amrex::Print() << " Threshold Value:         " << threshold_val << "\n";
             amrex::Print() << " Box Size:                " << box_size << "\n";
             amrex::Print() << " Verbose:                 " << verbose << "\n";
             amrex::Print() << " Tolerance:               " << tolerance << "\n";
-            amrex::Print() << " Check Boundary Voxels: " << (check_boundary_voxels ? "Yes" : "No") << "\n";
-            if (expected_vf0 >= 0.0) amrex::Print() << " Expected VF[" << phase0_id << "]:      " << expected_vf0 << "\n";
-            if (expected_vf1 >= 0.0) amrex::Print() << " Expected VF[" << phase1_id << "]:      " << expected_vf1 << "\n";
+            amrex::Print() << " Check Boundary Voxels: " << (check_boundary_voxels ? "Yes" : "No")
+                           << "\n";
+            if (expected_vf0 >= 0.0)
+                amrex::Print() << " Expected VF[" << phase0_id << "]:      " << expected_vf0
+                               << "\n";
+            if (expected_vf1 >= 0.0)
+                amrex::Print() << " Expected VF[" << phase1_id << "]:      " << expected_vf1
+                               << "\n";
             amrex::Print() << "--------------------------------------\n\n";
             amrex::OutStream() << std::flush; // Flush config output
         }
@@ -165,7 +169,7 @@ int main (int argc, char* argv[])
         amrex::BoxArray ba;
         amrex::DistributionMapping dm;
         amrex::iMultiFab mf_phase; // Phase data MultiFab
-        amrex::Box domain_box; // Store domain box for later use
+        amrex::Box domain_box;     // Store domain box for later use
 
         // --- Read TIFF and Setup Grids/Geometry ---
         try {
@@ -174,29 +178,33 @@ int main (int argc, char* argv[])
                 amrex::Print() << " Reading file " << tifffile << "...\n";
                 amrex::OutStream() << std::flush;
             }
-            reader_ptr = std::make_unique<OpenImpala::TiffReader>(tifffile); // Assumes constructor throws on fail
+            reader_ptr = std::make_unique<OpenImpala::TiffReader>(
+                tifffile); // Assumes constructor throws on fail
 
             // Basic check on reader state
-             if (!reader_ptr->isRead()) {
-                 throw std::runtime_error("TiffReader::isRead() returned false after construction.");
-             }
+            if (!reader_ptr->isRead()) {
+                throw std::runtime_error("TiffReader::isRead() returned false after construction.");
+            }
             // *** ADDED: Print FillOrder ***
             if (amrex::ParallelDescriptor::IOProcessor()) {
-                 amrex::Print() << " TiffReader FillOrder used: " << reader_ptr->getFillOrder() << " (1=MSB2LSB, 2=LSB2MSB)\n";
-                 amrex::OutStream() << std::flush;
+                amrex::Print() << " TiffReader FillOrder used: " << reader_ptr->getFillOrder()
+                               << " (1=MSB2LSB, 2=LSB2MSB)\n";
+                amrex::OutStream() << std::flush;
             }
             // *** END ADDED ***
 
 
             domain_box = reader_ptr->box(); // Get domain box from reader
-            if (domain_box.isEmpty()) { amrex::Abort("FAIL: TiffReader returned an empty box."); }
+            if (domain_box.isEmpty()) {
+                amrex::Abort("FAIL: TiffReader returned an empty box.");
+            }
 
             { // Setup geometry
                 amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
-                                   {AMREX_D_DECL(amrex::Real(domain_box.length(0)),
-                                                 amrex::Real(domain_box.length(1)),
-                                                 amrex::Real(domain_box.length(2)))});
-                amrex::Array<int,AMREX_SPACEDIM> is_periodic{0, 0, 0};
+                                  {AMREX_D_DECL(amrex::Real(domain_box.length(0)),
+                                                amrex::Real(domain_box.length(1)),
+                                                amrex::Real(domain_box.length(2)))});
+                amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
                 amrex::Geometry::Setup(&rb, 0, is_periodic.data());
                 geom.define(domain_box);
             }
@@ -211,40 +219,46 @@ int main (int argc, char* argv[])
 
             // Threshold image data into mf_phase using phase1_id and phase0_id
             if (verbose > 0) {
-                amrex::Print() << " Thresholding data (Phase " << phase1_id << " if > " << threshold_val << ")...\n";
+                amrex::Print() << " Thresholding data (Phase " << phase1_id << " if > "
+                               << threshold_val << ")...\n";
                 amrex::OutStream() << std::flush;
             }
-            reader_ptr->threshold(threshold_val, phase1_id, phase0_id, mf_phase); // Use flexible overload
+            reader_ptr->threshold(threshold_val, phase1_id, phase0_id,
+                                  mf_phase); // Use flexible overload
 
             // Check threshold result basic validity
             int min_val = mf_phase.min(phase_comp);
             int max_val = mf_phase.max(phase_comp);
             if (min_val != phase0_id || max_val != phase1_id) {
-                 amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
-                                << ") not the expected {" << phase0_id << ", " << phase1_id
-                                << "}. Check threshold value or sample data.\n";
-                 amrex::OutStream() << std::flush;
+                amrex::Print() << "Warning: Thresholded data min/max (" << min_val << "/" << max_val
+                               << ") not the expected {" << phase0_id << ", " << phase1_id
+                               << "}. Check threshold value or sample data.\n";
+                amrex::OutStream() << std::flush;
             } else {
-                 if (verbose > 0) {
-                     amrex::Print() << "  Threshold output range {" << min_val << ", " << max_val << "} looks plausible.\n";
-                     amrex::OutStream() << std::flush;
-                 }
+                if (verbose > 0) {
+                    amrex::Print() << "  Threshold output range {" << min_val << ", " << max_val
+                                   << "} looks plausible.\n";
+                    amrex::OutStream() << std::flush;
+                }
             }
 
             // No FillBoundary needed for mf_phase with 0 ghost cells
 
         } catch (const std::exception& e) {
-            amrex::Abort("Error during TiffReader processing or grid setup: " + std::string(e.what()));
+            amrex::Abort("Error during TiffReader processing or grid setup: " +
+                         std::string(e.what()));
         }
 
         // --- *** MODIFIED: Check Boundary Voxel Values with Debug Prints *** ---
         if (amrex::ParallelDescriptor::IOProcessor()) { // Print debug status only on IO rank
-            amrex::Print() << "DEBUG: Before boundary check block. check_boundary_voxels=" << check_boundary_voxels
+            amrex::Print() << "DEBUG: Before boundary check block. check_boundary_voxels="
+                           << check_boundary_voxels
                            << ", IOProcessor=" << amrex::ParallelDescriptor::IOProcessor() << "\n";
             amrex::OutStream() << std::flush;
         }
 
-        if (check_boundary_voxels && amrex::ParallelDescriptor::IOProcessor()) // Run full check only on Rank 0
+        if (check_boundary_voxels &&
+            amrex::ParallelDescriptor::IOProcessor()) // Run full check only on Rank 0
         {
             amrex::Print() << "DEBUG: ENTERING boundary check block.\n";
             amrex::OutStream() << std::flush;
@@ -255,35 +269,36 @@ int main (int argc, char* argv[])
             const amrex::IntVect dom_lo = domain_box.smallEnd();
             const amrex::IntVect dom_hi = domain_box.bigEnd();
             amrex::Vector<amrex::IntVect> corners = {
-                dom_lo,                                               // (0,0,0)
-                amrex::IntVect(dom_hi[0], dom_lo[1], dom_lo[2]),      // (Xmax, 0, 0)
-                amrex::IntVect(dom_lo[0], dom_hi[1], dom_lo[2]),      // (0, Ymax, 0)
-                amrex::IntVect(dom_lo[0], dom_lo[1], dom_hi[2]),      // (0, 0, Zmax)
-                amrex::IntVect(dom_hi[0], dom_hi[1], dom_lo[2]),      // (Xmax, Ymax, 0)
-                amrex::IntVect(dom_hi[0], dom_lo[1], dom_hi[2]),      // (Xmax, 0, Zmax)
-                amrex::IntVect(dom_lo[0], dom_hi[1], dom_hi[2]),      // (0, Ymax, Zmax)
-                dom_hi                                                // (Xmax, Ymax, Zmax)
+                dom_lo,                                          // (0,0,0)
+                amrex::IntVect(dom_hi[0], dom_lo[1], dom_lo[2]), // (Xmax, 0, 0)
+                amrex::IntVect(dom_lo[0], dom_hi[1], dom_lo[2]), // (0, Ymax, 0)
+                amrex::IntVect(dom_lo[0], dom_lo[1], dom_hi[2]), // (0, 0, Zmax)
+                amrex::IntVect(dom_hi[0], dom_hi[1], dom_lo[2]), // (Xmax, Ymax, 0)
+                amrex::IntVect(dom_hi[0], dom_lo[1], dom_hi[2]), // (Xmax, 0, Zmax)
+                amrex::IntVect(dom_lo[0], dom_hi[1], dom_hi[2]), // (0, Ymax, Zmax)
+                dom_hi                                           // (Xmax, Ymax, Zmax)
             };
 
             // Need to iterate MFIter to access data, but only check points if they are corners
             // This is inefficient but simple for a debug check.
             for (amrex::MFIter mfi(mf_phase); mfi.isValid(); ++mfi) {
-                 const amrex::Box& bx = mfi.validbox(); // Use validbox (no ghost cells)
-                 const auto& fab_arr = mf_phase.const_array(mfi, phase_comp);
+                const amrex::Box& bx = mfi.validbox(); // Use validbox (no ghost cells)
+                const auto& fab_arr = mf_phase.const_array(mfi, phase_comp);
 
-                 for(const auto& corner : corners) {
-                      if (bx.contains(corner)) { // Check if this Fab owns the corner point
-                          amrex::Print() << "  Corner " << corner << " value: " << fab_arr(corner) << "\n";
-                          amrex::OutStream() << std::flush; // Force flush
-                      }
-                 }
+                for (const auto& corner : corners) {
+                    if (bx.contains(corner)) { // Check if this Fab owns the corner point
+                        amrex::Print()
+                            << "  Corner " << corner << " value: " << fab_arr(corner) << "\n";
+                        amrex::OutStream() << std::flush; // Force flush
+                    }
+                }
             }
             amrex::Print() << "------------------------------------------\n";
-            amrex::OutStream() << std::flush; // Force flush
+            amrex::OutStream() << std::flush;                  // Force flush
         } else if (amrex::ParallelDescriptor::IOProcessor()) { // Print skip message only on IO rank
-             amrex::Print() << "DEBUG: SKIPPING boundary check block (check_boundary_voxels="
-                            << check_boundary_voxels << " or not IOProcessor).\n";
-             amrex::OutStream() << std::flush;
+            amrex::Print() << "DEBUG: SKIPPING boundary check block (check_boundary_voxels="
+                           << check_boundary_voxels << " or not IOProcessor).\n";
+            amrex::OutStream() << std::flush;
         }
 
         // Ensure all ranks wait if check was done (or skipped) before proceeding
@@ -308,42 +323,51 @@ int main (int argc, char* argv[])
 
         // Test Phase 0
         OpenImpala::VolumeFraction vf0(mf_phase, phase0_id, phase_comp); // Pass component
-        vf0.value(phase0_count_global, total_count0_global, false); // Get global counts
-        vf0.value(phase0_count_local, total_count0_local, true);   // Get local counts
+        vf0.value(phase0_count_global, total_count0_global, false);      // Get global counts
+        vf0.value(phase0_count_local, total_count0_local, true);         // Get local counts
 
         // Calculate VF from counts
-        amrex::Real actual_vf0_global = (total_count0_global > 0)
-                                        ? static_cast<amrex::Real>(phase0_count_global) / total_count0_global
-                                        : 0.0;
-        amrex::Real actual_vf0_local = (total_count0_local > 0)
-                                       ? static_cast<amrex::Real>(phase0_count_local) / total_count0_local
-                                       : 0.0;
+        amrex::Real actual_vf0_global =
+            (total_count0_global > 0)
+                ? static_cast<amrex::Real>(phase0_count_global) / total_count0_global
+                : 0.0;
+        amrex::Real actual_vf0_local =
+            (total_count0_local > 0)
+                ? static_cast<amrex::Real>(phase0_count_local) / total_count0_local
+                : 0.0;
 
         amrex::Print() << "  VF[" << phase0_id << "] (Global): " << actual_vf0_global << "\n";
         // *** ADDED: Print global counts ***
-        amrex::Print() << "    Phase[" << phase0_id << "] Count (Global): " << phase0_count_global << "\n";
+        amrex::Print() << "    Phase[" << phase0_id << "] Count (Global): " << phase0_count_global
+                       << "\n";
         amrex::Print() << "    Total Count (Global):      " << total_count0_global << "\n";
         amrex::OutStream() << std::flush; // Flush
         // *** END ADDED ***
-        if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) { // Print local only on Rank 0 for clarity
-            amrex::Print() << "  VF[" << phase0_id << "] (Local Rank 0): " << actual_vf0_local << "\n";
+        if (verbose > 0 &&
+            amrex::ParallelDescriptor::IOProcessor()) { // Print local only on Rank 0 for clarity
+            amrex::Print() << "  VF[" << phase0_id << "] (Local Rank 0): " << actual_vf0_local
+                           << "\n";
             amrex::OutStream() << std::flush;
         }
 
 
         if (expected_vf0 >= 0.0) { // Check global against expected
             if (std::abs(actual_vf0_global - expected_vf0) > tolerance) {
-                 amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " + std::to_string(phase0_id));
+                amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " +
+                             std::to_string(phase0_id));
             }
-             if (verbose > 0) {
-                 amrex::Print() << "  VF[" << phase0_id << "] Global Check: PASS\n";
-                 amrex::OutStream() << std::flush;
-             }
+            if (verbose > 0) {
+                amrex::Print() << "  VF[" << phase0_id << "] Global Check: PASS\n";
+                amrex::OutStream() << std::flush;
+            }
         }
-        if (actual_vf0_local < 0.0 - tolerance || actual_vf0_local > 1.0 + tolerance) { // Check local range with tolerance
+        if (actual_vf0_local < 0.0 - tolerance ||
+            actual_vf0_local > 1.0 + tolerance) { // Check local range with tolerance
             // This check might fail spuriously on ranks with no cells, do it carefully
             if (total_count0_local > 0) { // Only check if this rank actually has cells
-                amrex::Abort("FAIL: Local Volume Fraction for phase " + std::to_string(phase0_id) + " out of range [0, 1] on Rank " + std::to_string(amrex::ParallelDescriptor::MyProc()) + ".");
+                amrex::Abort("FAIL: Local Volume Fraction for phase " + std::to_string(phase0_id) +
+                             " out of range [0, 1] on Rank " +
+                             std::to_string(amrex::ParallelDescriptor::MyProc()) + ".");
             }
         }
 
@@ -354,44 +378,53 @@ int main (int argc, char* argv[])
 
         // Test Phase 1
         OpenImpala::VolumeFraction vf1(mf_phase, phase1_id, phase_comp); // Pass component
-        vf1.value(phase1_count_global, total_count1_global, false); // Global
-        vf1.value(phase1_count_local, total_count1_local, true);   // Local
+        vf1.value(phase1_count_global, total_count1_global, false);      // Global
+        vf1.value(phase1_count_local, total_count1_local, true);         // Local
 
         // Calculate VF
-        amrex::Real actual_vf1_global = (total_count1_global > 0)
-                                        ? static_cast<amrex::Real>(phase1_count_global) / total_count1_global
-                                        : 0.0;
-        amrex::Real actual_vf1_local = (total_count1_local > 0)
-                                       ? static_cast<amrex::Real>(phase1_count_local) / total_count1_local
-                                       : 0.0;
+        amrex::Real actual_vf1_global =
+            (total_count1_global > 0)
+                ? static_cast<amrex::Real>(phase1_count_global) / total_count1_global
+                : 0.0;
+        amrex::Real actual_vf1_local =
+            (total_count1_local > 0)
+                ? static_cast<amrex::Real>(phase1_count_local) / total_count1_local
+                : 0.0;
 
         amrex::Print() << "  VF[" << phase1_id << "] (Global): " << actual_vf1_global << "\n";
         // *** ADDED: Print global counts ***
-        amrex::Print() << "    Phase[" << phase1_id << "] Count (Global): " << phase1_count_global << "\n";
-        amrex::Print() << "    Total Count (Global):      " << total_count1_global << " (Should match total above)\n";
+        amrex::Print() << "    Phase[" << phase1_id << "] Count (Global): " << phase1_count_global
+                       << "\n";
+        amrex::Print() << "    Total Count (Global):      " << total_count1_global
+                       << " (Should match total above)\n";
         amrex::OutStream() << std::flush; // Flush
         // *** END ADDED ***
 
         if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) { // Print local only on Rank 0
-            amrex::Print() << "  VF[" << phase1_id << "] (Local Rank 0): " << actual_vf1_local << "\n";
+            amrex::Print() << "  VF[" << phase1_id << "] (Local Rank 0): " << actual_vf1_local
+                           << "\n";
             amrex::OutStream() << std::flush;
         }
 
 
         if (expected_vf1 >= 0.0) { // Check global against expected
-             if (std::abs(actual_vf1_global - expected_vf1) > tolerance) {
-                 amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " + std::to_string(phase1_id));
-             }
-              if (verbose > 0) {
-                  amrex::Print() << "  VF[" << phase1_id << "] Global Check: PASS\n";
-                  amrex::OutStream() << std::flush;
-              }
+            if (std::abs(actual_vf1_global - expected_vf1) > tolerance) {
+                amrex::Abort("FAIL: Global Volume Fraction mismatch for phase " +
+                             std::to_string(phase1_id));
+            }
+            if (verbose > 0) {
+                amrex::Print() << "  VF[" << phase1_id << "] Global Check: PASS\n";
+                amrex::OutStream() << std::flush;
+            }
         }
-         if (actual_vf1_local < 0.0 - tolerance || actual_vf1_local > 1.0 + tolerance) { // Check local range with tolerance
-              if(total_count1_local > 0) { // Only check if this rank actually has cells
-                  amrex::Abort("FAIL: Local Volume Fraction for phase " + std::to_string(phase1_id) + " out of range [0, 1] on Rank " + std::to_string(amrex::ParallelDescriptor::MyProc()) + ".");
-              }
-         }
+        if (actual_vf1_local < 0.0 - tolerance ||
+            actual_vf1_local > 1.0 + tolerance) { // Check local range with tolerance
+            if (total_count1_local > 0) {         // Only check if this rank actually has cells
+                amrex::Abort("FAIL: Local Volume Fraction for phase " + std::to_string(phase1_id) +
+                             " out of range [0, 1] on Rank " +
+                             std::to_string(amrex::ParallelDescriptor::MyProc()) + ".");
+            }
+        }
 
         // --- Check Sums ---
         if (verbose > 0) {
@@ -399,29 +432,32 @@ int main (int argc, char* argv[])
             amrex::OutStream() << std::flush;
         }
         amrex::Real vf_sum_global = actual_vf0_global + actual_vf1_global;
-        amrex::Real vf_sum_local = actual_vf0_local + actual_vf1_local; // Note: This is Rank 0's local sum
+        amrex::Real vf_sum_local =
+            actual_vf0_local + actual_vf1_local; // Note: This is Rank 0's local sum
 
         amrex::Print() << "  Global VF Sum = " << vf_sum_global << "\n";
         amrex::OutStream() << std::flush;
 
-        if (verbose > 0 && amrex::ParallelDescriptor::IOProcessor()) { // Print local sum only on Rank 0
-             amrex::Print() << "  Local VF Sum (Rank 0) = " << vf_sum_local << "\n";
-             amrex::OutStream() << std::flush;
+        if (verbose > 0 &&
+            amrex::ParallelDescriptor::IOProcessor()) { // Print local sum only on Rank 0
+            amrex::Print() << "  Local VF Sum (Rank 0) = " << vf_sum_local << "\n";
+            amrex::OutStream() << std::flush;
         }
 
 
         if (std::abs(1.0 - vf_sum_global) > tolerance) {
             amrex::Warning("Global Volume Fractions do not sum to 1.0 within tolerance.");
         } else {
-             if (verbose > 0) {
-                 amrex::Print() << "  Global Sum Check:        PASS\n";
-                 amrex::OutStream() << std::flush;
-             }
+            if (verbose > 0) {
+                amrex::Print() << "  Global Sum Check:        PASS\n";
+                amrex::OutStream() << std::flush;
+            }
         }
         // Local sum check requires care in parallel if mf_phase has zero cells on some ranks
-        if (mf_phase.boxArray().numPts() > 0 && std::abs(1.0 - vf_sum_local) > tolerance && amrex::ParallelDescriptor::IOProcessor()) {
-             // Only warn if Rank 0 (which we printed) doesn't sum, and it has points.
-             amrex::Warning("Local Volume Fractions do not sum to 1.0 on Rank 0.");
+        if (mf_phase.boxArray().numPts() > 0 && std::abs(1.0 - vf_sum_local) > tolerance &&
+            amrex::ParallelDescriptor::IOProcessor()) {
+            // Only warn if Rank 0 (which we printed) doesn't sum, and it has points.
+            amrex::Warning("Local Volume Fractions do not sum to 1.0 on Rank 0.");
         }
 
 
@@ -430,29 +466,37 @@ int main (int argc, char* argv[])
             amrex::Print() << " Comparing VolumeFraction class against direct AMReX summation...\n";
             amrex::OutStream() << std::flush;
         }
-        long long direct_phase0_count=0, direct_total0_count=0;
-        long long direct_phase1_count=0, direct_total1_count=0;
+        long long direct_phase0_count = 0, direct_total0_count = 0;
+        long long direct_phase1_count = 0, direct_total1_count = 0;
 
-        calculate_counts_direct(mf_phase, phase0_id, phase_comp, direct_phase0_count, direct_total0_count);
-        calculate_counts_direct(mf_phase, phase1_id, phase_comp, direct_phase1_count, direct_total1_count);
+        calculate_counts_direct(mf_phase, phase0_id, phase_comp, direct_phase0_count,
+                                direct_total0_count);
+        calculate_counts_direct(mf_phase, phase1_id, phase_comp, direct_phase1_count,
+                                direct_total1_count);
 
         // Compare counts directly
-        if (direct_phase0_count != phase0_count_global || direct_total0_count != total_count0_global) {
-            amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts for phase " + std::to_string(phase0_id));
+        if (direct_phase0_count != phase0_count_global ||
+            direct_total0_count != total_count0_global) {
+            amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts "
+                         "for phase " +
+                         std::to_string(phase0_id));
         } else {
-             if (verbose > 0) {
-                 amrex::Print() << "  Direct Sum Check[" << phase0_id << "]: PASS\n";
-                 amrex::OutStream() << std::flush;
-             }
+            if (verbose > 0) {
+                amrex::Print() << "  Direct Sum Check[" << phase0_id << "]: PASS\n";
+                amrex::OutStream() << std::flush;
+            }
         }
-         if (direct_phase1_count != phase1_count_global || direct_total1_count != total_count1_global) {
-             amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts for phase " + std::to_string(phase1_id));
-         } else {
-              if (verbose > 0) {
-                  amrex::Print() << "  Direct Sum Check[" << phase1_id << "]: PASS\n";
-                  amrex::OutStream() << std::flush;
-              }
-         }
+        if (direct_phase1_count != phase1_count_global ||
+            direct_total1_count != total_count1_global) {
+            amrex::Abort("FAIL: VolumeFraction::value() counts differ from direct AMReX Sum counts "
+                         "for phase " +
+                         std::to_string(phase1_id));
+        } else {
+            if (verbose > 0) {
+                amrex::Print() << "  Direct Sum Check[" << phase1_id << "]: PASS\n";
+                amrex::OutStream() << std::flush;
+            }
+        }
 
 
         // --- Optional Synthetic Test Case ---
@@ -464,7 +508,8 @@ int main (int argc, char* argv[])
         amrex::OutStream() << std::flush;
 
         amrex::Real stop_time = amrex::second() - strt_time;
-        amrex::ParallelDescriptor::ReduceRealMax(stop_time, amrex::ParallelDescriptor::IOProcessorNumber());
+        amrex::ParallelDescriptor::ReduceRealMax(stop_time,
+                                                 amrex::ParallelDescriptor::IOProcessorNumber());
         if (amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << " Run time = " << stop_time << " sec\n";
             amrex::OutStream() << std::flush;


### PR DESCRIPTION
## Summary

Closes #37

- Add `.clang-format` config (LLVM-based, C++17) with 4-space indent, 100-column limit, and preserved include ordering
- Apply `clang-format -i` to all 31 C++ files (17 `.cpp` + 14 `.H`) in `src/io/` and `src/props/`; Fortran `.F90` files are excluded
- Add a `format-check` CI job to `build-test.yml` that runs `clang-format --dry-run --Werror` on all C++ source files, failing PRs with unformatted code
- Add a "Code Formatting" section to `README.md` with local usage instructions

## Test plan

- [ ] Verify the `format-check` CI job passes on this PR
- [ ] Confirm no Fortran (`.F90`) files were modified
- [ ] Run `clang-format --dry-run --Werror` locally against `src/` to confirm zero violations
- [ ] Verify the existing `build-and-test-openimpala` CI job still passes (formatting is style-only, no logic changes)
