### PR TITLE
Add config-driven physics type support for Laplacian transport properties

### DIFF
--- a/src/props/Diffusion.cpp
+++ b/src/props/Diffusion.cpp
@@ -15,7 +15,8 @@
 #include "TortuosityHypre.H"
 #include "VolumeFraction.H"
 #include "PercolationCheck.H"
-#include "Tortuosity.H" // For OpenImpala::Direction enum
+#include "Tortuosity.H"    // For OpenImpala::Direction enum
+#include "PhysicsConfig.H" // For physics-type-aware output
 
 #include <AMReX.H>
 #include <AMReX_Array.H>
@@ -237,6 +238,14 @@ int main(int argc, char* argv[]) {
             ppr.query("results_file", rev_results_filename);
             ppr.query("write_plotfiles", rev_write_plotfiles);
             ppr.query("verbose", rev_verbose_level);
+        }
+
+        // --- Parse physics configuration ---
+        auto physics_config = OpenImpala::PhysicsConfig::fromParmParse();
+        if (main_verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "\n--- Physics Configuration ---\n";
+            physics_config.print(main_verbose);
+            amrex::Print() << "-----------------------------\n\n";
         }
 
         // --- Validate parsed parameters ---
@@ -800,8 +809,8 @@ int main(int argc, char* argv[]) {
                                                          active_mask_full, geom_full, main_verbose);
 
                     if (amrex::ParallelDescriptor::IOProcessor()) {
-                        amrex::Print()
-                            << "Full Domain Effective Diffusivity Tensor D_eff / D_material:\n";
+                        amrex::Print() << "Full Domain Effective " << physics_config.name
+                                       << " Tensor (" << physics_config.ratio_label << "):\n";
                         for (int r_print = 0; r_print < AMREX_SPACEDIM; ++r_print) {
                             amrex::Print() << "  [";
                             for (int c_print = 0; c_print < AMREX_SPACEDIM; ++c_print) {
@@ -810,6 +819,23 @@ int main(int argc, char* argv[]) {
                                                << (c_print == AMREX_SPACEDIM - 1 ? "" : ", ");
                             }
                             amrex::Print() << "]\n";
+                        }
+                        if (physics_config.bulk_property != 1.0) {
+                            amrex::Print()
+                                << "Full Domain Absolute " << physics_config.eff_property_label
+                                << " Tensor (scaled by " << physics_config.coeff_label
+                                << "_bulk=" << std::scientific << physics_config.bulk_property
+                                << "):\n";
+                            for (int r_print = 0; r_print < AMREX_SPACEDIM; ++r_print) {
+                                amrex::Print() << "  [";
+                                for (int c_print = 0; c_print < AMREX_SPACEDIM; ++c_print) {
+                                    amrex::Print() << std::scientific << std::setprecision(8)
+                                                   << physics_config.effectiveProperty(
+                                                          Deff_tensor_full[r_print][c_print])
+                                                   << (c_print == AMREX_SPACEDIM - 1 ? "" : ", ");
+                                }
+                                amrex::Print() << "]\n";
+                            }
                         }
                     }
                 } else {
@@ -868,6 +894,7 @@ int main(int argc, char* argv[]) {
 
                 // --- Parse Directions to Run ---
                 std::map<std::string, amrex::Real> tortuosity_results;
+                std::map<std::string, amrex::Real> deff_ratio_results;
                 std::string direction_str;
                 amrex::ParmParse pp; // Top-level ParmParse to get "direction"
                 pp.get("direction", direction_str);
@@ -940,13 +967,23 @@ int main(int argc, char* argv[]) {
                         (main_write_plotfile_full != 0));
 
                     amrex::Real tau = tort_solver.value();
+                    amrex::Real D_eff_ratio = (tau > 0.0 && !std::isnan(tau) && !std::isinf(tau))
+                                                  ? volume_fraction / tau
+                                                  : 0.0;
 
                     tortuosity_results["Tortuosity_" + dir_char] = tau;
+                    deff_ratio_results[dir_char] = D_eff_ratio;
 
                     if (amrex::ParallelDescriptor::IOProcessor()) {
                         amrex::Print()
                             << "  >>> Calculated Tortuosity (" << dir_char << "): " << std::fixed
                             << std::setprecision(8) << tau << " <<<\n";
+                        if (physics_config.type != OpenImpala::PhysicsType::Diffusion) {
+                            amrex::Print() << "  >>> " << physics_config.eff_property_label << " ("
+                                           << dir_char << "): " << std::scientific
+                                           << physics_config.effectiveProperty(D_eff_ratio)
+                                           << std::defaultfloat << " <<<\n";
+                        }
                     }
                 }
 
@@ -963,15 +1000,12 @@ int main(int argc, char* argv[]) {
 
                     std::ofstream outfile(output_filepath);
                     if (outfile.is_open()) {
-                        outfile << "# Tortuosity Calculation Results (Flow-Through Method)\n";
-                        outfile << "# Input File: " << main_filename << "\n";
-                        outfile << "# Analysis Phase ID: " << main_phase_id_analysis << "\n";
-                        outfile << "# -----------------------------\n";
+                        physics_config.writeHeader(outfile, main_filename, main_phase_id_analysis);
                         outfile << "VolumeFraction: " << std::fixed << std::setprecision(9)
                                 << volume_fraction << "\n";
-                        for (const auto& pair : tortuosity_results) {
-                            outfile << pair.first << ": " << std::fixed << std::setprecision(9)
-                                    << pair.second << "\n";
+                        for (const auto& pair : deff_ratio_results) {
+                            physics_config.writeDirectionResults(outfile, pair.first, pair.second,
+                                                                 volume_fraction);
                         }
                         outfile.close();
                     } else {

--- a/src/props/PhysicsConfig.H
+++ b/src/props/PhysicsConfig.H
@@ -1,0 +1,171 @@
+// --- PhysicsConfig.H ---
+//
+// Lightweight configuration for different Laplacian-type physics problems.
+//
+// The TortuosityHypre / EffectiveDiffusivityHypre solvers compute an effective
+// transport ratio (D_eff / D_phase).  This struct maps that raw output to
+// the appropriate physical quantity: effective conductivity, formation factor,
+// thermal conductivity, etc.
+//
+// Usage:
+//   auto physics = OpenImpala::PhysicsConfig::fromParmParse();
+//   amrex::Real sigma_eff = physics.effectiveProperty(D_eff_ratio);
+//
+// Input file (all optional — defaults to Diffusion with unit bulk property):
+//   physics.type = electrical_conductivity
+//   physics.bulk_property = 1.5e7
+
+#ifndef PHYSICSCONFIG_H
+#define PHYSICSCONFIG_H
+
+#include <AMReX_REAL.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+#include <AMReX_ParallelDescriptor.H>
+
+#include <string>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace OpenImpala {
+
+enum class PhysicsType {
+    Diffusion,
+    ElectricalConductivity,
+    ThermalConductivity,
+    DielectricPermittivity,
+    MagneticPermeability
+};
+
+struct PhysicsConfig {
+    PhysicsType type = PhysicsType::Diffusion;
+
+    // Human-readable labels for output
+    std::string name;
+    std::string coeff_label;
+    std::string field_label;
+    std::string eff_property_label;
+    std::string ratio_label;
+
+    // User-supplied bulk/reference property value (e.g. sigma_bulk)
+    amrex::Real bulk_property = 1.0;
+
+    // --- Interpret raw solver output ---
+
+    amrex::Real effectiveProperty(amrex::Real D_eff_ratio) const {
+        return D_eff_ratio * bulk_property;
+    }
+
+    amrex::Real tortuosityFactor(amrex::Real D_eff_ratio, amrex::Real vf) const {
+        if (D_eff_ratio > 0.0)
+            return vf / D_eff_ratio;
+        return std::numeric_limits<amrex::Real>::infinity();
+    }
+
+    amrex::Real formationFactor(amrex::Real D_eff_ratio) const {
+        if (D_eff_ratio > 0.0)
+            return 1.0 / D_eff_ratio;
+        return std::numeric_limits<amrex::Real>::infinity();
+    }
+
+    // --- Factory: build from input file parameters ---
+    static PhysicsConfig fromParmParse() {
+        PhysicsConfig cfg;
+
+        amrex::ParmParse pp("physics");
+        std::string type_str = "diffusion";
+        pp.query("type", type_str);
+        pp.query("bulk_property", cfg.bulk_property);
+
+        // Normalise to lowercase
+        std::transform(type_str.begin(), type_str.end(), type_str.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+
+        if (type_str == "diffusion") {
+            cfg.type = PhysicsType::Diffusion;
+            cfg.name = "Diffusion";
+            cfg.coeff_label = "D";
+            cfg.field_label = "concentration";
+            cfg.eff_property_label = "EffectiveDiffusivity";
+            cfg.ratio_label = "Deff_ratio";
+        } else if (type_str == "electrical_conductivity") {
+            cfg.type = PhysicsType::ElectricalConductivity;
+            cfg.name = "Electrical Conductivity";
+            cfg.coeff_label = "sigma";
+            cfg.field_label = "voltage";
+            cfg.eff_property_label = "EffectiveConductivity";
+            cfg.ratio_label = "sigma_eff_ratio";
+        } else if (type_str == "thermal_conductivity") {
+            cfg.type = PhysicsType::ThermalConductivity;
+            cfg.name = "Thermal Conductivity";
+            cfg.coeff_label = "k";
+            cfg.field_label = "temperature";
+            cfg.eff_property_label = "EffectiveThermalConductivity";
+            cfg.ratio_label = "k_eff_ratio";
+        } else if (type_str == "dielectric_permittivity") {
+            cfg.type = PhysicsType::DielectricPermittivity;
+            cfg.name = "Dielectric Permittivity";
+            cfg.coeff_label = "epsilon";
+            cfg.field_label = "potential";
+            cfg.eff_property_label = "EffectivePermittivity";
+            cfg.ratio_label = "eps_eff_ratio";
+        } else if (type_str == "magnetic_permeability") {
+            cfg.type = PhysicsType::MagneticPermeability;
+            cfg.name = "Magnetic Permeability";
+            cfg.coeff_label = "mu";
+            cfg.field_label = "potential";
+            cfg.eff_property_label = "EffectivePermeability";
+            cfg.ratio_label = "mu_eff_ratio";
+        } else {
+            amrex::Abort("Unknown physics.type: '" + type_str +
+                         "'. Valid options: diffusion, electrical_conductivity, "
+                         "thermal_conductivity, dielectric_permittivity, magnetic_permeability");
+        }
+
+        return cfg;
+    }
+
+    // --- Print configuration summary ---
+    void print(int verbose = 1) const {
+        if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "  Physics Type:      " << name << "\n";
+            amrex::Print() << "  Coefficient:       " << coeff_label << "\n";
+            amrex::Print() << "  Field:             " << field_label << "\n";
+            amrex::Print() << "  Bulk Property:     " << bulk_property << "\n";
+        }
+    }
+
+    // --- Write results for a single direction ---
+    void writeDirectionResults(std::ostream& os, const std::string& dir_label,
+                               amrex::Real D_eff_ratio, amrex::Real vf) const {
+        os << ratio_label << "_" << dir_label << ": " << std::scientific << D_eff_ratio << "\n";
+        os << "Tortuosity_" << dir_label << ": " << std::fixed << std::setprecision(9)
+           << tortuosityFactor(D_eff_ratio, vf) << "\n";
+        if (bulk_property != 1.0) {
+            os << eff_property_label << "_" << dir_label << ": " << std::scientific
+               << effectiveProperty(D_eff_ratio) << "\n";
+        }
+        if (type == PhysicsType::ElectricalConductivity) {
+            os << "FormationFactor_" << dir_label << ": " << std::fixed << std::setprecision(9)
+               << formationFactor(D_eff_ratio) << "\n";
+        }
+    }
+
+    // --- Write file header ---
+    void writeHeader(std::ostream& os, const std::string& input_file, int phase_id) const {
+        os << "# Transport Property Calculation Results\n";
+        os << "# Physics Type: " << name << "\n";
+        os << "# Input File: " << input_file << "\n";
+        os << "# Analysis Phase ID: " << phase_id << "\n";
+        if (bulk_property != 1.0) {
+            os << "# Bulk Property (" << coeff_label << "_bulk): " << std::scientific
+               << bulk_property << "\n";
+        }
+        os << "# -----------------------------\n";
+    }
+};
+
+} // namespace OpenImpala
+
+#endif // PHYSICSCONFIG_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,3 +129,37 @@ set_tests_properties(tEffectiveDiffusivity_multiphase PROPERTIES
     ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
     TIMEOUT 300
 )
+
+# ==============================================================================
+# Physics Type Tests (Electrical Conductivity)
+# ==============================================================================
+
+# Electrical conductivity variant of tortuosity test (reuses tTortuosity executable)
+add_test(
+    NAME tTortuosity_conductivity
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+            ${MPIEXEC_PREFLAGS}
+            $<TARGET_FILE:tTortuosity>
+            ${CMAKE_SOURCE_DIR}/tests/inputs/tTortuosity_conductivity.inputs
+            amrex.verbose=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(tTortuosity_conductivity PROPERTIES
+    ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
+    TIMEOUT 300
+)
+
+# Electrical conductivity variant of synthetic multi-phase test
+add_test(
+    NAME tMultiPhaseTransport_conductivity
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+            ${MPIEXEC_PREFLAGS}
+            $<TARGET_FILE:tMultiPhaseTransport>
+            ${CMAKE_SOURCE_DIR}/tests/inputs/tMultiPhaseTransport_conductivity.inputs
+            amrex.verbose=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(tMultiPhaseTransport_conductivity PROPERTIES
+    ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
+    TIMEOUT 300
+)

--- a/tests/inputs/tMultiPhaseTransport_conductivity.inputs
+++ b/tests/inputs/tMultiPhaseTransport_conductivity.inputs
@@ -1,0 +1,31 @@
+# Synthetic multi-phase transport test with electrical conductivity physics type
+#
+# Same as tMultiPhaseTransport.inputs but with physics.type = electrical_conductivity
+# and a non-unit bulk property to validate scaling.
+#
+# Expected tortuosity remains (N-1)/N = 31/32 = 0.96875.
+# With bulk_property = 5.96e7 (copper conductivity in S/m),
+# the effective conductivity should be D_eff_ratio * 5.96e7.
+
+domain_size = 32
+box_size = 16
+verbose = 2
+num_phases_fill = 1
+direction = X
+solver = FlexGMRES
+
+expected_tau = 0.96875
+tau_tolerance = 0.001
+
+resultsdir = ./tMultiPhaseTransport_conductivity_results
+
+hypre.maxiter = 500
+hypre.eps = 1e-9
+
+tortuosity.active_phases = 0
+tortuosity.phase_diffusivities = 1.0
+tortuosity.remspot_passes = 0
+
+# --- Physics configuration ---
+physics.type = electrical_conductivity
+physics.bulk_property = 5.96e7

--- a/tests/inputs/tTortuosity_conductivity.inputs
+++ b/tests/inputs/tTortuosity_conductivity.inputs
@@ -1,0 +1,25 @@
+# Input file for testing electrical conductivity physics type
+#
+# This reuses the tTortuosity test executable with the physics.type
+# set to electrical_conductivity. The solver and result are identical
+# to the standard tortuosity test; this validates that:
+#   - PhysicsConfig parses electrical_conductivity type correctly
+#   - Formation factor and effective conductivity are reported
+#   - Bulk property scaling works (sigma_eff = D_eff_ratio * sigma_bulk)
+
+tifffile = data/SampleData_2Phase_stack_3d_1bit.tif
+
+phase_id = 0
+direction = X
+solver = FlexGMRES
+
+hypre.maxiter = 1000
+hypre.eps = 1e-10
+
+verbose = 2
+
+tortuosity.remspot_passes = 0
+
+# --- Physics configuration ---
+physics.type = electrical_conductivity
+physics.bulk_property = 1.0   # Unit bulk conductivity for validation

--- a/tests/tMultiPhaseTransport.cpp
+++ b/tests/tMultiPhaseTransport.cpp
@@ -13,6 +13,7 @@
 
 #include "TortuosityHypre.H"
 #include "Tortuosity.H"
+#include "PhysicsConfig.H"
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
@@ -346,6 +347,46 @@ int main(int argc, char* argv[]) {
                                    << " faces, max_dev=" << std::scientific << max_dev
                                    << std::defaultfloat << ")\n";
                 }
+            }
+        }
+
+        // --- Validate PhysicsConfig interpretation layer ---
+        if (test_passed && !std::isnan(actual_tau) && !std::isinf(actual_tau) && actual_tau > 0.0) {
+            auto physics = OpenImpala::PhysicsConfig::fromParmParse();
+
+            // For unit bulk property, effective property should equal D_eff_ratio
+            amrex::Real D_eff_ratio = vf / actual_tau;
+            amrex::Real eff_prop = physics.effectiveProperty(D_eff_ratio);
+            amrex::Real expected_eff = D_eff_ratio * physics.bulk_property;
+            if (std::abs(eff_prop - expected_eff) > 1e-12) {
+                test_passed = false;
+                fail_reason = "PhysicsConfig::effectiveProperty() mismatch: got " +
+                              std::to_string(eff_prop) + ", expected " +
+                              std::to_string(expected_eff);
+            }
+
+            // tortuosityFactor should recover the original tau
+            amrex::Real recovered_tau = physics.tortuosityFactor(D_eff_ratio, vf);
+            if (std::abs(recovered_tau - actual_tau) > 1e-10) {
+                test_passed = false;
+                fail_reason = "PhysicsConfig::tortuosityFactor() mismatch: got " +
+                              std::to_string(recovered_tau) + ", expected " +
+                              std::to_string(actual_tau);
+            }
+
+            // formationFactor should be 1 / D_eff_ratio
+            amrex::Real ff = physics.formationFactor(D_eff_ratio);
+            amrex::Real expected_ff = 1.0 / D_eff_ratio;
+            if (std::abs(ff - expected_ff) > 1e-10) {
+                test_passed = false;
+                fail_reason = "PhysicsConfig::formationFactor() mismatch: got " +
+                              std::to_string(ff) + ", expected " + std::to_string(expected_ff);
+            }
+
+            if (test_passed && verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " PhysicsConfig checks:     PASS (type=" << physics.name
+                               << ", Deff_ratio=" << std::scientific << D_eff_ratio
+                               << std::defaultfloat << ")\n";
             }
         }
 

--- a/tests/tTortuosity.cpp
+++ b/tests/tTortuosity.cpp
@@ -2,6 +2,7 @@
 #include "TortuosityHypre.H" // Assuming TortuosityHypre is in OpenImpala namespace
 #include "VolumeFraction.H"  // Assuming VolumeFraction is in OpenImpala namespace
 #include "Tortuosity.H"      // Include base class for OpenImpala::Direction enum
+#include "PhysicsConfig.H"   // Physics-type-aware output
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
@@ -223,6 +224,12 @@ int main(int argc, char* argv[]) {
             amrex::Print() << "------------------------------------\n\n";
         }
 
+        // --- Parse physics configuration ---
+        auto physics_config = OpenImpala::PhysicsConfig::fromParmParse();
+        if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            physics_config.print(verbose);
+        }
+
         // --- AMReX Grid and Data Setup ---
         // (Keep setup block as before)
         amrex::Geometry geom;
@@ -394,6 +401,20 @@ int main(int argc, char* argv[]) {
                 if (amrex::ParallelDescriptor::IOProcessor()) {
                     amrex::Print() << " Final Calculated Tortuosity: " << std::fixed
                                    << std::setprecision(8) << actual_tau << "\n";
+                    // Physics-aware derived quantities
+                    amrex::Real D_eff_ratio = (actual_tau > 0.0) ? actual_vf / actual_tau : 0.0;
+                    amrex::Print() << " " << physics_config.ratio_label << ": " << std::scientific
+                                   << D_eff_ratio << std::defaultfloat << "\n";
+                    if (physics_config.bulk_property != 1.0) {
+                        amrex::Print()
+                            << " " << physics_config.eff_property_label << ": " << std::scientific
+                            << physics_config.effectiveProperty(D_eff_ratio) << std::defaultfloat
+                            << "\n";
+                    }
+                    if (physics_config.type == OpenImpala::PhysicsType::ElectricalConductivity) {
+                        amrex::Print() << " FormationFactor: " << std::fixed << std::setprecision(8)
+                                       << physics_config.formationFactor(D_eff_ratio) << "\n";
+                    }
                 }
                 if (expected_tau >= 0.0) {
                     if (amrex::ParallelDescriptor::IOProcessor()) {


### PR DESCRIPTION
The existing solver already computes effective transport ratios via the general equation -div(D grad phi) = 0. This commit adds a lightweight interpretation layer (PhysicsConfig) that maps the raw solver output to physics-specific quantities without changing the solver itself.

Supported physics types (selected via physics.type in input file):
- diffusion (default): D_eff/D_bulk and tortuosity
- electrical_conductivity: sigma_eff, formation factor F = 1/D_eff_ratio
- thermal_conductivity: k_eff
- dielectric_permittivity: eps_eff
- magnetic_permeability: mu_eff

Key changes:
- New PhysicsConfig.H: enum PhysicsType, PhysicsConfig struct with fromParmParse() factory, effectiveProperty(), tortuosityFactor(), formationFactor(), and writeDirectionResults() output methods
- Diffusion.cpp: parses physics config, uses it for both homogenization tensor output and flow-through results.txt (backwards-compatible)
- tTortuosity.cpp: displays physics-aware derived quantities
- tMultiPhaseTransport.cpp: validates PhysicsConfig interpretation (effectiveProperty scaling, tortuosityFactor round-trip, formationFactor)
- New test inputs for electrical conductivity validation
- CMakeLists.txt: registers tTortuosity_conductivity and tMultiPhaseTransport_conductivity test variants

Addresses #1
