### PR TITLE
Set RTLD_GLOBAL before first amrex import to fix cross-module segfault

### DIFF
--- a/python/openimpala/session.py
+++ b/python/openimpala/session.py
@@ -35,13 +35,25 @@ class Session:
     # ------------------------------------------------------------------
     @staticmethod
     def _do_initialize() -> None:
+        import os
+        import sys
+
         # Import mpi4py first so MPI_Init happens before AMReX touches MPI.
         try:
             from mpi4py import MPI  # noqa: F401
         except ImportError:
             pass
 
-        import amrex.space3d as amrex
+        # CRITICAL: Set RTLD_GLOBAL *before* the first import of amrex so that
+        # pyAMReX's C++ type registry is visible to openimpala._core.so.
+        # If amrex is loaded with RTLD_LOCAL (the default), pybind11 cross-module
+        # type casts will segfault.
+        old_flags = sys.getdlopenflags()
+        sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_NOW)
+        try:
+            import amrex.space3d as amrex
+        finally:
+            sys.setdlopenflags(old_flags)
 
         if not amrex.initialized():
             amrex.initialize([])

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,33 +1,25 @@
 """Shared pytest fixtures for OpenImpala Python binding tests.
 
-Ensures AMReX is initialised exactly once per test session.
+Ensures AMReX is initialised exactly once per test session via
+``openimpala.Session``, which sets the required RTLD_GLOBAL dlopen
+flags before loading pyAMReX.
 """
 
 import pytest
 import numpy as np
-import gc  
+
+from openimpala.session import Session
+
+# Single session instance shared across all tests.
+_session = Session()
+
 
 @pytest.fixture(scope="session", autouse=True)
 def amrex_session():
     """Initialise AMReX for the entire test session."""
-    try:
-        from mpi4py import MPI  # noqa: F401
-    except ImportError:
-        pass
-
-    import amrex.space3d as amrex
-
-    if not amrex.initialized():
-        amrex.initialize([])
-    
+    _session.__enter__()
     yield
-    
-    # Force Python to destroy all C++ Pybind11 objects NOW
-    gc.collect()
-    
-    # Safely shut down AMReX and MPI before Python exits
-    if amrex.initialized():
-        amrex.finalize()
+    _session.__exit__(None, None, None)
 
 
 @pytest.fixture


### PR DESCRIPTION
The pybind11 cross-module type registry requires that pyAMReX's shared library is loaded with RTLD_GLOBAL so that openimpala._core.so can see its C++ type_info symbols. Previously, conftest.py imported amrex with the default RTLD_LOCAL flags, and the later RTLD_GLOBAL in _load_core() was a no-op (Python caches the already-loaded module). This caused segfaults when TortuosityHypre tried to use AMReX objects passed from Python.

Fix: Session._do_initialize() now sets RTLD_GLOBAL before importing amrex, and conftest.py uses Session instead of manual amrex init.