### PR TITLE
Guard HYPRE destructors against post-MPI_Finalize cleanup

### DIFF
--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -248,16 +248,23 @@ EffectiveDiffusivityHypre::EffectiveDiffusivityHypre(
 }
 
 EffectiveDiffusivityHypre::~EffectiveDiffusivityHypre() {
-    if (m_x)
-        HYPRE_StructVectorDestroy(m_x);
-    if (m_b)
-        HYPRE_StructVectorDestroy(m_b);
-    if (m_A)
-        HYPRE_StructMatrixDestroy(m_A);
-    if (m_stencil)
-        HYPRE_StructStencilDestroy(m_stencil);
-    if (m_grid)
-        HYPRE_StructGridDestroy(m_grid);
+    // Guard HYPRE cleanup: these functions use MPI internally, so they must
+    // not be called after MPI_Finalize (e.g. during Python interpreter
+    // shutdown when AMReX has already been finalised).
+    int mpi_finalized = 0;
+    MPI_Finalized(&mpi_finalized);
+    if (!mpi_finalized) {
+        if (m_x)
+            HYPRE_StructVectorDestroy(m_x);
+        if (m_b)
+            HYPRE_StructVectorDestroy(m_b);
+        if (m_A)
+            HYPRE_StructMatrixDestroy(m_A);
+        if (m_stencil)
+            HYPRE_StructStencilDestroy(m_stencil);
+        if (m_grid)
+            HYPRE_StructGridDestroy(m_grid);
+    }
     m_x = m_b = nullptr;
     m_A = nullptr;
     m_stencil = nullptr;

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -280,16 +280,23 @@ OpenImpala::TortuosityHypre::TortuosityHypre(const amrex::Geometry& geom, const 
 // --- Destructor ---
 // Remains the same...
 OpenImpala::TortuosityHypre::~TortuosityHypre() {
-    if (m_x)
-        HYPRE_StructVectorDestroy(m_x);
-    if (m_b)
-        HYPRE_StructVectorDestroy(m_b);
-    if (m_A)
-        HYPRE_StructMatrixDestroy(m_A);
-    if (m_stencil)
-        HYPRE_StructStencilDestroy(m_stencil);
-    if (m_grid)
-        HYPRE_StructGridDestroy(m_grid);
+    // Guard HYPRE cleanup: these functions use MPI internally, so they must
+    // not be called after MPI_Finalize (e.g. during Python interpreter
+    // shutdown when AMReX has already been finalised).
+    int mpi_finalized = 0;
+    MPI_Finalized(&mpi_finalized);
+    if (!mpi_finalized) {
+        if (m_x)
+            HYPRE_StructVectorDestroy(m_x);
+        if (m_b)
+            HYPRE_StructVectorDestroy(m_b);
+        if (m_A)
+            HYPRE_StructMatrixDestroy(m_A);
+        if (m_stencil)
+            HYPRE_StructStencilDestroy(m_stencil);
+        if (m_grid)
+            HYPRE_StructGridDestroy(m_grid);
+    }
     m_x = m_b = nullptr;
     m_A = nullptr;
     m_stencil = nullptr;


### PR DESCRIPTION
In Python, pybind11-wrapped TortuosityHypre/EffDiffHypre objects may survive past amrex.finalize() (which calls MPI_Finalize) if Python's GC doesn't collect them during Session teardown. Their destructors then call HYPRE_Struct*Destroy which uses MPI internally, causing a "double free or corruption" crash.

Fix: check MPI_Finalized() before calling any HYPRE destroy functions. If MPI is already gone, skip cleanup (the OS reclaims everything at process exit anyway).
