### PR TITLE
Use py::cast for cross-module AMReX type interop in all bindings

### DIFF
--- a/python/bindings/io.cpp
+++ b/python/bindings/io.cpp
@@ -41,17 +41,25 @@ void init_io(py::module_& m) {
              "Read metadata from a TIFF sequence (clears previous state).")
 
         // Two-arg threshold (binary 0/1 output)
-        .def("threshold",
-             py::overload_cast<double, amrex::iMultiFab&>(&TiffReader::threshold, py::const_),
-             py::arg("raw_threshold"), py::arg("mf"),
-             "Fill *mf* with 1 where pixel > threshold, else 0.")
+        .def(
+            "threshold",
+            [](const TiffReader& self, double raw_threshold, py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, mf);
+            },
+            py::arg("raw_threshold"), py::arg("mf"),
+            "Fill *mf* with 1 where pixel > threshold, else 0.")
 
         // Four-arg threshold (custom output values)
-        .def("threshold",
-             py::overload_cast<double, int, int, amrex::iMultiFab&>(&TiffReader::threshold,
-                                                                    py::const_),
-             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-             py::arg("mf"), "Fill *mf* with custom values based on threshold comparison.")
+        .def(
+            "threshold",
+            [](const TiffReader& self, double raw_threshold, int value_if_true, int value_if_false,
+               py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+            },
+            py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
+            py::arg("mf"), "Fill *mf* with custom values based on threshold comparison.")
 
         // Metadata properties
         .def_property_readonly("box", &TiffReader::box)
@@ -85,15 +93,23 @@ void init_io(py::module_& m) {
         .def("read_file", &HDF5Reader::readFile, py::arg("filename"), py::arg("hdf5dataset"),
              "Read metadata from an HDF5 file + dataset (clears previous state).")
 
-        .def("threshold",
-             py::overload_cast<double, amrex::iMultiFab&>(&HDF5Reader::threshold, py::const_),
-             py::arg("raw_threshold"), py::arg("mf"))
+        .def(
+            "threshold",
+            [](const HDF5Reader& self, double raw_threshold, py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, mf);
+            },
+            py::arg("raw_threshold"), py::arg("mf"))
 
-        .def("threshold",
-             py::overload_cast<double, int, int, amrex::iMultiFab&>(&HDF5Reader::threshold,
-                                                                    py::const_),
-             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-             py::arg("mf"))
+        .def(
+            "threshold",
+            [](const HDF5Reader& self, double raw_threshold, int value_if_true, int value_if_false,
+               py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+            },
+            py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
+            py::arg("mf"))
 
         .def_property_readonly("box", &HDF5Reader::box)
         .def_property_readonly("width", &HDF5Reader::width)
@@ -128,15 +144,23 @@ void init_io(py::module_& m) {
         .def("read_file", &RawReader::readFile, py::arg("filename"), py::arg("width"),
              py::arg("height"), py::arg("depth"), py::arg("data_type"))
 
-        .def("threshold",
-             py::overload_cast<double, amrex::iMultiFab&>(&RawReader::threshold, py::const_),
-             py::arg("threshold_value"), py::arg("mf"))
+        .def(
+            "threshold",
+            [](const RawReader& self, double threshold_value, py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(threshold_value, mf);
+            },
+            py::arg("threshold_value"), py::arg("mf"))
 
-        .def("threshold",
-             py::overload_cast<double, int, int, amrex::iMultiFab&>(&RawReader::threshold,
-                                                                    py::const_),
-             py::arg("threshold_value"), py::arg("value_if_true"), py::arg("value_if_false"),
-             py::arg("mf"))
+        .def(
+            "threshold",
+            [](const RawReader& self, double threshold_value, int value_if_true, int value_if_false,
+               py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(threshold_value, value_if_true, value_if_false, mf);
+            },
+            py::arg("threshold_value"), py::arg("value_if_true"), py::arg("value_if_false"),
+            py::arg("mf"))
 
         .def_property_readonly("box", &RawReader::box)
         .def_property_readonly("width", &RawReader::width)
@@ -166,16 +190,23 @@ void init_io(py::module_& m) {
 
         .def("read_file", &DatReader::readFile, py::arg("filename"))
 
-        .def("threshold",
-             py::overload_cast<DatReader::DataType, amrex::iMultiFab&>(&DatReader::threshold,
-                                                                       py::const_),
-             py::arg("raw_threshold"), py::arg("mf"))
+        .def(
+            "threshold",
+            [](const DatReader& self, DatReader::DataType raw_threshold, py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, mf);
+            },
+            py::arg("raw_threshold"), py::arg("mf"))
 
-        .def("threshold",
-             py::overload_cast<DatReader::DataType, int, int, amrex::iMultiFab&>(
-                 &DatReader::threshold, py::const_),
-             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-             py::arg("mf"))
+        .def(
+            "threshold",
+            [](const DatReader& self, DatReader::DataType raw_threshold, int value_if_true,
+               int value_if_false, py::object mf_obj) {
+                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
+                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+            },
+            py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
+            py::arg("mf"))
 
         .def_property_readonly("box", &DatReader::box)
         .def_property_readonly("width", &DatReader::width)

--- a/python/bindings/props.cpp
+++ b/python/bindings/props.cpp
@@ -18,8 +18,11 @@ void init_props(py::module_& m) {
     py::class_<VolumeFraction>(m, "VolumeFraction",
                                "Computes volume fraction of a phase within an iMultiFab.")
 
-        .def(py::init<const amrex::iMultiFab&, int, int>(), py::arg("mf"), py::arg("phase") = 0,
-             py::arg("comp") = 0,
+        .def(py::init([](py::object mf_obj, int phase, int comp) {
+                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
+                 return new VolumeFraction(mf, phase, comp);
+             }),
+             py::arg("mf"), py::arg("phase") = 0, py::arg("comp") = 0,
              // keep mf alive while this object lives
              py::keep_alive<1, 2>(),
              "Create a volume-fraction calculator for *phase* in component *comp* of *mf*.")
@@ -47,9 +50,14 @@ void init_props(py::module_& m) {
         m, "PercolationCheck",
         "Parallel flood-fill connectivity check for a phase in a given direction.")
 
-        .def(py::init<const amrex::Geometry&, const amrex::BoxArray&,
-                      const amrex::DistributionMapping&, const amrex::iMultiFab&, int,
-                      OpenImpala::Direction, int>(),
+        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
+                         py::object mf_obj, int phase_id, OpenImpala::Direction dir, int verbose) {
+                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
+                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
+                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
+                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
+                 return new PercolationCheck(geom, ba, dm, mf, phase_id, dir, verbose);
+             }),
              py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"),
              py::arg("phase_id"), py::arg("dir"), py::arg("verbose") = 0,
              // prevent GC of referenced AMReX objects

--- a/python/bindings/solvers.cpp
+++ b/python/bindings/solvers.cpp
@@ -25,10 +25,17 @@ void init_solvers(py::module_& m) {
                                 "equation on a masked phase and computes tortuosity from the "
                                 "resulting flux.")
 
-        .def(py::init<const amrex::Geometry&, const amrex::BoxArray&,
-                      const amrex::DistributionMapping&, const amrex::iMultiFab&, amrex::Real, int,
-                      OpenImpala::Direction, TortuosityHypre::SolverType, const std::string&,
-                      amrex::Real, amrex::Real, int, bool>(),
+        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
+                         py::object mf_obj, amrex::Real vf, int phase, OpenImpala::Direction dir,
+                         TortuosityHypre::SolverType solver_type, const std::string& results_path,
+                         amrex::Real vlo, amrex::Real vhi, int verbose, bool write_plotfile) {
+                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
+                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
+                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
+                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
+                 return new TortuosityHypre(geom, ba, dm, mf, vf, phase, dir, solver_type,
+                                            results_path, vlo, vhi, verbose, write_plotfile);
+             }),
              py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"), py::arg("vf"),
              py::arg("phase"), py::arg("dir"), py::arg("solver_type"), py::arg("results_path"),
              py::arg("vlo") = 0.0, py::arg("vhi") = 1.0, py::arg("verbose") = 0,
@@ -82,17 +89,24 @@ void init_solvers(py::module_& m) {
         m, "TortuosityDirect",
         "Legacy iterative tortuosity solver using Forward-Euler time-stepping.")
 
-        .def(py::init<const amrex::Geometry&, const amrex::BoxArray&,
-                      const amrex::DistributionMapping&, const amrex::iMultiFab&, int,
-                      OpenImpala::Direction, amrex::Real, int, int, const std::string&, amrex::Real,
-                      amrex::Real>(),
+        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
+                         py::object mf_obj, int phase, OpenImpala::Direction dir, amrex::Real eps,
+                         int n_steps, int plot_interval, const std::string& plot_basename,
+                         amrex::Real vlo, amrex::Real vhi) {
+                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
+                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
+                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
+                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
+                 return new TortuosityDirect(geom, ba, dm, mf, phase, dir, eps, n_steps,
+                                             plot_interval, plot_basename, vlo, vhi);
+             }),
              py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"), py::arg("phase"),
              py::arg("dir"), py::arg("eps"), py::arg("n_steps"), py::arg("plot_interval"),
              py::arg("plot_basename"), py::arg("vlo"), py::arg("vhi"),
              py::keep_alive<1, 2>(), // geom
              py::keep_alive<1, 3>(), // ba
              py::keep_alive<1, 4>(), // dm
-             py::keep_alive<1, 5>()) // mf_phase (stored as reference!)
+             py::keep_alive<1, 5>()) // mf_phase
 
         .def(
             "value",
@@ -121,10 +135,17 @@ void init_solvers(py::module_& m) {
         m, "EffectiveDiffusivityHypre",
         "Solves the cell problem for effective diffusivity via HYPRE.")
 
-        .def(py::init<const amrex::Geometry&, const amrex::BoxArray&,
-                      const amrex::DistributionMapping&, const amrex::iMultiFab&, int,
-                      OpenImpala::Direction, EffectiveDiffusivityHypre::SolverType,
-                      const std::string&, int, bool>(),
+        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
+                         py::object mf_obj, int phase_id, OpenImpala::Direction dir,
+                         EffectiveDiffusivityHypre::SolverType solver_type,
+                         const std::string& results_path, int verbose, bool write_plotfile) {
+                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
+                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
+                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
+                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
+                 return new EffectiveDiffusivityHypre(geom, ba, dm, mf, phase_id, dir, solver_type,
+                                                      results_path, verbose, write_plotfile);
+             }),
              py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"),
              py::arg("phase_id"), py::arg("dir"), py::arg("solver_type"), py::arg("results_path"),
              py::arg("verbose") = 1, py::arg("write_plotfile") = false,


### PR DESCRIPTION
pyAMReX registers AMReX types (Geometry, BoxArray, DistributionMapping, iMultiFab) in its own pybind11 module. When OpenImpala bindings declare constructors with direct C++ type parameters, pybind11 cannot match objects created by pyAMReX due to separate type registries.

Fix by accepting py::object and using py::cast<const T&>() to resolve the cross-module type at runtime. Applied to:

- props.cpp: VolumeFraction and PercolationCheck constructors
- solvers.cpp: TortuosityHypre, TortuosityDirect, and EffectiveDiffusivityHypre constructors
- io.cpp: All threshold() method overloads for TiffReader, HDF5Reader, RawReader, and DatReader (iMultiFab parameter)

