### PR TITLE
Fix pull_request trigger to target master and working branches

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,8 +11,8 @@ on:
       - build
       - 'makefile' # Include makefile branch trigger
   pull_request:
-    # Trigger on Pull Requests targeting main branch
-    branches: [ main ]
+    # Trigger on Pull Requests targeting these branches
+    branches: [ master, working ]
   workflow_dispatch: # Allows manual triggering
 
 jobs:


### PR DESCRIPTION
The pull_request trigger was targeting 'main' but the repository uses 'master' as the default branch. This caused PRs into master/working to only fire as push events, skipping the code coverage job which requires github.event_name == 'pull_request'.
