### PR TITLE
Add HYPRE_Init/Finalize to Python lifecycle to fix solver segfault

### DIFF
--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -7,6 +7,9 @@
 
 #include <pybind11/pybind11.h>
 
+#include <HYPRE.h>
+#include <stdexcept>
+
 namespace py = pybind11;
 
 // Forward declarations — each implemented in its own .cpp
@@ -22,6 +25,29 @@ PYBIND11_MODULE(_core, m) {
 
     m.doc() = "OpenImpala C++ backend — low-level bindings for transport property "
               "computation on 3-D voxel images of porous microstructures.";
+
+    // --- HYPRE lifecycle functions ---
+    m.def(
+        "hypre_init",
+        []() {
+            int ierr = HYPRE_Init();
+            if (ierr != 0) {
+                throw std::runtime_error("HYPRE_Init() failed with error code " +
+                                         std::to_string(ierr));
+            }
+        },
+        "Initialise the HYPRE library.  Must be called before using any HYPRE-based solver.");
+
+    m.def(
+        "hypre_finalize",
+        []() {
+            int ierr = HYPRE_Finalize();
+            if (ierr != 0) {
+                throw std::runtime_error("HYPRE_Finalize() failed with error code " +
+                                         std::to_string(ierr));
+            }
+        },
+        "Shut down the HYPRE library.  Call after all HYPRE solvers have been destroyed.");
 
     // Register enums first (used by everything else)
     init_enums(m);

--- a/python/openimpala/session.py
+++ b/python/openimpala/session.py
@@ -58,14 +58,24 @@ class Session:
         if not amrex.initialized():
             amrex.initialize([])
 
+        # Initialise HYPRE (required before any HYPRE-based solver is used).
+        import importlib
+        _core = importlib.import_module("openimpala._core")
+        _core.hypre_init()
+
     @staticmethod
     def _do_finalize() -> None:
         import gc
+        import importlib
         import amrex.space3d as amrex
 
         if amrex.initialized():
             # Force Python to destroy all orphaned C++ pybind11 objects NOW
             gc.collect()
-            
+
+            # Shut down HYPRE before AMReX finalises MPI.
+            _core = importlib.import_module("openimpala._core")
+            _core.hypre_finalize()
+
             # Now it is safe to shut down the C++ backend
             amrex.finalize()


### PR DESCRIPTION
All C++ tests call HYPRE_Init() before using any HYPRE solver, but the Python bindings never did. This caused a segfault when TortuosityHypre tried to use uninitialised HYPRE internals.

- Expose hypre_init() and hypre_finalize() in the _core module
- Call them in Session._do_initialize() and Session._do_finalize()
- HYPRE is initialised after AMReX (which handles MPI) and finalised before AMReX shuts down
