### PR TITLE
Add multi-phase transport coefficient support (Issue #3)

### DIFF
--- a/src/props/EffDiffFillMtx_F.H
+++ b/src/props/EffDiffFillMtx_F.H
@@ -59,7 +59,8 @@ extern "C" {
  */
 void effdiff_fillmtx(amrex_real* a_out, amrex_real* rhs_out, amrex_real* xinit_out,
                      const int* npts_valid, const int* active_mask_ptr, const int* mask_lo,
-                     const int* mask_hi, const int* valid_bx_lo, const int* valid_bx_hi,
+                     const int* mask_hi, const amrex_real* diff_coeff_ptr, const int* dc_lo,
+                     const int* dc_hi, const int* valid_bx_lo, const int* valid_bx_hi,
                      const int* domain_lo, const int* domain_hi, const amrex_real* cell_sizes_in,
                      const int* dir_k_in, const int* verbose_level_in);
 

--- a/src/props/EffectiveDiffusivityHypre.H
+++ b/src/props/EffectiveDiffusivityHypre.H
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <limits>
+#include <map>
 
 #include <AMReX.H>
 #include <AMReX_iMultiFab.H>
@@ -113,7 +114,10 @@ public:
     }
     const amrex::iMultiFab& getActiveMask() const {
         return m_mf_active_mask;
-    } // Useful for D_eff calc
+    }
+    const amrex::MultiFab& getDiffCoeff() const {
+        return m_mf_diff_coeff;
+    }
 
     // Static Helper Functions for HYPRE box conversion (can be shared if moved to a common utility)
     static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> loV(const amrex::Box& b);
@@ -145,7 +149,12 @@ private:
     const amrex::DistributionMapping& m_dm;
     amrex::iMultiFab m_mf_phase_original; // Stores the input phase data
     amrex::iMultiFab m_mf_active_mask;    // Binary mask (1 for active phase, 0 otherwise)
+    amrex::MultiFab m_mf_diff_coeff;      // Spatially varying transport coefficient D(x)
     amrex::MultiFab m_mf_chi;             // Stores the solved chi_k for internal use/plotting
+
+    // Multi-phase configuration
+    std::map<int, amrex::Real> m_phase_coeff_map; // Maps phase ID -> transport coefficient
+    bool m_is_multi_phase = false;
 
     // Solver Statistics
     HYPRE_Int m_num_iterations;
@@ -182,12 +191,12 @@ extern "C" {
  * @param dir_k Integer representing the direction of ê_k (0 for X, 1 for Y, 2 for Z).
  * @param verbose_level Verbosity level for debugging in Fortran.
  */
-void effdiff_fillmtx( // Name matches the one used in the .cpp
-    amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit, const int* npts_valid,
-    const int* active_mask_ptr, const int* mask_lo, const int* mask_hi, const int* valid_bx_lo,
-    const int* valid_bx_hi, const int* domain_lo, const int* domain_hi,
-    const amrex::Real* cell_sizes, // Pass dx, dy, dz
-    const int* dir_k, const int* verbose_level);
+void effdiff_fillmtx(amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit, const int* npts_valid,
+                     const int* active_mask_ptr, const int* mask_lo, const int* mask_hi,
+                     const amrex::Real* diff_coeff_ptr, const int* dc_lo, const int* dc_hi,
+                     const int* valid_bx_lo, const int* valid_bx_hi, const int* domain_lo,
+                     const int* domain_hi, const amrex::Real* cell_sizes, const int* dir_k,
+                     const int* verbose_level);
 }
 
 

--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -4,6 +4,7 @@
 #include <string> // Needed for std::string
 #include <vector> // Needed for Vector<IntVect> in helper functions
 #include <limits> // Needed for std::numeric_limits
+#include <map>    // Needed for phase-coefficient mapping
 
 #include <AMReX.H>
 #include <AMReX_iMultiFab.H>
@@ -129,6 +130,16 @@ public:
     }
     // --- END ADD ---
 
+    /** @brief Returns true if multi-phase transport coefficients are configured. */
+    bool isMultiPhase() const {
+        return m_is_multi_phase;
+    }
+
+    /** @brief Returns the phase-to-coefficient mapping. */
+    const std::map<int, amrex::Real>& getPhaseCoeffMap() const {
+        return m_phase_coeff_map;
+    }
+
 
     // Static Helper Functions
     static amrex::Array<HYPRE_Int, AMREX_SPACEDIM> loV(const amrex::Box& b);
@@ -171,6 +182,11 @@ private:
     amrex::iMultiFab m_mf_phase;
     amrex::MultiFab m_mf_phi;
     amrex::iMultiFab m_mf_active_mask;
+    amrex::MultiFab m_mf_diff_coeff; ///< Spatially varying transport coefficient D(x)
+
+    // Multi-phase configuration
+    std::map<int, amrex::Real> m_phase_coeff_map; ///< Maps phase ID -> transport coefficient
+    bool m_is_multi_phase = false;                ///< True if multiple conducting phases configured
 
     // State
     amrex::Real m_value = std::numeric_limits<amrex::Real>::quiet_NaN();
@@ -201,7 +217,8 @@ private:
 extern "C" {
 void tortuosity_fillmtx(amrex::Real* a, amrex::Real* rhs, amrex::Real* xinit, const int* nval,
                         const int* p, const int* p_lo, const int* p_hi, const int* active_mask,
-                        const int* mask_lo, const int* mask_hi, const int* bxlo, const int* bxhi,
+                        const int* mask_lo, const int* mask_hi, const amrex::Real* diff_coeff,
+                        const int* dc_lo, const int* dc_hi, const int* bxlo, const int* bxhi,
                         const int* domlo, const int* domhi, const amrex::Real* dxinv,
                         const amrex::Real* vlo, const amrex::Real* vhi, const int* phase_unused,
                         const int* dir, const int* debug_print_level);

--- a/src/props/TortuosityHypreFill.F90
+++ b/src/props/TortuosityHypreFill.F90
@@ -36,14 +36,15 @@ module tortuosity_poisson_3d_module
 contains
 
   ! ::: -----------------------------------------------------------
-  ! ::: Fills HYPRE matrix coefficients for a Poisson equation.
-  ! ::: Constructs the matrix for cells that belong to the specified 'phase'
-  ! ::: AND are marked as active in the 'active_mask' (i.e., part of a
-  ! ::: percolating path).
+  ! ::: Fills HYPRE matrix coefficients for a variable-coefficient
+  ! ::: diffusion equation: div(D(x) grad(phi)) = 0
+  ! ::: Uses harmonic mean for face coefficients between cells.
+  ! ::: Supports multi-phase computations with spatially varying D.
   ! ::: -----------------------------------------------------------
   subroutine tortuosity_fillmtx(a, rhs, xinit, nval, &
                                 p, p_lo, p_hi, &
                                 active_mask, mask_lo, mask_hi, &
+                                diff_coeff, dc_lo, dc_hi, &
                                 bxlo, bxhi, domlo, domhi, dxinv, vlo, vhi, phase, dir, &
                                 debug_print_level) bind(c)
 
@@ -56,11 +57,15 @@ contains
     integer,            intent(in)  :: active_mask(mask_lo(1):mask_hi(1), &
                                                      mask_lo(2):mask_hi(2), &
                                                      mask_lo(3):mask_hi(3))
+    integer,            intent(in)  :: dc_lo(3), dc_hi(3)
+    real(amrex_real),   intent(in)  :: diff_coeff(dc_lo(1):dc_hi(1), &
+                                                    dc_lo(2):dc_hi(2), &
+                                                    dc_lo(3):dc_hi(3))
     integer,            intent(in)  :: bxlo(3), bxhi(3)
     integer,            intent(in)  :: domlo(3), domhi(3)
     real(amrex_real),   intent(in)  :: dxinv(3) ! [1/dx^2, 1/dy^2, 1/dz^2]
     real(amrex_real),   intent(in)  :: vlo, vhi
-    integer,            intent(in)  :: phase, dir ! The phase ID to solve for
+    integer,            intent(in)  :: phase, dir ! phase kept for backwards compat
     integer,            intent(in)  :: debug_print_level
 
     ! Local variables
@@ -68,6 +73,7 @@ contains
     integer :: len_x, len_y, len_z, expected_nval
     real(amrex_real) :: diag_val, coeff_x, coeff_y, coeff_z
     real(amrex_real) :: domain_extent, factor
+    real(amrex_real) :: D_c, D_nbr, D_face
     logical :: on_dirichlet_boundary
     logical :: has_inactive_neighbor
     ! Debugging variables
@@ -81,12 +87,12 @@ contains
     len_z = bxhi(3) - bxlo(3) + 1
     expected_nval = len_x * len_y * len_z
 
-    ! Pre-calculate stencil coefficients based on grid spacing
+    ! Pre-calculate inverse grid spacing squared
     coeff_x = dxinv(1)
     coeff_y = dxinv(2)
     coeff_z = dxinv(3)
 
-    ! Check consistency between expected nval and passed nval (only if box not empty)
+    ! Check consistency
     if (expected_nval > 0 .and. expected_nval /= nval) then
        call amrex_abort("tortuosity_fillmtx: nval mismatch.")
     end if
@@ -107,8 +113,8 @@ contains
           has_inactive_neighbor = .false.
 
           ! --- Check if the cell is part of the simulation ---
-          ! It must both be in the correct phase AND part of the percolating mask.
-          if ( p(i,j,k,comp_phase) /= phase .or. active_mask(i,j,k) == cell_inactive ) then
+          ! Cell must be marked active in the percolating mask.
+          if ( active_mask(i,j,k) == cell_inactive ) then
               ! --- Apply Explicit Decoupling for INACTIVE cells ---
               a(stencil_idx_start : stencil_idx_start + nstencil - 1) = 0.0_amrex_real
               a(stencil_idx_start + istn_c) = 1.0_amrex_real
@@ -117,50 +123,70 @@ contains
               cycle ! Skip to next (i,j,k)
           end if
 
-          ! --- If we reach here, cell (i,j,k) is ACTIVE and in the correct PHASE ---
+          ! --- If we reach here, cell (i,j,k) is ACTIVE ---
+          D_c = diff_coeff(i,j,k)
           diag_val = 0.0_amrex_real
-          a(stencil_idx_start : stencil_idx_start + nstencil - 1) = 0.0_amrex_real ! Initialize stencil row to zero
+          a(stencil_idx_start : stencil_idx_start + nstencil - 1) = 0.0_amrex_real
 
-          ! --- Assemble stencil based on ACTIVE neighbors in the same PHASE ---
+          ! --- Assemble stencil using harmonic mean face coefficients ---
+          ! For each face: D_face = 2*D_c*D_nbr / (D_c + D_nbr)
+
           ! -X face
-          if ( p(i-1,j,k,comp_phase) == phase .and. active_mask(i-1,j,k) == cell_active ) then
-             a(stencil_idx_start + istn_mx) = -coeff_x
-             diag_val = diag_val + coeff_x
+          if ( active_mask(i-1,j,k) == cell_active ) then
+             D_nbr = diff_coeff(i-1,j,k)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_mx) = -D_face * coeff_x
+             diag_val = diag_val + D_face * coeff_x
           else
              has_inactive_neighbor = .true.
           end if
+
           ! +X face
-          if ( p(i+1,j,k,comp_phase) == phase .and. active_mask(i+1,j,k) == cell_active ) then
-             a(stencil_idx_start + istn_px) = -coeff_x
-             diag_val = diag_val + coeff_x
+          if ( active_mask(i+1,j,k) == cell_active ) then
+             D_nbr = diff_coeff(i+1,j,k)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_px) = -D_face * coeff_x
+             diag_val = diag_val + D_face * coeff_x
           else
              has_inactive_neighbor = .true.
           end if
+
           ! -Y face
-          if ( p(i,j-1,k,comp_phase) == phase .and. active_mask(i,j-1,k) == cell_active ) then
-             a(stencil_idx_start + istn_my) = -coeff_y
-             diag_val = diag_val + coeff_y
+          if ( active_mask(i,j-1,k) == cell_active ) then
+             D_nbr = diff_coeff(i,j-1,k)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_my) = -D_face * coeff_y
+             diag_val = diag_val + D_face * coeff_y
           else
              has_inactive_neighbor = .true.
           end if
+
           ! +Y face
-          if ( p(i,j+1,k,comp_phase) == phase .and. active_mask(i,j+1,k) == cell_active ) then
-             a(stencil_idx_start + istn_py) = -coeff_y
-             diag_val = diag_val + coeff_y
+          if ( active_mask(i,j+1,k) == cell_active ) then
+             D_nbr = diff_coeff(i,j+1,k)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_py) = -D_face * coeff_y
+             diag_val = diag_val + D_face * coeff_y
           else
              has_inactive_neighbor = .true.
           end if
+
           ! -Z face
-          if ( p(i,j,k-1,comp_phase) == phase .and. active_mask(i,j,k-1) == cell_active ) then
-             a(stencil_idx_start + istn_mz) = -coeff_z
-             diag_val = diag_val + coeff_z
+          if ( active_mask(i,j,k-1) == cell_active ) then
+             D_nbr = diff_coeff(i,j,k-1)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_mz) = -D_face * coeff_z
+             diag_val = diag_val + D_face * coeff_z
           else
              has_inactive_neighbor = .true.
           end if
-           ! +Z face
-          if ( p(i,j,k+1,comp_phase) == phase .and. active_mask(i,j,k+1) == cell_active ) then
-             a(stencil_idx_start + istn_pz) = -coeff_z
-             diag_val = diag_val + coeff_z
+
+          ! +Z face
+          if ( active_mask(i,j,k+1) == cell_active ) then
+             D_nbr = diff_coeff(i,j,k+1)
+             D_face = 2.0_amrex_real * D_c * D_nbr / (D_c + D_nbr)
+             a(stencil_idx_start + istn_pz) = -D_face * coeff_z
+             diag_val = diag_val + D_face * coeff_z
           else
              has_inactive_neighbor = .true.
           end if
@@ -168,26 +194,20 @@ contains
           ! Set the diagonal entry
           a(stencil_idx_start + istn_c) = diag_val
 
-          ! Check for zero diagonal in an active cell (should only happen if isolated, which mask should prevent)
+          ! Check for zero diagonal in an active cell
           if ( abs(diag_val) < small_real ) then
-             ! This case should ideally not be reached if the mask is correct,
-             ! but as a safety, decouple it.
              write(*,'(A,3I5)') "WARNING: Zero diagonal in ACTIVE cell at (i,j,k)=", i,j,k
              a(stencil_idx_start : stencil_idx_start + nstencil - 1) = 0.0_amrex_real
              a(stencil_idx_start + istn_c) = 1.0_amrex_real
              rhs(m_idx)  = 0.0_amrex_real
-             ! Keep xinit as calculated below or set to 0? Set to 0 for safety.
              xinit(m_idx) = 0.0_amrex_real
-             cycle ! Skip Dirichlet overwrite if we decouple here
+             cycle
           else
-             ! Set default RHS for active interior cells
              rhs(m_idx) = 0.0_amrex_real
           endif
 
 
           ! --- Overwrite stencil for Domain Boundaries Perpendicular to Flow (Dirichlet) ---
-          ! This applies AFTER the active cell logic. If an active cell is on the
-          ! Dirichlet boundary, its equation becomes Aii=1, bi=V.
           on_dirichlet_boundary = .false.
           if ( dir == direction_x ) then
               if ( i == domlo(1) ) then
@@ -228,10 +248,7 @@ contains
           end if ! End of Dirichlet BC overwrite
 
           ! --- Calculate Initial Guess (Only for ACTIVE cells) ---
-          ! Note: Inactive cells had xinit set to 0 already
-          ! If an active cell was decoupled due to safety check, xinit was also set to 0
           if ( abs(a(stencil_idx_start + istn_c) - 1.0_amrex_real) > small_real .or. on_dirichlet_boundary ) then
-             ! Calculate linear ramp only for active cells not safety-decoupled
              if ( dir == direction_x ) then
                  domain_extent = domhi(1) - domlo(1)
                  if (abs(domain_extent) < small_real) then
@@ -263,38 +280,34 @@ contains
 
           ! --- ** Debug Printing Section (Activated if debug_print_level >= 3) ** ---
           if (debug_print_level >= 3) then
-              ! Check if cell is near physical boundary (within 1 cell)
               near_boundary = (i <= domlo(1)+1 .or. i >= domhi(1)-1 .or. &
                                j <= domlo(2)+1 .or. j >= domhi(2)-1 .or. &
                                k <= domlo(3)+1 .or. k >= domhi(3)-1)
 
-              ! Decide whether to print: Print if near boundary OR if it's an interface cell
               print_this_cell = near_boundary .or. has_inactive_neighbor
 
               if (print_this_cell) then
-                  ! Calculate sum of absolute off-diagonals for ratio calculation
                   off_diag_sum = 0.0_amrex_real
-                  do s_idx = 1, nstencil-1 ! Skip diagonal index istn_c = 0
+                  do s_idx = 1, nstencil-1
                       off_diag_sum = off_diag_sum + abs(a(stencil_idx_start + s_idx))
                   end do
 
-                  ! Calculate diagonal dominance ratio
-                  diag_val = a(stencil_idx_start + istn_c) ! Get the final diagonal value
+                  diag_val = a(stencil_idx_start + istn_c)
                   if (abs(off_diag_sum) < small_real) then
                       if (abs(diag_val) < small_real) then
-                          diag_ratio = 1.0_amrex_real ! Define as 1 if both are zero (e.g., isolated active cell?)
+                          diag_ratio = 1.0_amrex_real
                       else
-                          diag_ratio = 1.0e+30_amrex_real ! Indicate infinitely dominant if off-diag is zero
+                          diag_ratio = 1.0e+30_amrex_real
                       end if
                   else
                       diag_ratio = abs(diag_val) / off_diag_sum
                   end if
 
-                  ! Print Information
-                  write(*,'(A,3I5,A,L1,A,L1,A,L1)') "DEBUG Stencil at (", i, j, k, ")", &
-                      " Active=", .true., & ! We know it's active if we reached here
+                  write(*,'(A,3I5,A,L1,A,L1,A,L1,A,ES12.4)') "DEBUG Stencil at (", i, j, k, ")", &
+                      " Active=", .true., &
                       " Dirichlet=", on_dirichlet_boundary, &
-                      " Interface=", has_inactive_neighbor
+                      " Interface=", has_inactive_neighbor, &
+                      " D_c=", D_c
                   write(*,'(A,ES12.4)')   "  RHS =", rhs(m_idx)
                   write(*,'(A,7(ES12.4,1X))') "  Stencil (C, -X,+X, -Y,+Y, -Z,+Z) =" , &
                                              a(stencil_idx_start + istn_c), a(stencil_idx_start + istn_mx), &

--- a/src/props/TortuosityHypreFill_F.H
+++ b/src/props/TortuosityHypreFill_F.H
@@ -53,16 +53,12 @@ extern "C" {
  * calculation. Verify this!
  */
 void tortuosity_fillmtx(amrex_real* a, amrex_real* rhs, amrex_real* xinit, const int* nval,
-                        const int* p, const int* p_lo, const int* p_hi,
-                        const int* active_mask, // <<< NEW
-                        const int* mask_lo,     // <<< NEW
-                        const int* mask_hi,     // <<< NEW
-                        const int* bxlo, const int* bxhi, const int* domlo, const int* domhi,
-                        const amrex_real* dxinv, const amrex_real* vlo, const amrex_real* vhi,
-                        const int* phase_unused, // <<< Renamed
-                        const int* dir,
-                        const int* debug_print_level // <<< ADDED THIS LINE
-);
+                        const int* p, const int* p_lo, const int* p_hi, const int* active_mask,
+                        const int* mask_lo, const int* mask_hi, const amrex_real* diff_coeff,
+                        const int* dc_lo, const int* dc_hi, const int* bxlo, const int* bxhi,
+                        const int* domlo, const int* domhi, const amrex_real* dxinv,
+                        const amrex_real* vlo, const amrex_real* vhi, const int* phase_unused,
+                        const int* dir, const int* debug_print_level);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Implement variable-coefficient diffusion across both TortuosityHypre and EffectiveDiffusivityHypre solvers. Each material phase can now have its own transport coefficient D, enabling multi-phase simulations (e.g. heat flux through composites with different thermal conductivities).

Key changes:
- Parse tortuosity.active_phases and tortuosity.phase_diffusivities from input to build a phase-to-coefficient map
- Build spatially varying D(x) MultiFab from phase data and coefficient map
- Rewrite Fortran stencil kernels (TortuosityHypreFill.F90, EffDiffFillMtx.F90) to use harmonic mean face coefficients: D_face = 2*D_c*D_nbr/(D_c+D_nbr)
- Update C/Fortran interfaces to pass diff_coeff arrays
- Multi-phase percolation via binary traversable mask (D>0 -> 1)
- Update global_fluxes to use D_face for boundary flux computation
- Update D_eff tensor calculation to weight by D(x)
- Full backwards compatibility: without multi-phase params, defaults to single-phase D=1 for target phase

Still need to do test drivers.