### PR TITLE
Fix pypi wheels workflow p gw8y

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -25,6 +25,16 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.16.5
 
+      # Cache the compiled C/C++ dependencies (HDF5, libtiff, HYPRE, AMReX)
+      # inside the manylinux container. cibuildwheel runs CIBW_BEFORE_ALL only
+      # once per container launch, so we tar /usr/local after the first build
+      # and restore it on subsequent runs to skip the ~5-minute dep compile.
+      - name: Cache native dependencies
+        uses: actions/cache@v4
+        with:
+          path: .cibw-deps-cache
+          key: cibw-deps-manylinux_2_28-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v1
+
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
@@ -43,12 +53,21 @@ jobs:
           #     get linked into the wheel without auditwheel needing to vendor them
           #   - HYPRE is built static (--enable-shared=no)
           #   - AMReX is built static (-DBUILD_SHARED_LIBS=OFF)
+          # Install system packages, then restore cached deps or build from source.
+          # The cache tarball (.cibw-deps-cache/deps.tar.gz) is mounted into the
+          # container via the project bind-mount. On cache hit we just untar it;
+          # on miss we build everything and create the tarball for next time.
           CIBW_BEFORE_ALL_LINUX: >
             dnf install -y epel-release &&
             dnf --enablerepo=powertools install -y
             openmpi-devel gcc-gfortran gcc-c++ cmake wget git
             zlib-devel libjpeg-turbo-devel &&
             export PATH=/usr/lib64/openmpi/bin:$PATH &&
+            if [ -f /project/.cibw-deps-cache/deps.tar.gz ]; then
+            echo "=== Restoring cached dependencies ===" &&
+            tar xzf /project/.cibw-deps-cache/deps.tar.gz -C / ;
+            else
+            echo "=== Building dependencies from source ===" &&
             wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz &&
             tar xzf hdf5-1.14.6.tar.gz &&
             cd hdf5-1.14.6 &&
@@ -96,7 +115,10 @@ jobs:
             -DAMReX_PARTICLES=OFF
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
-            cmake --install /tmp/amrex/build
+            cmake --install /tmp/amrex/build &&
+            mkdir -p /project/.cibw-deps-cache &&
+            tar czf /project/.cibw-deps-cache/deps.tar.gz /usr/local ;
+            fi
 
           # Point scikit-build-core to our newly compiled dependencies and MPI compilers
           CIBW_ENVIRONMENT_LINUX: >

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BASE-Laboratory/OpenImpala/blob/master/tutorials/01_hello_openimpala.ipynb)
 [![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![DOI](https://img.shields.io/badge/DOI-10.1016/j.softx.2021.100729-blue)](https://doi.org/10.1016/j.softx.2021.100729)
+[![PyPI](https://img.shields.io/pypi/v/openimpala)](https://pypi.org/project/openimpala/)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/BASE-Laboratory/OpenImpala)](https://github.com/BASE-Laboratory/OpenImpala/releases/latest)
 [![GitHub contributors](https://img.shields.io/github/contributors/BASE-Laboratory/OpenImpala)](https://github.com/BASE-Laboratory/OpenImpala/graphs/contributors)
 [![Build and Test Status](https://github.com/BASE-Laboratory/OpenImpala/actions/workflows/build-test.yml/badge.svg?branch=master)](https://github.com/BASE-Laboratory/OpenImpala/actions/workflows/build-test.yml)
@@ -26,6 +27,7 @@ These calculated coefficients can directly parameterize continuum-scale models, 
 * [Getting Started (Recommended: Apptainer/Singularity)](#getting-started-recommended-apptainersingularity)
     * [1. Download the Container](#1-download-the-container)
     * [2. Run the Application](#2-run-the-application)
+* [Python Installation (pip)](#python-installation-pip)
 * [Building from Source (for Developers)](#building-from-source-for-developers)
 * [Native Installation (Advanced)](#native-installation-advanced)
     * [Dependencies](#dependencies)
@@ -92,6 +94,81 @@ apptainer exec -B "$(pwd):/data" ${SIF_FILE} /usr/local/bin/Diffusion /data/inpu
 # Ensure OMP_NUM_THREADS=1 if using multiple MPI ranks
 export OMP_NUM_THREADS=1
 mpirun -np 4 apptainer exec -B "$(pwd):/data" ${SIF_FILE} /usr/local/bin/Diffusion /data/inputs
+```
+
+---
+
+## Python Installation (pip)
+
+OpenImpala provides Python bindings that can be installed directly from PyPI. This gives you a high-level, NumPy-native API for computing transport properties on 3D voxel images without needing to write C++ code or manage input files.
+
+### Prerequisites
+
+OpenImpala uses MPI for parallel computation. You **must** have a working MPI installation before installing:
+
+```bash
+# Ubuntu / Debian
+sudo apt install libopenmpi-dev
+
+# Fedora / RHEL / Rocky
+sudo dnf install openmpi-devel
+# then add to PATH: export PATH=/usr/lib64/openmpi/bin:$PATH
+
+# macOS (Homebrew)
+brew install open-mpi
+
+# Conda (any platform)
+conda install -c conda-forge openmpi
+```
+
+> **Note:** The pre-built wheels are built against OpenMPI. Other MPI implementations (MPICH, Intel MPI) may work but are not tested. If you encounter MPI-related errors at runtime, ensure your MPI installation is ABI-compatible with OpenMPI.
+
+### Install
+
+```bash
+pip install openimpala
+```
+
+To install with optional dependencies:
+
+```bash
+# MPI-aware Python (recommended)
+pip install openimpala[mpi]
+
+# All optional dependencies
+pip install openimpala[all]
+```
+
+### Quick Start
+
+```python
+import numpy as np
+from openimpala import Session, volume_fraction, tortuosity
+
+# All computation must happen inside a Session context manager,
+# which initialises MPI and AMReX.
+with Session():
+    # Create a simple 3D test image (32x32x32, phase 0 = pore, phase 1 = solid)
+    image = np.zeros((32, 32, 32), dtype=np.int32)
+    image[:, :, 16:] = 1  # half pore, half solid
+
+    vf = volume_fraction(image, phase=0)
+    print(f"Volume fraction: {vf.value:.4f}")
+
+    tau = tortuosity(image, phase=0, direction="x")
+    print(f"Tortuosity: {tau.value:.4f}")
+```
+
+### CLI
+
+OpenImpala also provides a command-line interface:
+
+```bash
+# Analyse a TIFF image stack
+openimpala analyze my_sample.tif --phase 0 --direction x
+
+# Volume fraction only
+openimpala vf my_sample.tif --phase 0
 ```
 
 ---


### PR DESCRIPTION
The auditwheel repair step was failing because several shared libraries (AMReX, HDF5, libtiff, libgomp, libgfortran) were dynamically linked but not on the manylinux allowlist and not in the exclude list.

Changes:
- Build HDF5 and libtiff from source as static libraries (-DBUILD_SHARED_LIBS=OFF) so they are linked directly into the wheel
- Build AMReX as a static library (-DBUILD_SHARED_LIBS=OFF)
- Add missing auditwheel excludes for libgomp.so.1, libgfortran.so.5, libquadmath.so.0, and libmpi_mpifh.so/libmpi_mpifh.so.40
- Explicitly install gcc-gfortran for Fortran compilation
- Add CMAKE_Fortran_COMPILER to CIBW_ENVIRONMENT_LINUX
- Add FFLAGS="-O2 -fPIC" to HYPRE build for Fortran object files