### PR TITLE
Guard HYPRE init/finalize with try/except for graceful fallback

### DIFF
--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -8,7 +8,9 @@
 #include <pybind11/pybind11.h>
 
 #include <HYPRE.h>
+
 #include <stdexcept>
+#include <string>
 
 namespace py = pybind11;
 

--- a/python/openimpala/session.py
+++ b/python/openimpala/session.py
@@ -59,14 +59,18 @@ class Session:
             amrex.initialize([])
 
         # Initialise HYPRE (required before any HYPRE-based solver is used).
-        import importlib
-        _core = importlib.import_module("openimpala._core")
-        _core.hypre_init()
+        # Guarded with try/except so that pure-Python usage (e.g. CLI parser
+        # tests) still works when _core.so is not available.
+        try:
+            import importlib
+            _core = importlib.import_module("openimpala._core")
+            _core.hypre_init()
+        except (ImportError, ModuleNotFoundError):
+            pass
 
     @staticmethod
     def _do_finalize() -> None:
         import gc
-        import importlib
         import amrex.space3d as amrex
 
         if amrex.initialized():
@@ -74,8 +78,12 @@ class Session:
             gc.collect()
 
             # Shut down HYPRE before AMReX finalises MPI.
-            _core = importlib.import_module("openimpala._core")
-            _core.hypre_finalize()
+            try:
+                import importlib
+                _core = importlib.import_module("openimpala._core")
+                _core.hypre_finalize()
+            except (ImportError, ModuleNotFoundError):
+                pass
 
             # Now it is safe to shut down the C++ backend
             amrex.finalize()


### PR DESCRIPTION
Session._do_initialize() unconditionally imported _core for hypre_init(), which broke all tests when _core.so wasn't built (ModuleNotFoundError). Now both hypre_init() and hypre_finalize() are wrapped in try/except ImportError so pure-Python tests work even without the C extension.

Also add missing <string> include in module.cpp.
