### PR TITLE
Fix TIFF transitive deps and pin pybind11 < 3 for ABI safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ find_package(HYPRE REQUIRED)
 # We need the C++ bindings (hdf5_cpp).
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
 
+# --- Transitive dependencies for static TIFF ---
+find_package(ZLIB REQUIRED)
+find_package(JPEG REQUIRED)
+
 # --- TIFF ---
 find_package(TIFF REQUIRED)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "scikit-build-core>=0.8",
-    "pybind11>=2.11",
+    "pybind11>=2.11,<3",
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
1. Add find_package(ZLIB) and find_package(JPEG) before find_package(TIFF) in CMakeLists.txt. When TIFF is built as a static library, its CMake config file (TiffTargets.cmake) declares dependencies on ZLIB::ZLIB and JPEG::JPEG targets. These must exist before TIFF is found or CMake configuration fails.

2. Pin pybind11 to <3 in pyproject.toml. pybind11 3.0 introduces an ABI break that causes segfaults when cross-module casting between openimpala._core (built with pybind11 3.x) and pyamrex (built with pybind11 2.x). Both modules must use the same major version.