### PR TITLE
Add automated Doxygen documentation generation (#110)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+# .github/workflows/docs.yml
+name: Deploy Doxygen Documentation
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'src/**'
+      - 'Doxyfile'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:  # Allow manual triggering
+
+# Sets permissions for GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only allow one deployment at a time
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    name: Build Doxygen Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+          echo "Doxygen version: $(doxygen --version)"
+          echo "Dot version: $(dot -V 2>&1)"
+
+      - name: Generate documentation
+        run: doxygen Doxyfile
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/doxygen/html
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build-docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,92 @@
+# Doxyfile for OpenImpala
+# Auto-generated documentation: class hierarchy, dependency graphs, API reference
+
+#---------------------------------------------------------------------------
+# Project
+#---------------------------------------------------------------------------
+PROJECT_NAME           = "OpenImpala"
+PROJECT_BRIEF          = "Image-based parallel transport property solver"
+PROJECT_NUMBER         = ""
+OUTPUT_DIRECTORY       = docs/doxygen
+CREATE_SUBDIRS         = NO
+
+#---------------------------------------------------------------------------
+# Input
+#---------------------------------------------------------------------------
+INPUT                  = src/ docs/mainpage.md
+FILE_PATTERNS          = *.H *.h *.hpp *.cpp *.cc
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */build/* */external/*
+USE_MDFILE_AS_MAINPAGE = docs/mainpage.md
+
+#---------------------------------------------------------------------------
+# Parsing
+#---------------------------------------------------------------------------
+EXTENSION_MAPPING      = H=C++ F90=Fortran
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+SORT_MEMBER_DOCS       = YES
+SORT_BRIEF_DOCS        = YES
+
+#---------------------------------------------------------------------------
+# Build
+#---------------------------------------------------------------------------
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+PREDEFINED             = __cplusplus \
+                         AMREX_SPACEDIM=3 \
+                         BL_LANG_CC
+EXPAND_ONLY_PREDEF     = NO
+SKIP_FUNCTION_MACROS   = YES
+
+#---------------------------------------------------------------------------
+# Warnings
+#---------------------------------------------------------------------------
+WARN_IF_UNDOCUMENTED   = YES
+WARN_NO_PARAMDOC       = NO
+WARN_AS_ERROR          = NO
+
+#---------------------------------------------------------------------------
+# HTML Output
+#---------------------------------------------------------------------------
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_COLORSTYLE        = LIGHT
+SEARCHENGINE           = YES
+GENERATE_TREEVIEW      = YES
+DISABLE_INDEX          = NO
+FULL_SIDEBAR           = NO
+
+#---------------------------------------------------------------------------
+# Other Output (disabled)
+#---------------------------------------------------------------------------
+GENERATE_LATEX         = NO
+GENERATE_RTF           = NO
+GENERATE_MAN           = NO
+GENERATE_XML           = NO
+
+#---------------------------------------------------------------------------
+# Graphs (requires Graphviz dot)
+#---------------------------------------------------------------------------
+HAVE_DOT               = YES
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
+CLASS_GRAPH            = YES
+COLLABORATION_GRAPH    = YES
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+DIRECTORY_GRAPH        = YES
+DOT_GRAPH_MAX_NODES    = 100
+MAX_DOT_GRAPH_DEPTH    = 0
+
+#---------------------------------------------------------------------------
+# Namespace
+#---------------------------------------------------------------------------
+HIDE_UNDOC_RELATIONS   = NO
+SHOW_INCLUDE_FILES     = YES
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES

--- a/docs/mainpage.md
+++ b/docs/mainpage.md
@@ -1,0 +1,60 @@
+# OpenImpala API Reference {#mainpage}
+
+OpenImpala is a high-performance framework for computing effective transport
+properties (diffusivity, conductivity, tortuosity) directly on 3D voxel images
+of porous microstructures.
+
+## Architecture
+
+The codebase is organized into three layers:
+
+| Layer | Location | Purpose |
+|-------|----------|---------|
+| **I/O Readers** | `src/io/` | Read TIFF, HDF5, RAW, DAT images into `amrex::iMultiFab` |
+| **Physics Solvers** | `src/props/` | Solve transport equations, compute effective properties |
+| **Fortran Kernels** | `src/props/*.F90` | Performance-critical matrix fill and flux calculations |
+
+## Key Classes
+
+### I/O Layer
+- @ref OpenImpala::TiffReader — Single/multi-directory TIFF and TIFF sequence reader
+- @ref OpenImpala::HDF5Reader — HDF5 dataset reader with parallel I/O
+- @ref OpenImpala::RawReader — Flat binary file reader (UINT8, INT16, FLOAT32, etc.)
+- @ref OpenImpala::DatReader — Legacy DAT binary format reader
+
+### Physics Solvers
+- @ref OpenImpala::Tortuosity — Abstract base class defining the solver interface
+- @ref OpenImpala::TortuosityHypre — Primary solver: HYPRE-based tortuosity via Laplace equation
+- @ref OpenImpala::TortuosityDirect — Legacy Forward Euler iterative solver
+- @ref OpenImpala::EffectiveDiffusivityHypre — Effective diffusivity tensor via homogenization
+- @ref OpenImpala::VolumeFraction — Phase volume fraction calculator
+- @ref OpenImpala::PercolationCheck — Flood-fill percolation connectivity check
+
+### Configuration & Output
+- @ref OpenImpala::PhysicsConfig — Maps solver output to physical quantities
+- @ref OpenImpala::ResultsJSON — Structured JSON output (BPX/BattINFO compatible)
+
+## Data Flow
+
+```
+TIFF/HDF5/RAW file
+  -> Reader.threshold() -> iMultiFab (phase IDs)
+    -> PercolationCheck (connectivity?)
+    -> VolumeFraction (phase fraction?)
+    -> TortuosityHypre or EffDiffusivityHypre
+      -> Fortran kernel fills HYPRE matrix
+      -> HYPRE solve
+      -> Flux integration -> D_eff, tortuosity
+        -> ResultsJSON -> results.json
+```
+
+## Dependency Graph
+
+Use the **Include Dependency** graphs on each file page to trace how
+modules depend on AMReX (`amrex::iMultiFab`, `amrex::Geometry`, etc.)
+and HYPRE.
+
+## Further Information
+
+- [GitHub Repository](https://github.com/BASE-Laboratory/OpenImpala)
+- [Software Paper (SoftwareX 2021)](https://doi.org/10.1016/j.softx.2021.100729)


### PR DESCRIPTION
Three new files implement CI-driven API documentation:

1. Doxyfile — Configured for the project with:
   - SVG class hierarchy and include dependency graphs (Graphviz)
   - Collaboration diagrams showing AMReX/HYPRE interfaces
   - Directory dependency graphs
   - Tree-view navigation with search
   - All public APIs extracted from the doxygen comments standardized in the previous commit

2. docs/mainpage.md — Landing page with:
   - Architecture overview table (I/O, Physics, Fortran layers)
   - Cross-referenced class listing (@ref links)
   - Data flow diagram

3. .github/workflows/docs.yml — GitHub Actions workflow that:
   - Triggers on pushes to master that touch src/, docs/, or Doxyfile
   - Installs doxygen + graphviz on ubuntu-latest
   - Builds HTML documentation
   - Deploys to GitHub Pages via actions/deploy-pages@v4
   - Supports manual dispatch via workflow_dispatch

Note: GitHub Pages must be configured to use "GitHub Actions" as the source (Settings > Pages > Source) for the deployment to work.
