### PR TITLE
Integrate Catch2 unit testing framework and add PhysicsConfig unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,5 +84,15 @@ add_subdirectory(src)
 # ==============================================================================
 include(CTest)
 if(BUILD_TESTING)
+    # --- Catch2 (for lightweight unit tests) ---
+    include(FetchContent)
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v3.5.2
+    )
+    FetchContent_MakeAvailable(Catch2)
+    list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
+
     add_subdirectory(tests)
 endif()

--- a/src/props/PhysicsConfig.H
+++ b/src/props/PhysicsConfig.H
@@ -14,21 +14,37 @@
 // Input file (all optional — defaults to Diffusion with unit bulk property):
 //   physics.type = electrical_conductivity
 //   physics.bulk_property = 1.5e7
+//
+// Unit testing:
+//   Define OPENIMPALA_UNIT_TEST before including this header to compile
+//   without AMReX dependencies.  In that mode, fromParmParse() and print()
+//   are unavailable; use fromTypeString() and direct construction instead.
 
 #ifndef PHYSICSCONFIG_H
 #define PHYSICSCONFIG_H
 
+#ifndef OPENIMPALA_UNIT_TEST
 #include <AMReX_REAL.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 #include <AMReX_ParallelDescriptor.H>
+#endif
 
 #include <string>
 #include <algorithm>
 #include <cmath>
+#include <iomanip>
 #include <limits>
+#include <ostream>
 
 namespace OpenImpala {
+
+// When compiling for unit tests without AMReX, use double directly
+#ifdef OPENIMPALA_UNIT_TEST
+using Real = double;
+#else
+using Real = amrex::Real;
+#endif
 
 enum class PhysicsType {
     Diffusion,
@@ -49,36 +65,30 @@ struct PhysicsConfig {
     std::string ratio_label;
 
     // User-supplied bulk/reference property value (e.g. sigma_bulk)
-    amrex::Real bulk_property = 1.0;
+    Real bulk_property = 1.0;
 
     // --- Interpret raw solver output ---
 
-    amrex::Real effectiveProperty(amrex::Real D_eff_ratio) const {
+    Real effectiveProperty(Real D_eff_ratio) const {
         return D_eff_ratio * bulk_property;
     }
 
-    amrex::Real tortuosityFactor(amrex::Real D_eff_ratio, amrex::Real vf) const {
+    Real tortuosityFactor(Real D_eff_ratio, Real vf) const {
         if (D_eff_ratio > 0.0)
             return vf / D_eff_ratio;
-        return std::numeric_limits<amrex::Real>::infinity();
+        return std::numeric_limits<Real>::infinity();
     }
 
-    amrex::Real formationFactor(amrex::Real D_eff_ratio) const {
+    Real formationFactor(Real D_eff_ratio) const {
         if (D_eff_ratio > 0.0)
             return 1.0 / D_eff_ratio;
-        return std::numeric_limits<amrex::Real>::infinity();
+        return std::numeric_limits<Real>::infinity();
     }
 
-    // --- Factory: build from input file parameters ---
-    static PhysicsConfig fromParmParse() {
-        PhysicsConfig cfg;
-
-        amrex::ParmParse pp("physics");
-        std::string type_str = "diffusion";
-        pp.query("type", type_str);
-        pp.query("bulk_property", cfg.bulk_property);
-
-        // Normalise to lowercase
+    // --- Factory: build from a type string (no AMReX dependency) ---
+    // Returns true on success, false if type_str is unrecognised.
+    static bool fromTypeString(const std::string& type_str_in, PhysicsConfig& cfg) {
+        std::string type_str = type_str_in;
         std::transform(type_str.begin(), type_str.end(), type_str.begin(),
                        [](unsigned char c) { return std::tolower(c); });
 
@@ -118,6 +128,22 @@ struct PhysicsConfig {
             cfg.eff_property_label = "EffectivePermeability";
             cfg.ratio_label = "mu_eff_ratio";
         } else {
+            return false;
+        }
+        return true;
+    }
+
+#ifndef OPENIMPALA_UNIT_TEST
+    // --- Factory: build from input file parameters ---
+    static PhysicsConfig fromParmParse() {
+        PhysicsConfig cfg;
+
+        amrex::ParmParse pp("physics");
+        std::string type_str = "diffusion";
+        pp.query("type", type_str);
+        pp.query("bulk_property", cfg.bulk_property);
+
+        if (!fromTypeString(type_str, cfg)) {
             amrex::Abort("Unknown physics.type: '" + type_str +
                          "'. Valid options: diffusion, electrical_conductivity, "
                          "thermal_conductivity, dielectric_permittivity, magnetic_permeability");
@@ -135,10 +161,11 @@ struct PhysicsConfig {
             amrex::Print() << "  Bulk Property:     " << bulk_property << "\n";
         }
     }
+#endif
 
     // --- Write results for a single direction ---
-    void writeDirectionResults(std::ostream& os, const std::string& dir_label,
-                               amrex::Real D_eff_ratio, amrex::Real vf) const {
+    void writeDirectionResults(std::ostream& os, const std::string& dir_label, Real D_eff_ratio,
+                               Real vf) const {
         os << ratio_label << "_" << dir_label << ": " << std::scientific << D_eff_ratio << "\n";
         os << "Tortuosity_" << dir_label << ": " << std::fixed << std::setprecision(9)
            << tortuosityFactor(D_eff_ratio, vf) << "\n";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,3 +163,8 @@ set_tests_properties(tMultiPhaseTransport_conductivity PROPERTIES
     ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
     TIMEOUT 300
 )
+
+# ==============================================================================
+# Unit Tests (Catch2 — fast, no MPI/AMReX required)
+# ==============================================================================
+add_subdirectory(unit)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,21 @@
+# ==============================================================================
+# OpenImpala - Unit Tests (Catch2)
+#
+# These tests exercise pure C++ logic (config parsing, computation helpers)
+# without requiring MPI, AMReX, or HYPRE. They compile fast and run in
+# milliseconds, making them ideal for rapid iteration.
+# ==============================================================================
+
+include(Catch)
+
+# --- PhysicsConfig unit tests ---
+add_executable(unit_PhysicsConfig
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_PhysicsConfig.cpp"
+)
+target_include_directories(unit_PhysicsConfig PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/props
+)
+target_compile_definitions(unit_PhysicsConfig PRIVATE OPENIMPALA_UNIT_TEST)
+target_link_libraries(unit_PhysicsConfig PRIVATE Catch2::Catch2WithMain)
+
+catch_discover_tests(unit_PhysicsConfig)

--- a/tests/unit/test_PhysicsConfig.cpp
+++ b/tests/unit/test_PhysicsConfig.cpp
@@ -1,0 +1,294 @@
+// Unit tests for PhysicsConfig — runs without AMReX, MPI, or HYPRE.
+// OPENIMPALA_UNIT_TEST is defined via target_compile_definitions in CMakeLists.txt.
+#include "PhysicsConfig.H"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <cmath>
+#include <limits>
+#include <sstream>
+
+using Catch::Approx;
+using namespace OpenImpala;
+
+// ============================================================================
+// Helper: construct a PhysicsConfig from a type string, asserting success
+// ============================================================================
+static PhysicsConfig makeConfig(const std::string& type_str, double bulk = 1.0) {
+    PhysicsConfig cfg;
+    cfg.bulk_property = bulk;
+    REQUIRE(PhysicsConfig::fromTypeString(type_str, cfg));
+    return cfg;
+}
+
+// ============================================================================
+// fromTypeString — type parsing
+// ============================================================================
+TEST_CASE("fromTypeString parses all valid physics types", "[PhysicsConfig][parsing]") {
+    SECTION("diffusion") {
+        auto cfg = makeConfig("diffusion");
+        CHECK(cfg.type == PhysicsType::Diffusion);
+        CHECK(cfg.name == "Diffusion");
+        CHECK(cfg.coeff_label == "D");
+        CHECK(cfg.field_label == "concentration");
+        CHECK(cfg.eff_property_label == "EffectiveDiffusivity");
+        CHECK(cfg.ratio_label == "Deff_ratio");
+    }
+
+    SECTION("electrical_conductivity") {
+        auto cfg = makeConfig("electrical_conductivity");
+        CHECK(cfg.type == PhysicsType::ElectricalConductivity);
+        CHECK(cfg.name == "Electrical Conductivity");
+        CHECK(cfg.coeff_label == "sigma");
+        CHECK(cfg.field_label == "voltage");
+        CHECK(cfg.eff_property_label == "EffectiveConductivity");
+        CHECK(cfg.ratio_label == "sigma_eff_ratio");
+    }
+
+    SECTION("thermal_conductivity") {
+        auto cfg = makeConfig("thermal_conductivity");
+        CHECK(cfg.type == PhysicsType::ThermalConductivity);
+        CHECK(cfg.name == "Thermal Conductivity");
+        CHECK(cfg.coeff_label == "k");
+        CHECK(cfg.field_label == "temperature");
+        CHECK(cfg.eff_property_label == "EffectiveThermalConductivity");
+        CHECK(cfg.ratio_label == "k_eff_ratio");
+    }
+
+    SECTION("dielectric_permittivity") {
+        auto cfg = makeConfig("dielectric_permittivity");
+        CHECK(cfg.type == PhysicsType::DielectricPermittivity);
+        CHECK(cfg.name == "Dielectric Permittivity");
+        CHECK(cfg.coeff_label == "epsilon");
+        CHECK(cfg.field_label == "potential");
+        CHECK(cfg.eff_property_label == "EffectivePermittivity");
+        CHECK(cfg.ratio_label == "eps_eff_ratio");
+    }
+
+    SECTION("magnetic_permeability") {
+        auto cfg = makeConfig("magnetic_permeability");
+        CHECK(cfg.type == PhysicsType::MagneticPermeability);
+        CHECK(cfg.name == "Magnetic Permeability");
+        CHECK(cfg.coeff_label == "mu");
+        CHECK(cfg.field_label == "potential");
+        CHECK(cfg.eff_property_label == "EffectivePermeability");
+        CHECK(cfg.ratio_label == "mu_eff_ratio");
+    }
+}
+
+TEST_CASE("fromTypeString is case-insensitive", "[PhysicsConfig][parsing]") {
+    PhysicsConfig cfg;
+
+    SECTION("UPPERCASE") {
+        CHECK(PhysicsConfig::fromTypeString("DIFFUSION", cfg));
+        CHECK(cfg.type == PhysicsType::Diffusion);
+    }
+
+    SECTION("MixedCase") {
+        CHECK(PhysicsConfig::fromTypeString("Electrical_Conductivity", cfg));
+        CHECK(cfg.type == PhysicsType::ElectricalConductivity);
+    }
+
+    SECTION("Thermal_CONDUCTIVITY") {
+        CHECK(PhysicsConfig::fromTypeString("THERMAL_CONDUCTIVITY", cfg));
+        CHECK(cfg.type == PhysicsType::ThermalConductivity);
+    }
+}
+
+TEST_CASE("fromTypeString returns false for invalid types", "[PhysicsConfig][parsing]") {
+    PhysicsConfig cfg;
+    CHECK_FALSE(PhysicsConfig::fromTypeString("invalid_type", cfg));
+    CHECK_FALSE(PhysicsConfig::fromTypeString("", cfg));
+    CHECK_FALSE(PhysicsConfig::fromTypeString("conductivity", cfg));
+    CHECK_FALSE(PhysicsConfig::fromTypeString("electric", cfg));
+}
+
+TEST_CASE("fromTypeString preserves bulk_property set before call", "[PhysicsConfig][parsing]") {
+    PhysicsConfig cfg;
+    cfg.bulk_property = 42.0;
+    REQUIRE(PhysicsConfig::fromTypeString("diffusion", cfg));
+    CHECK(cfg.bulk_property == 42.0);
+}
+
+// ============================================================================
+// effectiveProperty
+// ============================================================================
+TEST_CASE("effectiveProperty scales D_eff_ratio by bulk_property", "[PhysicsConfig][computation]") {
+    SECTION("unit bulk property") {
+        auto cfg = makeConfig("diffusion", 1.0);
+        CHECK(cfg.effectiveProperty(0.5) == Approx(0.5));
+        CHECK(cfg.effectiveProperty(1.0) == Approx(1.0));
+        CHECK(cfg.effectiveProperty(0.0) == Approx(0.0));
+    }
+
+    SECTION("non-unit bulk property (copper conductivity)") {
+        auto cfg = makeConfig("electrical_conductivity", 5.96e7);
+        CHECK(cfg.effectiveProperty(0.5) == Approx(2.98e7));
+        CHECK(cfg.effectiveProperty(0.0) == Approx(0.0));
+        CHECK(cfg.effectiveProperty(1.0) == Approx(5.96e7));
+    }
+
+    SECTION("negative D_eff_ratio") {
+        auto cfg = makeConfig("diffusion", 2.0);
+        CHECK(cfg.effectiveProperty(-0.1) == Approx(-0.2));
+    }
+}
+
+// ============================================================================
+// tortuosityFactor
+// ============================================================================
+TEST_CASE("tortuosityFactor computes vf / D_eff_ratio", "[PhysicsConfig][computation]") {
+    auto cfg = makeConfig("diffusion");
+
+    SECTION("typical values") {
+        CHECK(cfg.tortuosityFactor(0.5, 0.4) == Approx(0.8));
+        CHECK(cfg.tortuosityFactor(0.25, 0.5) == Approx(2.0));
+        CHECK(cfg.tortuosityFactor(1.0, 1.0) == Approx(1.0));
+    }
+
+    SECTION("round-trip: tau -> D_eff -> tau") {
+        double vf = 0.35;
+        double tau_original = 1.42;
+        double D_eff = vf / tau_original;
+        double tau_recovered = cfg.tortuosityFactor(D_eff, vf);
+        CHECK(tau_recovered == Approx(tau_original));
+    }
+
+    SECTION("zero D_eff_ratio returns infinity") {
+        double result = cfg.tortuosityFactor(0.0, 0.5);
+        CHECK(std::isinf(result));
+    }
+
+    SECTION("negative D_eff_ratio returns infinity") {
+        double result = cfg.tortuosityFactor(-0.1, 0.5);
+        CHECK(std::isinf(result));
+    }
+}
+
+// ============================================================================
+// formationFactor
+// ============================================================================
+TEST_CASE("formationFactor computes 1 / D_eff_ratio", "[PhysicsConfig][computation]") {
+    auto cfg = makeConfig("electrical_conductivity");
+
+    SECTION("typical values") {
+        CHECK(cfg.formationFactor(0.5) == Approx(2.0));
+        CHECK(cfg.formationFactor(0.25) == Approx(4.0));
+        CHECK(cfg.formationFactor(1.0) == Approx(1.0));
+    }
+
+    SECTION("very small D_eff_ratio gives large formation factor") {
+        CHECK(cfg.formationFactor(1e-6) == Approx(1e6));
+    }
+
+    SECTION("zero D_eff_ratio returns infinity") {
+        double result = cfg.formationFactor(0.0);
+        CHECK(std::isinf(result));
+    }
+}
+
+// ============================================================================
+// writeDirectionResults — output formatting
+// ============================================================================
+TEST_CASE("writeDirectionResults produces correct output", "[PhysicsConfig][output]") {
+    SECTION("diffusion with unit bulk writes ratio and tortuosity only") {
+        auto cfg = makeConfig("diffusion", 1.0);
+        std::ostringstream oss;
+        cfg.writeDirectionResults(oss, "X", 0.5, 0.4);
+        std::string output = oss.str();
+
+        CHECK(output.find("Deff_ratio_X:") != std::string::npos);
+        CHECK(output.find("Tortuosity_X:") != std::string::npos);
+        // No EffectiveDiffusivity line when bulk_property == 1.0
+        CHECK(output.find("EffectiveDiffusivity_X:") == std::string::npos);
+        // No FormationFactor for diffusion type
+        CHECK(output.find("FormationFactor_X:") == std::string::npos);
+    }
+
+    SECTION("electrical_conductivity with non-unit bulk writes all fields") {
+        auto cfg = makeConfig("electrical_conductivity", 5.96e7);
+        std::ostringstream oss;
+        cfg.writeDirectionResults(oss, "Z", 0.3, 0.5);
+        std::string output = oss.str();
+
+        CHECK(output.find("sigma_eff_ratio_Z:") != std::string::npos);
+        CHECK(output.find("Tortuosity_Z:") != std::string::npos);
+        CHECK(output.find("EffectiveConductivity_Z:") != std::string::npos);
+        CHECK(output.find("FormationFactor_Z:") != std::string::npos);
+    }
+
+    SECTION("thermal_conductivity with non-unit bulk — no formation factor") {
+        auto cfg = makeConfig("thermal_conductivity", 401.0);
+        std::ostringstream oss;
+        cfg.writeDirectionResults(oss, "Y", 0.5, 0.4);
+        std::string output = oss.str();
+
+        CHECK(output.find("k_eff_ratio_Y:") != std::string::npos);
+        CHECK(output.find("Tortuosity_Y:") != std::string::npos);
+        CHECK(output.find("EffectiveThermalConductivity_Y:") != std::string::npos);
+        CHECK(output.find("FormationFactor_Y:") == std::string::npos);
+    }
+}
+
+// ============================================================================
+// writeHeader — header formatting
+// ============================================================================
+TEST_CASE("writeHeader produces correct header", "[PhysicsConfig][output]") {
+    SECTION("diffusion with unit bulk — no bulk property line") {
+        auto cfg = makeConfig("diffusion", 1.0);
+        std::ostringstream oss;
+        cfg.writeHeader(oss, "test.tif", 0);
+        std::string output = oss.str();
+
+        CHECK(output.find("# Physics Type: Diffusion") != std::string::npos);
+        CHECK(output.find("# Input File: test.tif") != std::string::npos);
+        CHECK(output.find("# Analysis Phase ID: 0") != std::string::npos);
+        CHECK(output.find("# Bulk Property") == std::string::npos);
+    }
+
+    SECTION("conductivity with bulk — includes bulk property line") {
+        auto cfg = makeConfig("electrical_conductivity", 5.96e7);
+        std::ostringstream oss;
+        cfg.writeHeader(oss, "sample.h5", 1);
+        std::string output = oss.str();
+
+        CHECK(output.find("# Physics Type: Electrical Conductivity") != std::string::npos);
+        CHECK(output.find("# Bulk Property (sigma_bulk):") != std::string::npos);
+    }
+}
+
+// ============================================================================
+// Default construction
+// ============================================================================
+TEST_CASE("Default PhysicsConfig has sensible defaults", "[PhysicsConfig]") {
+    PhysicsConfig cfg;
+    CHECK(cfg.type == PhysicsType::Diffusion);
+    CHECK(cfg.bulk_property == 1.0);
+    CHECK(cfg.name.empty());
+    CHECK(cfg.coeff_label.empty());
+}
+
+// ============================================================================
+// Cross-physics consistency: all types produce finite results
+// ============================================================================
+TEST_CASE("All physics types produce finite results for valid inputs",
+          "[PhysicsConfig][computation]") {
+    const std::vector<std::string> types = {"diffusion", "electrical_conductivity",
+                                            "thermal_conductivity", "dielectric_permittivity",
+                                            "magnetic_permeability"};
+
+    for (const auto& type_str : types) {
+        DYNAMIC_SECTION("type=" << type_str) {
+            auto cfg = makeConfig(type_str, 100.0);
+            double D_eff_ratio = 0.42;
+            double vf = 0.35;
+
+            CHECK(std::isfinite(cfg.effectiveProperty(D_eff_ratio)));
+            CHECK(std::isfinite(cfg.tortuosityFactor(D_eff_ratio, vf)));
+            CHECK(std::isfinite(cfg.formationFactor(D_eff_ratio)));
+            CHECK(cfg.effectiveProperty(D_eff_ratio) == Approx(D_eff_ratio * 100.0));
+        }
+    }
+}


### PR DESCRIPTION
Add Catch2 v3.5.2 via CMake FetchContent as a lightweight unit testing framework for fast, isolated tests that don't require AMReX/MPI/HYPRE.

Infrastructure changes:
- CMakeLists.txt: fetch Catch2, add extras to CMAKE_MODULE_PATH
- tests/CMakeLists.txt: add_subdirectory(unit)
- tests/unit/CMakeLists.txt: build unit_PhysicsConfig, discover tests

PhysicsConfig.H refactoring for testability:
- Extract fromTypeString() static method from fromParmParse() — this pure-C++ factory parses type strings without any AMReX dependency
- Add OPENIMPALA_UNIT_TEST preprocessor guard: when defined, AMReX headers are excluded and OpenImpala::Real aliases to double directly
- fromParmParse() and print() are only available in full-build mode

Unit test suite (tests/unit/test_PhysicsConfig.cpp):
- 11 test cases, 127 assertions, runs in ~0.1s
- fromTypeString parsing: all 5 physics types, case-insensitivity, invalid inputs, bulk_property preservation
- Computation methods: effectiveProperty scaling, tortuosityFactor round-trip, formationFactor reciprocal, edge cases (zero, negative, infinity)
- Output formatting: writeDirectionResults and writeHeader content verification for diffusion, conductivity, and thermal types
- Cross-physics consistency: all types produce finite results

Addresses #79