### PR TITLE
Pin CMake to 3.x to fix FindHDF5 parallel detection in CMake 4.x

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -62,7 +62,7 @@ jobs:
             dnf --enablerepo=powertools install -y
             openmpi-devel gcc-gfortran gcc-c++ wget git
             zlib-devel libjpeg-turbo-devel python3-pip &&
-            pip3 install cmake &&
+            pip3 install "cmake>=3.28,<4" &&
             export PATH=/usr/lib64/openmpi/bin:$PATH &&
             if [ -f /project/.cibw-deps-cache/deps.tar.gz ]; then
             echo "=== Restoring cached dependencies ===" &&
@@ -77,7 +77,6 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release
             -DBUILD_SHARED_LIBS=OFF
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             -DHDF5_BUILD_CXX=ON
             -DHDF5_ENABLE_PARALLEL=ON
             -DCMAKE_C_COMPILER=mpicc
@@ -92,8 +91,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release
             -DBUILD_SHARED_LIBS=OFF
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 &&
+            -DCMAKE_POSITION_INDEPENDENT_CODE=ON &&
             cmake --build build -j$(nproc) &&
             cmake --install build &&
             cd .. &&
@@ -110,7 +108,6 @@ jobs:
             cmake -S /tmp/amrex -B /tmp/amrex/build
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release
-            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
             -DBUILD_SHARED_LIBS=OFF
             -DAMReX_MPI=ON
             -DAMReX_OMP=ON
@@ -125,7 +122,7 @@ jobs:
             fi
 
           # Ensure each Python version has cmake >= 3.28 (needed by AMReX)
-          CIBW_BEFORE_BUILD: pip install cmake
+          CIBW_BEFORE_BUILD: pip install "cmake>=3.28,<4"
 
           # Point scikit-build-core to our newly compiled dependencies and MPI compilers
           CIBW_ENVIRONMENT_LINUX: >


### PR DESCRIPTION
CMake 4.2's FindHDF5 module fails to detect our parallel HDF5 install because its compiler wrapper test uses the plain C compiler instead of mpicc. Pin cmake pip package to >=3.28,<4 which satisfies AMReX's requirement while avoiding the CMake 4.x FindHDF5 regression. This also removes the CMAKE_POLICY_VERSION_MINIMUM workaround since CMake 3.x doesn't need it.
