### PR TITLE
Migrate build system from GNUmakefile to CMake

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,5 @@
 # .github/workflows/build-test.yml
-name: Build and Test OpenImpala Makefile with SIF Cache
+name: Build and Test OpenImpala
 
 # Define workflow triggers
 on:
@@ -88,7 +88,7 @@ jobs:
               echo "clang-tidy passed on all files."
             '
 
-  build-and-test-openimpala: # Renamed job for clarity
+  build-and-test-openimpala:
     runs-on: ubuntu-latest
 
     steps:
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Apptainer
         uses: eWaterCycle/setup-apptainer@v2
         with:
-          apptainer-version: 1.2.5 # Or your desired version
+          apptainer-version: 1.2.5
 
       # Step 3: Restore Dependency SIF Cache
       - name: Restore Dependency SIF Cache
@@ -108,19 +108,17 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: dependency_image.sif
-          # Key includes hash of the definition file
           key: ${{ runner.os }}-apptainer-sif-${{ hashFiles('containers/Singularity.deps.def') }}
           restore-keys: |
             ${{ runner.os }}-apptainer-sif-
 
-      # Step 3.5: Debug cache hit status
       - name: Debug cache hit status
         if: always()
         run: echo "Cache hit status is >>>${{ steps.cache-restore-sif.outputs.cache-hit }}<<<"
 
       # Step 4: Build Dependency SIF Image (if cache miss)
       - name: Build Dependency SIF Image Locally (if cache miss)
-        id: build_sif # Give this step an ID
+        id: build_sif
         if: steps.cache-restore-sif.outputs.cache-hit != 'true'
         run: |
           RECIPE_FILE="containers/Singularity.deps.def"
@@ -130,20 +128,18 @@ jobs:
             exit 1
           fi
           echo "Cache miss or invalid. Building dependencies SIF image '$TARGET_SIF' from $RECIPE_FILE..."
-          echo "Executing: sudo apptainer build --force \"$TARGET_SIF\" \"$RECIPE_FILE\""
-          # Build the SIF image using Apptainer
           sudo apptainer build --force "$TARGET_SIF" "$RECIPE_FILE"
           BUILD_EXIT_CODE=$?
           if [ $BUILD_EXIT_CODE -ne 0 ]; then
             echo "Error: Apptainer SIF build failed with exit code $BUILD_EXIT_CODE."
-            exit $BUILD_EXIT_CODE # Job stops here if SIF build fails
+            exit $BUILD_EXIT_CODE
           fi
           echo "Apptainer SIF build successful."
           ls -lh ./dependency_image.sif
 
       # Step 5: Verify SIF exists
       - name: Verify SIF exists after cache/build step
-        id: verify_sif # Give this step an ID
+        id: verify_sif
         run: |
           if [ ! -f "./dependency_image.sif" ]; then
             echo "Error: dependency_image.sif not found after cache/build steps!"
@@ -153,48 +149,39 @@ jobs:
             ls -lh ./dependency_image.sif
           fi
 
-      # *** CORRECTED: Step 5.5: Copy HYPRE Test Log from Container ***
       - name: Copy HYPRE Check Log from Container
-        # Run this step always *after* Step 5, assuming Step 5 passes or the job would have failed.
-        # The internal 'if' handles the case where the log file might not exist.
-        if: always() && steps.verify_sif.outcome == 'success' # Ensure Step 5 succeeded
+        if: always() && steps.verify_sif.outcome == 'success'
         run: |
-          # Check if the log file exists inside the container at the expected path
           if sudo apptainer exec ./dependency_image.sif test -f /hypre_make_check.log; then
             echo "Copying /hypre_make_check.log..."
-            # Execute 'cat' inside the container and redirect output to a file on the host
             sudo apptainer exec ./dependency_image.sif cat /hypre_make_check.log > ./hypre_make_check.log
-            ls -l ./hypre_make_check.log # Verify the file was created on the host
+            ls -l ./hypre_make_check.log
           else
             echo "HYPRE check log /hypre_make_check.log not found in container."
           fi
-        continue-on-error: true # Don't fail workflow if log copy fails
+        continue-on-error: true
 
-      # Step 5.6: Upload HYPRE Test Log Artifact
       - name: Upload HYPRE Check Log Artifact
-        if: always() # Upload even if copy step had issues, might be empty or non-existent
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: hypre-make-check-log-${{ github.run_id }}
-          path: hypre_make_check.log # Path on the host runner
+          path: hypre_make_check.log
           retention-days: 5
-          if-no-files-found: warn # Use 'warn' if the file might not exist
+          if-no-files-found: warn
 
       # Step 6: Save the SIF image to the cache (only if built)
       - name: Save Dependency SIF Image Cache
-        # Condition: Only run if Step 3 missed cache AND Step 4 succeeded
         if: steps.cache-restore-sif.outputs.cache-hit != 'true' && steps.build_sif.outcome == 'success'
         uses: actions/cache/save@v4
         with:
           path: dependency_image.sif
           key: ${{ runner.os }}-apptainer-sif-${{ hashFiles('containers/Singularity.deps.def') }}
 
-      
-      # Step 6.1: Verify hypre_test.cpp exists in src/props/
+      # Standalone HYPRE Test (unchanged)
       - name: Verify hypre_test.cpp exists
         id: check_hypre_test_file
         run: |
-          # Check relative to the repository root ($PWD in the runner)
           if [ ! -f ./src/props/hypre_test.cpp ]; then
             echo "::error::Standalone test file ./src/props/hypre_test.cpp not found!"
             exit 1
@@ -202,16 +189,11 @@ jobs:
             echo "Standalone test file ./src/props/hypre_test.cpp found."
           fi
 
-      # Step 6.2: Compile Standalone HYPRE Test inside Container
       - name: Compile Standalone HYPRE Test
         id: compile_hypre_test
-        # Run only if the test file exists
         if: steps.check_hypre_test_file.outcome == 'success'
         run: |
           echo "Compiling hypre_test.cpp inside container..."
-          # Execute compile command inside the container
-          # Use mpic++ for C++ file
-          # The source file path is now relative to the /src mount point inside the container
           sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
@@ -220,26 +202,20 @@ jobs:
                      echo "Running: mpic++ src/props/hypre_test.cpp -o hypre_test -I/opt/hypre/v2.32.0/include -L/opt/hypre/v2.32.0/lib -lHYPRE -fopenmp -lm" && \
                      mpic++ src/props/hypre_test.cpp -o hypre_test -I/opt/hypre/v2.32.0/include -L/opt/hypre/v2.32.0/lib -lHYPRE -fopenmp -lm' > compile_hypre_test.log 2>&1
           COMPILE_EXIT_CODE=$?
-          cat compile_hypre_test.log # Print compile output
+          cat compile_hypre_test.log
           if [ $COMPILE_EXIT_CODE -ne 0 ]; then
             echo "::error::Standalone HYPRE test compilation failed! Exit code: $COMPILE_EXIT_CODE"
             exit $COMPILE_EXIT_CODE
           fi
           echo "Standalone HYPRE test compilation successful."
-          # The executable 'hypre_test' will be created in /src (which is $PWD on the host)
-          ls -l ./hypre_test # Verify executable exists
+          ls -l ./hypre_test
 
-     # Step 6.3: Run Standalone HYPRE Test inside Container (Direct Output)
       - name: Run Standalone HYPRE Test (Direct Output)
         id: run_hypre_test
-        # Run only if compilation succeeded
         if: steps.compile_hypre_test.outcome == 'success'
-        # Use 'continue-on-error: true' to ensure the step completes
         continue-on-error: true
         run: |
           echo "Running hypre_test inside container (logging directly)..."
-          # Execute run command inside the container
-          # Redirect stderr to stdout (2>&1) for the mpirun command
           sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
@@ -247,71 +223,65 @@ jobs:
                      cd /src && \
                      echo "Executing: mpirun -np 1 --allow-run-as-root ./hypre_test 2>&1" && \
                      mpirun -np 1 --allow-run-as-root ./hypre_test 2>&1'
-          # Capture the exit code directly from the apptainer exec command
           RUN_EXIT_CODE=$?
           echo "Standalone HYPRE test execution finished with exit code: $RUN_EXIT_CODE"
-          # Store the exit code as an output for the next step
           echo "exit_code=$RUN_EXIT_CODE" >> $GITHUB_OUTPUT
 
-      # Step 6.4: Check Standalone Test Outcome
-      # (Keep the previous Step 6.4 as it was, it checks steps.run_hypre_test.outcome)
       - name: Check Standalone Test Outcome
         if: steps.run_hypre_test.outcome == 'failure' || steps.run_hypre_test.outputs.exit_code != '0'
         run: |
           echo "::error::Standalone HYPRE test execution failed (Exit Code: ${{ steps.run_hypre_test.outputs.exit_code }}). See output above."
-          # Decide if this failure should stop the whole workflow
-          # exit 1
-          echo "::warning::Standalone HYPRE test failed, but continuing workflow..." # Example: Warn but continue
+          echo "::warning::Standalone HYPRE test failed, but continuing workflow..."
 
-
-      # Step 7: Build OpenImpala using Dependency SIF
-      - name: Build OpenImpala using Dependency SIF
-        id: make_build
-        continue-on-error: true # Allow logs to upload even if build fails
+      # Step 7: Build OpenImpala with CMake inside the Dependency SIF
+      - name: Build OpenImpala (CMake)
+        id: cmake_build
+        continue-on-error: true
         run: |
-          echo "Running make clean..."
-          # Execute make clean inside the container
+          echo "Configuring and building OpenImpala with CMake..."
           sudo apptainer exec \
+            --writable-tmpfs \
             --bind $PWD:/src \
             ./dependency_image.sif \
-            bash -c 'source /opt/rh/gcc-toolset-11/enable && cd /src && make clean'
-
-          echo "Running make all..."
-          # Execute make all inside the container, redirect output to log file
-          sudo apptainer exec \
-            --bind $PWD:/src \
-            ./dependency_image.sif \
-            bash -c 'source /opt/rh/gcc-toolset-11/enable && cd /src && make all -j$(nproc)' > make_build_output.log 2>&1
-          MAKE_EXIT_CODE=$?
-          echo "Make build exit code: $MAKE_EXIT_CODE"
-          # Exit the step with the make exit code
-          exit $MAKE_EXIT_CODE
+            bash -c 'source /opt/rh/gcc-toolset-11/enable && \
+                     cd /src && \
+                     rm -rf cmake_build && mkdir cmake_build && cd cmake_build && \
+                     cmake3 .. \
+                       -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_C_COMPILER=$(which mpicc) \
+                       -DCMAKE_CXX_COMPILER=$(which mpicxx) \
+                       -DCMAKE_Fortran_COMPILER=$(which mpif90) \
+                       -DCMAKE_PREFIX_PATH="/opt/amrex/25.03;/opt/hypre/v2.32.0;/opt/hdf5/1.12.3;/opt/libtiff/4.6.0" \
+                       -DBUILD_TESTING=ON && \
+                     make -j$(nproc)' > cmake_build_output.log 2>&1
+          CMAKE_EXIT_CODE=$?
+          echo "CMake build exit code: $CMAKE_EXIT_CODE"
+          exit $CMAKE_EXIT_CODE
 
       # Step 8: Upload Build Log
       - name: Upload Build Log
-        if: always() # Always run to upload log even if build failed
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: make-build-log-${{ github.run_id }}
-          path: make_build_output.log
+          name: cmake-build-log-${{ github.run_id }}
+          path: cmake_build_output.log
           retention-days: 5
           if-no-files-found: warn
 
-      # Step 9: Explicitly fail the JOB if the make build step failed
+      # Step 9: Fail if build failed
       - name: Check build outcome
-        if: steps.make_build.outcome == 'failure'
+        if: steps.cmake_build.outcome == 'failure'
         run: |
-          echo "Make build command failed. See uploaded 'make-build-log' artifact for details."
-          exit 1 # Job stops here if make build failed
+          echo "CMake build failed. See uploaded 'cmake-build-log' artifact for details."
+          cat cmake_build_output.log || true
+          exit 1
 
-      # Step 9.5: Check Test TIFF File Before Running Tests (Optional debug)
+      # Step 9.5: Check Test TIFF File Before Running Tests
       - name: Check Test TIFF File Status Inside Container
-        # Run only if build succeeded, before running tests
-        if: steps.make_build.outcome == 'success'
+        if: steps.cmake_build.outcome == 'success'
         run: |
-          echo "Checking status of data/SampleData_2Phase_stack_3d_1bit.tif inside container..." # Use correct filename
-          TARGET_FILE="data/SampleData_2Phase_stack_3d_1bit.tif" # Use correct filename
-          # Execute commands inside container to check the file
+          echo "Checking status of data/SampleData_2Phase_stack_3d_1bit.tif inside container..."
+          TARGET_FILE="data/SampleData_2Phase_stack_3d_1bit.tif"
           sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
@@ -323,66 +293,52 @@ jobs:
                      echo '--- Running tiffinfo:' && \
                      tiffinfo \"${TARGET_FILE}\"" || echo "::warning::Checking test file failed, proceeding anyway..."
           echo "Finished checking test file status."
-        continue-on-error: true # Don't fail workflow if this check fails
+        continue-on-error: true
 
-      # Step 10: Run Tests and Copy Backtrace
-      - name: Run Tests and Copy Backtrace
-        id: make_test
-        # This step is only reached if the build (Step 7/9) succeeded
-        if: steps.make_build.outcome == 'success'
-        continue-on-error: true # Keep this true to allow log/artifact upload on test failure
+      # Step 10: Run Tests with CTest
+      - name: Run Tests (CTest)
+        id: ctest_run
+        if: steps.cmake_build.outcome == 'success'
+        continue-on-error: true
         run: |
-          echo "Running make test..."
-          # Add timeout (e.g., 1200 seconds = 20 minutes). Adjust time as needed.
-          # Run tests within timeout, redirect stdout/stderr to log file
+          echo "Running ctest..."
           timeout 1200 sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
-            bash -c 'source /opt/rh/gcc-toolset-11/enable && cd /src && make test' > make_test_output.log 2>&1
+            bash -c 'source /opt/rh/gcc-toolset-11/enable && \
+                     cd /src/cmake_build && \
+                     ctest --output-on-failure --timeout 300' > ctest_output.log 2>&1
           TEST_EXIT_CODE=$?
-          # Check if timeout occurred (exit code 124 for GNU timeout)
           if [ $TEST_EXIT_CODE -eq 124 ]; then
               echo "::error::Test step timed out after 20 minutes!"
-              # The job will fail later based on steps.make_test.outcome == 'failure' anyway,
-              # but this provides an explicit error message in the logs.
           fi
-          echo "Make test exit code: $TEST_EXIT_CODE"
+          echo "CTest exit code: $TEST_EXIT_CODE"
 
-          # --- Attempt to copy Backtrace files from container's /src to host's PWD ---
-          echo "Attempting to find and copy Backtrace files from /src inside container..."
-          # Use find within the container, execute cp to copy to the bound /src dir ($PWD). Ignore errors if not found.
+          # Attempt to copy Backtrace files
+          echo "Attempting to find and copy Backtrace files..."
           sudo apptainer exec \
             --bind $PWD:/src \
             ./dependency_image.sif \
-            bash -c 'find /src -maxdepth 1 -name "Backtrace.*" -exec echo "==> Found Backtrace file:" {} \; -exec cp {} /src/ \;' || true
+            bash -c 'find /src -maxdepth 2 -name "Backtrace.*" -exec echo "==> Found Backtrace file:" {} \; -exec cp {} /src/ \;' || true
 
-          echo "Listing files in PWD (workspace: $PWD) after copy attempt:"
-          ls -la "$PWD"
-          # --- End copy attempt ---
-
-          # Exit step with the original test exit code
-          echo "Exiting step with original test code: $TEST_EXIT_CODE"
           exit $TEST_EXIT_CODE
 
       # Step 11: Upload Test Log and Backtrace
       - name: Upload Test Log and Backtrace Artifacts
-        # This step runs even if make_test failed (due to continue-on-error), but only if build succeeded
-        if: always() && steps.make_build.outcome == 'success'
+        if: always() && steps.cmake_build.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
-          name: make-test-output-${{ github.run_id }}
+          name: ctest-output-${{ github.run_id }}
           path: |
-            make_test_output.log
+            ctest_output.log
             Backtrace.*
-            debug_matrix_state.log # Keep this if you added matrix printing
           retention-days: 5
-          if-no-files-found: warn # Use warn instead of error if no backtrace/debug files found
+          if-no-files-found: warn
 
-      # Step 12: Explicitly fail the JOB if the make test step failed
+      # Step 12: Fail if tests failed
       - name: Check test outcome
-        # This step is only reached if the build (Step 7/9) succeeded
-        if: steps.make_build.outcome == 'success' && steps.make_test.outcome == 'failure'
+        if: steps.cmake_build.outcome == 'success' && steps.ctest_run.outcome == 'failure'
         run: |
-          echo "Make test command failed. See uploaded 'make-test-output' artifact for details."
-          exit 1 # Job stops here if make test failed
-
+          echo "CTest failed. See uploaded 'ctest-output' artifact for details."
+          cat ctest_output.log || true
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,26 @@ jobs:
           path: dependency_image.sif
           key: ${{ steps.cache-restore-sif.outputs.cache-primary-key || format('{0}-apptainer-sif-{1}', runner.os, hashFiles('containers/Singularity.deps.def')) }}
 
-      - name: Compile Application Binaries
+      - name: Compile Application Binaries (CMake)
         run: |
-          echo "Compiling application executables inside the dependency container..."
+          echo "Compiling application executables inside the dependency container using CMake..."
           sudo apptainer exec \
+            --writable-tmpfs \
             --bind $PWD:/src \
             ./dependency_image.sif \
-            bash -c 'source /opt/rh/gcc-toolset-11/enable && cd /src && make all -j$(nproc)'
+            bash -c 'source /opt/rh/gcc-toolset-11/enable && \
+                     cd /src && \
+                     rm -rf cmake_build && mkdir cmake_build && cd cmake_build && \
+                     cmake3 .. \
+                       -DCMAKE_BUILD_TYPE=Release \
+                       -DCMAKE_C_COMPILER=$(which mpicc) \
+                       -DCMAKE_CXX_COMPILER=$(which mpicxx) \
+                       -DCMAKE_Fortran_COMPILER=$(which mpif90) \
+                       -DCMAKE_PREFIX_PATH="/opt/amrex/25.03;/opt/hypre/v2.32.0;/opt/hdf5/1.12.3;/opt/libtiff/4.6.0" \
+                       -DBUILD_TESTING=OFF \
+                       -DCMAKE_INSTALL_PREFIX=/src/cmake_install && \
+                     make -j$(nproc) && \
+                     make install'
           echo "Compilation complete."
 
       - name: Build Final Release SIF
@@ -58,7 +71,7 @@ jobs:
           echo "Using staging directory: $STAGING_DIR"
 
           echo "Copying compiled application binaries and custom libraries to staging area..."
-          cp -r ./build/apps "$STAGING_DIR/"
+          cp -r ./cmake_install/bin "$STAGING_DIR/apps"
           sudo apptainer exec \
             --bind "$STAGING_DIR:/staging" \
             ./dependency_image.sif \

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,15 @@
 tmp_build_dir
 build
+cmake_build
+cmake_install
 .DS_Store
 plt*
 phi*
 Backtrace*
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+Makefile
+*.mod

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,88 @@
+# ==============================================================================
+# OpenImpala - CMake Build System
+# ==============================================================================
+#
+# Usage (inside the Singularity/Apptainer container):
+#   mkdir build && cd build
+#   cmake ..
+#   make -j$(nproc)
+#   ctest
+#
+# Usage (native build with custom dependency paths):
+#   cmake .. -DCMAKE_PREFIX_PATH="/path/to/amrex;/path/to/hypre;/path/to/hdf5;/path/to/libtiff"
+#
+# ==============================================================================
+
+cmake_minimum_required(VERSION 3.18)
+
+project(OpenImpala
+    VERSION 0.1.0
+    LANGUAGES C CXX Fortran
+    DESCRIPTION "Image-based simulation of transport properties in porous media"
+)
+
+# ==============================================================================
+# C++ Standard
+# ==============================================================================
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# ==============================================================================
+# Build type defaults
+# ==============================================================================
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo)
+endif()
+
+# ==============================================================================
+# Custom CMake modules
+# ==============================================================================
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+# ==============================================================================
+# Dependencies
+# ==============================================================================
+
+# --- MPI ---
+find_package(MPI REQUIRED COMPONENTS CXX Fortran)
+
+# --- OpenMP ---
+find_package(OpenMP REQUIRED COMPONENTS CXX Fortran)
+
+# --- AMReX ---
+# AMReX ships AMReXConfig.cmake when installed via CMake.
+# The container sets CMAKE_PREFIX_PATH to include the AMReX install prefix.
+find_package(AMReX REQUIRED)
+
+# --- HYPRE ---
+# HYPRE is built with autoconf in the container, so we use our own FindHYPRE.cmake.
+# If HYPRE was built with CMake and installed, find_package(HYPRE CONFIG) would work instead.
+find_package(HYPRE REQUIRED)
+
+# --- HDF5 ---
+# We need the C++ bindings (hdf5_cpp).
+find_package(HDF5 REQUIRED COMPONENTS C CXX)
+
+# --- TIFF ---
+find_package(TIFF REQUIRED)
+
+# ==============================================================================
+# Compiler flags
+# ==============================================================================
+# AMReX requires -DOMPI_SKIP_MPICXX to prevent inclusion of the deprecated MPI C++ bindings.
+add_compile_definitions(OMPI_SKIP_MPICXX)
+
+# ==============================================================================
+# Library targets
+# ==============================================================================
+add_subdirectory(src)
+
+# ==============================================================================
+# Testing
+# ==============================================================================
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,15 @@
+# ==============================================================================
+# DEPRECATED: This GNUmakefile is retained for backward compatibility.
+# The project has migrated to CMake. Please use the CMake build system:
+#
+#   mkdir cmake_build && cd cmake_build
+#   cmake ..
+#   make -j$(nproc)
+#   ctest
+#
+# This Makefile will be removed in a future release.
+# ==============================================================================
+#
 # GNU MakeFile for OpenImpala Diffusion Application and Tests
 # Corrected version 2: Uses Static Pattern Rules for compilation.
 

--- a/cmake/FindHYPRE.cmake
+++ b/cmake/FindHYPRE.cmake
@@ -1,0 +1,61 @@
+# FindHYPRE.cmake
+# ----------------
+# Find the HYPRE library (https://github.com/hypre-space/hypre).
+#
+# This module is needed when HYPRE was built with autoconf (./configure)
+# rather than CMake, so no HYPREConfig.cmake is installed.
+#
+# The following variables influence the search:
+#   HYPRE_ROOT / HYPRE_HOME / ENV{HYPRE_HOME}
+#
+# This module defines:
+#   HYPRE_FOUND        - True if HYPRE was found
+#   HYPRE_INCLUDE_DIRS - HYPRE include directories
+#   HYPRE_LIBRARIES    - HYPRE libraries to link against
+#
+# And the imported target:
+#   HYPRE::HYPRE
+
+# Look for the header
+find_path(HYPRE_INCLUDE_DIR
+    NAMES HYPRE.h
+    HINTS
+        ${HYPRE_ROOT}
+        ${HYPRE_HOME}
+        $ENV{HYPRE_ROOT}
+        $ENV{HYPRE_HOME}
+        $ENV{HYPRE_INSTALL_PREFIX}
+    PATH_SUFFIXES include
+)
+
+# Look for the library
+find_library(HYPRE_LIBRARY
+    NAMES HYPRE
+    HINTS
+        ${HYPRE_ROOT}
+        ${HYPRE_HOME}
+        $ENV{HYPRE_ROOT}
+        $ENV{HYPRE_HOME}
+        $ENV{HYPRE_INSTALL_PREFIX}
+    PATH_SUFFIXES lib lib64
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HYPRE
+    REQUIRED_VARS HYPRE_LIBRARY HYPRE_INCLUDE_DIR
+)
+
+if(HYPRE_FOUND)
+    set(HYPRE_INCLUDE_DIRS ${HYPRE_INCLUDE_DIR})
+    set(HYPRE_LIBRARIES ${HYPRE_LIBRARY})
+
+    if(NOT TARGET HYPRE::HYPRE)
+        add_library(HYPRE::HYPRE UNKNOWN IMPORTED)
+        set_target_properties(HYPRE::HYPRE PROPERTIES
+            IMPORTED_LOCATION "${HYPRE_LIBRARY}"
+            INTERFACE_INCLUDE_DIRECTORIES "${HYPRE_INCLUDE_DIR}"
+        )
+    endif()
+endif()
+
+mark_as_advanced(HYPRE_INCLUDE_DIR HYPRE_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,100 @@
+# ==============================================================================
+# OpenImpala - src/ CMakeLists.txt
+# Builds the IO and Props library targets and the Diffusion application.
+# ==============================================================================
+
+# ==============================================================================
+# IO Library
+# ==============================================================================
+# Library sources (exclude test drivers that start with 't')
+add_library(openimpala_io OBJECT
+    io/CathodeWrite.cpp
+    io/DatReader.cpp
+    io/HDF5Reader.cpp
+    io/RawReader.cpp
+    io/TiffReader.cpp
+)
+
+target_include_directories(openimpala_io PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/io
+)
+
+target_link_libraries(openimpala_io PUBLIC
+    AMReX::amrex
+    MPI::MPI_CXX
+    OpenMP::OpenMP_CXX
+    ${HDF5_CXX_LIBRARIES}
+    ${HDF5_C_LIBRARIES}
+    TIFF::TIFF
+)
+
+target_include_directories(openimpala_io PUBLIC
+    ${HDF5_INCLUDE_DIRS}
+)
+
+# ==============================================================================
+# Props Library (C++ and Fortran)
+# ==============================================================================
+add_library(openimpala_props OBJECT
+    # C++ sources
+    props/EffectiveDiffusivityHypre.cpp
+    props/TortuosityDirect.cpp
+    props/TortuosityHypre.cpp
+    props/VolumeFraction.cpp
+    # Fortran sources
+    props/EffDiffFillMtx.F90
+    props/TortuosityHypreFill.F90
+    props/Tortuosity_filcc.F90
+    props/Tortuosity_poisson_3d.F90
+)
+
+target_include_directories(openimpala_props PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/props
+    ${CMAKE_CURRENT_SOURCE_DIR}/io
+)
+
+# Fortran module output directory
+set_target_properties(openimpala_props PROPERTIES
+    Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran_modules
+)
+
+target_include_directories(openimpala_props PUBLIC
+    ${CMAKE_BINARY_DIR}/fortran_modules
+)
+
+target_link_libraries(openimpala_props PUBLIC
+    AMReX::amrex
+    HYPRE::HYPRE
+    MPI::MPI_CXX
+    MPI::MPI_Fortran
+    OpenMP::OpenMP_CXX
+    OpenMP::OpenMP_Fortran
+)
+
+# ==============================================================================
+# Diffusion Application
+# ==============================================================================
+add_executable(Diffusion
+    props/Diffusion.cpp
+)
+
+target_link_libraries(Diffusion PRIVATE
+    openimpala_io
+    openimpala_props
+    AMReX::amrex
+    HYPRE::HYPRE
+    ${HDF5_CXX_LIBRARIES}
+    ${HDF5_C_LIBRARIES}
+    TIFF::TIFF
+    MPI::MPI_CXX
+    OpenMP::OpenMP_CXX
+)
+
+target_include_directories(Diffusion PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/io
+    ${CMAKE_CURRENT_SOURCE_DIR}/props
+    ${HDF5_INCLUDE_DIRS}
+)
+
+# Install the main executable
+install(TARGETS Diffusion RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,78 @@
+# ==============================================================================
+# OpenImpala - tests/ CMakeLists.txt
+# Builds test executables and registers them with CTest.
+#
+# Test source files currently live in src/io/ and src/props/ (prefixed with 't').
+# Each test is an independent executable that links against the project libraries.
+# Tests are run via: mpirun -np 1 <test_exe> <inputs_file>
+# ==============================================================================
+
+# Common link libraries for all tests
+set(OPENIMPALA_TEST_LIBS
+    openimpala_io
+    openimpala_props
+    AMReX::amrex
+    HYPRE::HYPRE
+    ${HDF5_CXX_LIBRARIES}
+    ${HDF5_C_LIBRARIES}
+    TIFF::TIFF
+    MPI::MPI_CXX
+    OpenMP::OpenMP_CXX
+)
+
+set(OPENIMPALA_TEST_INCLUDES
+    ${CMAKE_SOURCE_DIR}/src/io
+    ${CMAKE_SOURCE_DIR}/src/props
+    ${HDF5_INCLUDE_DIRS}
+)
+
+# Helper: define a test executable and register it with CTest.
+# If an inputs file exists in tests/inputs/<name>.inputs, it is passed as an argument.
+function(openimpala_add_test TEST_NAME SOURCE_FILE)
+    add_executable(${TEST_NAME} ${SOURCE_FILE})
+    target_link_libraries(${TEST_NAME} PRIVATE ${OPENIMPALA_TEST_LIBS})
+    target_include_directories(${TEST_NAME} PRIVATE ${OPENIMPALA_TEST_INCLUDES})
+
+    # Check for a matching inputs file
+    set(INPUTS_FILE "${CMAKE_SOURCE_DIR}/tests/inputs/${TEST_NAME}.inputs")
+    if(EXISTS "${INPUTS_FILE}")
+        add_test(
+            NAME ${TEST_NAME}
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+                    ${MPIEXEC_PREFLAGS}
+                    $<TARGET_FILE:${TEST_NAME}>
+                    ${INPUTS_FILE}
+                    amrex.verbose=0
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+    else()
+        add_test(
+            NAME ${TEST_NAME}
+            COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+                    ${MPIEXEC_PREFLAGS}
+                    $<TARGET_FILE:${TEST_NAME}>
+                    amrex.verbose=0
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+    endif()
+
+    # Allow running as root inside containers
+    set_tests_properties(${TEST_NAME} PROPERTIES
+        ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
+        TIMEOUT 300
+    )
+endfunction()
+
+# ==============================================================================
+# IO Tests
+# ==============================================================================
+openimpala_add_test(tTiffReader    "${CMAKE_SOURCE_DIR}/src/io/tTiffReader.cpp")
+openimpala_add_test(tRawReader     "${CMAKE_SOURCE_DIR}/src/io/tRawReader.cpp")
+openimpala_add_test(tHDF5Reader    "${CMAKE_SOURCE_DIR}/src/io/tHDF5Reader.cpp")
+
+# ==============================================================================
+# Props Tests
+# ==============================================================================
+openimpala_add_test(tTortuosity             "${CMAKE_SOURCE_DIR}/src/props/tTortuosity.cpp")
+openimpala_add_test(tVolumeFraction         "${CMAKE_SOURCE_DIR}/src/props/tVolumeFraction.cpp")
+openimpala_add_test(tEffectiveDiffusivity   "${CMAKE_SOURCE_DIR}/src/props/tEffectiveDiffusivity.cpp")


### PR DESCRIPTION
Replace the hand-written GNUmakefile with a proper CMake build system that aligns with AMReX ecosystem conventions. This lowers the contributor barrier by enabling standard cmake/make/ctest workflows, IDE integration, and native builds without the Singularity container.

New files:
- CMakeLists.txt: Root config with find_package for AMReX, HYPRE, HDF5, TIFF
- cmake/FindHYPRE.cmake: Custom find module for autoconf-built HYPRE
- src/CMakeLists.txt: IO and Props library targets plus Diffusion executable
- tests/CMakeLists.txt: Test executables registered with CTest

Updated files:
- .github/workflows/build-test.yml: CI uses cmake3 + ctest instead of make
- .github/workflows/release.yml: Release build uses CMake
- .gitignore: Added cmake_build/, cmake_install/, CMake artifacts
- GNUmakefile: Added deprecation notice (retained for backward compat)
