### PR TITLE
Fix expected tortuosity for cell-centered ghost Dirichlet BCs

### DIFF
--- a/tests/inputs/tTortuosityDirect.inputs
+++ b/tests/inputs/tTortuosityDirect.inputs
@@ -2,7 +2,8 @@
 #
 # Geometry:  8^3 domain, all voxels = single conducting phase
 # Solver:    Forward Euler (TortuosityDirect), not HYPRE
-# Analytical: tau = (N-1)/N = 7/8 = 0.875
+# Analytical: tau = (N+1)/N = 9/8 = 1.125 (cell-centered ghost Dirichlet BCs
+#             stretch the diffusion path by half a cell on each side)
 #
 # Note: Forward Euler is slow to converge — needs many iterations.
 #       Tolerance is set looser than HYPRE-based tests.
@@ -14,7 +15,7 @@ direction = X
 n_steps = 50000
 plot_interval = 5000
 eps = 1e-6
-expected_tau = 0.875
+expected_tau = 1.125
 tau_tolerance = 0.05
 
 resultsdir = ./tTortuosityDirect_results

--- a/tests/tTortuosityDirect.cpp
+++ b/tests/tTortuosityDirect.cpp
@@ -83,10 +83,10 @@ int main(int argc, char* argv[]) {
 
         OpenImpala::Direction direction = stringToDirection(direction_str);
 
-        // Default expected_tau = (N-1)/N for uniform medium
+        // Default expected_tau = (N+1)/N for uniform medium with cell-centered ghost BCs
         if (expected_tau < 0.0) {
             expected_tau =
-                static_cast<amrex::Real>(domain_size - 1) / static_cast<amrex::Real>(domain_size);
+                static_cast<amrex::Real>(domain_size + 1) / static_cast<amrex::Real>(domain_size);
         }
 
         if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {


### PR DESCRIPTION
The Forward Euler solver applies Dirichlet BCs at ghost cell centers (i=-1 and i=N), not at domain faces. This stretches the diffusion path by half a cell on each side, giving N+1 intervals instead of N-1.

For N=8: tau = (N+1)/N = 9/8 = 1.125, not (N-1)/N = 7/8 = 0.875. The computed flux of 64/9 = 7.1111 confirms this exactly.
