### PR TITLE
Move HYPRE_Init to C++ solver constructors via std::call_once

### DIFF
--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -7,11 +7,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include <HYPRE.h>
-
-#include <stdexcept>
-#include <string>
-
 namespace py = pybind11;
 
 // Forward declarations — each implemented in its own .cpp
@@ -27,29 +22,6 @@ PYBIND11_MODULE(_core, m) {
 
     m.doc() = "OpenImpala C++ backend — low-level bindings for transport property "
               "computation on 3-D voxel images of porous microstructures.";
-
-    // --- HYPRE lifecycle functions ---
-    m.def(
-        "hypre_init",
-        []() {
-            int ierr = HYPRE_Init();
-            if (ierr != 0) {
-                throw std::runtime_error("HYPRE_Init() failed with error code " +
-                                         std::to_string(ierr));
-            }
-        },
-        "Initialise the HYPRE library.  Must be called before using any HYPRE-based solver.");
-
-    m.def(
-        "hypre_finalize",
-        []() {
-            int ierr = HYPRE_Finalize();
-            if (ierr != 0) {
-                throw std::runtime_error("HYPRE_Finalize() failed with error code " +
-                                         std::to_string(ierr));
-            }
-        },
-        "Shut down the HYPRE library.  Call after all HYPRE solvers have been destroyed.");
 
     // Register enums first (used by everything else)
     init_enums(m);

--- a/python/openimpala/session.py
+++ b/python/openimpala/session.py
@@ -58,15 +58,9 @@ class Session:
         if not amrex.initialized():
             amrex.initialize([])
 
-        # Initialise HYPRE (required before any HYPRE-based solver is used).
-        # Guarded with try/except so that pure-Python usage (e.g. CLI parser
-        # tests) still works when _core.so is not available.
-        try:
-            import importlib
-            _core = importlib.import_module("openimpala._core")
-            _core.hypre_init()
-        except (ImportError, ModuleNotFoundError):
-            pass
+        # NOTE: HYPRE initialisation is handled automatically by the C++
+        # solver constructors (TortuosityHypre, EffectiveDiffusivityHypre)
+        # via std::call_once, so no Python-side HYPRE_Init() is needed.
 
     @staticmethod
     def _do_finalize() -> None:
@@ -76,14 +70,6 @@ class Session:
         if amrex.initialized():
             # Force Python to destroy all orphaned C++ pybind11 objects NOW
             gc.collect()
-
-            # Shut down HYPRE before AMReX finalises MPI.
-            try:
-                import importlib
-                _core = importlib.import_module("openimpala._core")
-                _core.hypre_finalize()
-            except (ImportError, ModuleNotFoundError):
-                pass
 
             # Now it is safe to shut down the C++ backend
             amrex.finalize()

--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -4,6 +4,7 @@
 #include "EffDiffFillMtx_F.H" // For effdiff_fillmtx
 
 #include <cstdlib>
+#include <mutex>
 #include <vector>
 #include <string>
 #include <cmath>
@@ -118,6 +119,10 @@ EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
       m_mf_active_mask(ba, dm, 1, 1), m_mf_diff_coeff(ba, dm, 1, 1), m_grid(nullptr),
       m_stencil(nullptr), m_A(nullptr), m_b(nullptr), m_x(nullptr), m_num_iterations(-1),
       m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()), m_converged(false) {
+    // Ensure HYPRE is initialised exactly once (thread-safe via std::call_once).
+    static std::once_flag hypre_once;
+    std::call_once(hypre_once, []() { HYPRE_Init(); });
+
     BL_PROFILE("EffectiveDiffusivityHypre::Constructor");
 
     amrex::Copy(m_mf_phase_original, mf_phase_input, 0, 0, m_mf_phase_original.nComp(),

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -7,6 +7,7 @@
 // Includes remain the same...
 #include <cstdlib>
 #include <ctime>
+#include <mutex>
 #include <vector>
 #include <string>
 #include <cmath>     // Required for std::isnan, std::isinf, std::abs
@@ -118,6 +119,11 @@ OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom, const 
       m_stencil(nullptr), m_A(nullptr), m_b(nullptr), m_x(nullptr), m_num_iterations(-1),
       m_final_res_norm(std::numeric_limits<amrex::Real>::quiet_NaN()), m_converged(false),
       m_flux_in(0.0), m_flux_out(0.0) {
+    // Ensure HYPRE is initialised exactly once (thread-safe via std::call_once).
+    // C++ tests call HYPRE_Init() in main(), but Python bindings have no main().
+    static std::once_flag hypre_once;
+    std::call_once(hypre_once, []() { HYPRE_Init(); });
+
     // Copy data from input iMultiFab to member iMultiFab
     amrex::Copy(m_mf_phase, mf_phase_input, 0, 0, m_mf_phase.nComp(), m_mf_phase.nGrow());
 


### PR DESCRIPTION
HYPRE_Init()/HYPRE_Finalize() are not declared in <HYPRE.h> on the container's HYPRE version, so exposing them from module.cpp caused a build failure. Instead, call HYPRE_Init() automatically in the C++ solver constructors (TortuosityHypre, EffectiveDiffusivityHypre) using std::call_once for thread-safe one-time initialisation.

This is transparent to Python — no Session or user code changes needed. Reverted module.cpp and session.py to remove all HYPRE references.
