### PR TITLE
Add CMAKE_POLICY_VERSION_MINIMUM=3.5 for CMake 3.31+ compatibility

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -77,6 +77,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
             -DBUILD_SHARED_LIBS=OFF
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             -DHDF5_BUILD_CXX=ON
             -DHDF5_ENABLE_PARALLEL=ON
             -DCMAKE_C_COMPILER=mpicc
@@ -91,7 +92,8 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release
             -DBUILD_SHARED_LIBS=OFF
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON &&
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 &&
             cmake --build build -j$(nproc) &&
             cmake --install build &&
             cd .. &&
@@ -108,6 +110,7 @@ jobs:
             cmake -S /tmp/amrex -B /tmp/amrex/build
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             -DBUILD_SHARED_LIBS=OFF
             -DAMReX_MPI=ON
             -DAMReX_OMP=ON


### PR DESCRIPTION
CMake 3.31+ (installed via pip) rejects cmake_minimum_required() calls with versions < 3.5, which breaks HDF5's doc/CMakeLists.txt. Adding -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to all dependency builds (HDF5, libtiff, AMReX) lets them configure under the newer CMake.
