### PR TITLE
Fix gcovr compatibility: use --xml instead of --cobertura

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -411,14 +411,14 @@ jobs:
             bash -c '
               source /opt/rh/gcc-toolset-11/enable
               dnf install -y python3-pip 2>&1 | tail -1
-              pip3 install "gcovr>=7.0" 2>&1 | tail -1
+              pip3 install gcovr 2>&1 | tail -1
               cd /src
               gcovr --root . \
                 --filter "src/" \
                 --print-summary \
-                --cobertura coverage.xml \
+                --xml coverage.xml \
                 --txt coverage.txt \
-                --search-path cmake_build_cov/
+                cmake_build_cov/
             '
 
       - name: Generate summary


### PR DESCRIPTION
The container's Python is too old for gcovr>=7.0. gcovr 5.0 (which installs successfully) supports --xml but not --cobertura (added in 5.1). The XML output is Cobertura-format either way. Also reverts --search-path back to positional arg, which is valid in 5.0.
