### PR TITLE
Fix solver variant test: replace PCG with BiCGSTAB

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -168,17 +168,17 @@ set_tests_properties(tMultiPhaseTransport_dirZ PROPERTIES
 # Solver Variant Tests
 # ==============================================================================
 
-# PCG solver — should converge to same result as FlexGMRES
+# BiCGSTAB solver — should converge to same result as FlexGMRES
 add_test(
-    NAME tMultiPhaseTransport_pcg
+    NAME tMultiPhaseTransport_bicgstab
     COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
             ${MPIEXEC_PREFLAGS}
             $<TARGET_FILE:tMultiPhaseTransport>
-            ${CMAKE_SOURCE_DIR}/tests/inputs/tMultiPhaseTransport_pcg.inputs
+            ${CMAKE_SOURCE_DIR}/tests/inputs/tMultiPhaseTransport_bicgstab.inputs
             amrex.verbose=0
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 )
-set_tests_properties(tMultiPhaseTransport_pcg PROPERTIES
+set_tests_properties(tMultiPhaseTransport_bicgstab PROPERTIES
     ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
     TIMEOUT 300
 )

--- a/tests/inputs/tMultiPhaseTransport_bicgstab.inputs
+++ b/tests/inputs/tMultiPhaseTransport_bicgstab.inputs
@@ -1,8 +1,8 @@
-# Synthetic multi-phase transport test — PCG solver
+# Synthetic multi-phase transport test — BiCGSTAB solver
 #
-# Same as tMultiPhaseTransport.inputs but using the PCG solver instead
-# of FlexGMRES. Validates that different Krylov solvers converge to
-# the same result on the same problem.
+# Same as tMultiPhaseTransport.inputs but using the BiCGSTAB solver
+# instead of FlexGMRES. Validates that different Krylov solvers
+# converge to the same result on the same problem.
 #
 # Expected: tau = (N-1)/N = 31/32 = 0.96875 for N=32 grid
 
@@ -11,12 +11,12 @@ box_size = 16
 verbose = 2
 num_phases_fill = 1
 direction = X
-solver = PCG
+solver = BiCGSTAB
 
 expected_tau = 0.96875
 tau_tolerance = 0.001
 
-resultsdir = ./tMultiPhaseTransport_pcg_results
+resultsdir = ./tMultiPhaseTransport_bicgstab_results
 
 hypre.maxiter = 500
 hypre.eps = 1e-9


### PR DESCRIPTION
PCG (Conjugate Gradient) failed in CI because it requires a symmetric positive definite preconditioner setup that isn't guaranteed with HYPRE's structured solver interface for this problem. BiCGSTAB handles non-symmetric systems robustly and is a better choice for validating solver-independence of the result.
