### PR TITLE
Fix gcovr version and CLI flags for code coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -411,14 +411,14 @@ jobs:
             bash -c '
               source /opt/rh/gcc-toolset-11/enable
               dnf install -y python3-pip 2>&1 | tail -1
-              pip3 install gcovr 2>&1 | tail -1
+              pip3 install "gcovr>=7.0" 2>&1 | tail -1
               cd /src
               gcovr --root . \
                 --filter "src/" \
                 --print-summary \
                 --cobertura coverage.xml \
                 --txt coverage.txt \
-                cmake_build_cov/
+                --search-path cmake_build_cov/
             '
 
       - name: Generate summary


### PR DESCRIPTION
- Pin gcovr>=7.0 to ensure --cobertura flag is available (gcovr 5.0 only supported --xml)
- Use --search-path instead of positional argument for build directory, which was causing 'unrecognized arguments' error

