### PR TITLE
Pass CMAKE_FIND_PACKAGE_PREFER_CONFIG via SKBUILD_CMAKE_ARGS

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -125,7 +125,8 @@ jobs:
           CIBW_BEFORE_BUILD: pip install "cmake>=3.28,<4"
 
           # Point scikit-build-core to our newly compiled dependencies and MPI compilers.
-          # CMAKE_FIND_PACKAGE_PREFER_CONFIG makes find_package() use HDF5Config.cmake
+          # CMAKE_FIND_PACKAGE_PREFER_CONFIG is passed via SKBUILD_CMAKE_ARGS so it
+          # reaches CMake as a -D flag. This makes find_package() use HDF5Config.cmake
           # (installed by our CMake-built HDF5) instead of the FindHDF5.cmake module,
           # which fails its compiler-wrapper test inside the manylinux container.
           CIBW_ENVIRONMENT_LINUX: >
@@ -134,7 +135,7 @@ jobs:
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_Fortran_COMPILER="mpif90"
             CMAKE_PREFIX_PATH="/usr/local"
-            CMAKE_FIND_PACKAGE_PREFER_CONFIG="ON"
+            SKBUILD_CMAKE_ARGS="-DOPENIMPALA_PYTHON=ON;-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
 
           # Vendor libraries into the wheel, but exclude host-specific MPI and
           # runtime libraries that users must provide on their system.


### PR DESCRIPTION
CMake doesn't read CMAKE_FIND_PACKAGE_PREFER_CONFIG from the environment - it must be passed as a -D flag. Use SKBUILD_CMAKE_ARGS to forward it through scikit-build-core to CMake, which makes find_package(HDF5) use the installed HDF5Config.cmake instead of the broken FindHDF5.cmake module-mode wrapper test.