### PR TITLE
Fix recursion in lazy _core import by using importlib

### DIFF
--- a/python/openimpala/__init__.py
+++ b/python/openimpala/__init__.py
@@ -20,6 +20,7 @@ Quick-start::
         print(f"Volume fraction: {vf.fraction:.4f}")
 """
 
+import importlib
 import os
 import sys
 
@@ -46,7 +47,7 @@ def _load_core():
     sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_NOW)
     try:
         import amrex.space3d  # noqa: F401 — load pyAMReX globally first
-        from . import _core
+        _core = importlib.import_module("openimpala._core")
     finally:
         sys.setdlopenflags(old_flags)
     return _core

--- a/python/openimpala/facade.py
+++ b/python/openimpala/facade.py
@@ -81,8 +81,8 @@ class TortuosityResult:
 
 def _get_core():
     """Import and return the _core C extension (lazy, cached by Python)."""
-    from . import _core
-    return _core
+    import importlib
+    return importlib.import_module("openimpala._core")
 
 
 def _parse_direction(d):


### PR DESCRIPTION
`from . import _core` inside __getattr__ triggers __getattr__("_core") again because Python checks package attributes before resolving submodules. Switch to importlib.import_module() which bypasses the package __getattr__ and loads the extension module directly.
