### PR TITLE
ci: add cibuildwheel workflow for automated PyPI publishing

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -93,6 +93,7 @@ jobs:
     needs: build_wheels
     runs-on: ubuntu-latest
     # Required for PyPI's Trusted Publishing
+    environment: pypi
     permissions:
       id-token: write 
       


### PR DESCRIPTION
## Description
This PR introduces a fully automated GitHub Actions CI/CD pipeline (`pypi-wheels.yml`) to build and distribute binary Python wheels for OpenImpala. 

Packaging a heavy HPC C++ stack (MPI, AMReX, HYPRE) into a portable Python wheel requires specific environment tuning. This workflow handles the complex dependency compilation and leverages PyPI's modern Trusted Publishing (OIDC) for secure, passwordless releases.

## Key Technical Details
* **cibuildwheel Integration**: Automates the creation of `manylinux` wheels targeting modern 64-bit CPython versions (3.9 - 3.12). Explicitly excludes 32-bit and `musllinux` builds to avoid `glibc`/`musl` compiler clashes.
* **Pre-build Dependency Compilation**: Uses `CIBW_BEFORE_ALL_LINUX` to compile HYPRE (v2.31.0) and AMReX (v25.03) from source within the CentOS build container.
* **Static Linking & `-fPIC`**: Injects `CFLAGS="-O2 -fPIC"` into HYPRE and `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` into AMReX to ensure these static libraries can be successfully linked into the final Python `.so` extension.
* **Auditwheel MPI Exclusions**: Explicitly instructs `auditwheel` *not* to vendor CentOS OpenMPI shared libraries (e.g., `libmpi.so`, `libopen-rte.so`). This prevents the wheel from hard-locking to the build container's MPI fabric, deferring to the end-user's host MPI installation (matching `mpi4py`'s behavior).
* **Trusted Publishing (OIDC)**: Deploys via the `pypi` GitHub Environment using short-lived identity tokens, eliminating the need for long-lived PyPI API secrets.

## How to Trigger
This workflow is configured to run automatically whenever a new **GitHub Release** is published. It can also be triggered manually via `workflow_dispatch` for testing purposes.

## Reviewer Notes
Ensure that the `pypi` environment is configured in the repository settings and that deployment protection rules (like tag restrictions or manual reviewer approvals) are properly set up before merging. No repository secrets are required.