### PR TITLE
Fix remaining clang-tidy findings uncovered after -fopenmp fix

### DIFF
--- a/src/io/DatReader.cpp
+++ b/src/io/DatReader.cpp
@@ -24,7 +24,7 @@ namespace OpenImpala {
 namespace { // Anonymous namespace
 
 inline std::int32_t swap_bytes_int32(std::int32_t val) {
-    return __builtin_bswap32(val);
+    return static_cast<std::int32_t>(__builtin_bswap32(static_cast<std::uint32_t>(val)));
 }
 
 inline std::uint16_t swap_bytes_uint16(std::uint16_t val) {

--- a/src/io/TiffReader.cpp
+++ b/src/io/TiffReader.cpp
@@ -566,7 +566,7 @@ void TiffReader::readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_
                                             (size_t)j_chk * tile_width_int +
                                             i_chk; // Use tile_width_int for tile calculations
                                         byte_i = lin_i_chk / 8;
-                                        bit_i = lin_i_chk % 8;
+                                        bit_i = static_cast<int>(lin_i_chk % 8);
                                         if (byte_i < (size_t)bytes_rd) {
                                             p_byte = temp_buffer[byte_i];
                                             bit_v = (fill_order_local == FILLORDER_MSB2LSB)

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -47,7 +47,7 @@
 // HYPRE_CHECK macro remains the same...
 #define HYPRE_CHECK(ierr)                                                                          \
     do {                                                                                           \
-        if (ierr != 0) {                                                                           \
+        if ((ierr) != 0) {                                                                         \
             char hypre_error_msg[256];                                                             \
             HYPRE_DescribeError(ierr, hypre_error_msg);                                            \
             amrex::Abort("HYPRE Error: " + std::string(hypre_error_msg) +                          \

--- a/src/props/VolumeFraction.H
+++ b/src/props/VolumeFraction.H
@@ -73,7 +73,7 @@ public:
     amrex::Real value_vf(bool local = false) const {
         long long pc, tc;
         value(pc, tc, local); // Call the method that returns counts
-        return (tc > 0) ? static_cast<amrex::Real>(pc) / tc : 0.0;
+        return (tc > 0) ? static_cast<amrex::Real>(pc) / static_cast<amrex::Real>(tc) : 0.0;
     }
 
 private:


### PR DESCRIPTION
Now that the OpenMP compiler error no longer masks findings:
- bugprone-macro-parentheses: parenthesize macro arg in HYPRE_CHECK (TortuosityHypre.cpp)
- bugprone-narrowing-conversions: cast tc to amrex::Real in division (VolumeFraction.H), cast via uint32_t for __builtin_bswap32 (DatReader.cpp), cast size_t modulo result to int (TiffReader.cpp)
