### PR TITLE
Fix intermittent double-free crash in pytest_tortuosity

### DIFF
--- a/python/tests/test_percolation.py
+++ b/python/tests/test_percolation.py
@@ -20,10 +20,14 @@ class TestPercolationCheckCore:
         assert pc.percolates is True
         assert pc.active_volume_fraction > 0.0
 
+        del pc, mf, dm, ba, geom
+
     def test_disconnected_does_not_percolate(self, disconnected_phase):
         geom, ba, dm, mf = _make_mf(disconnected_phase)
         pc = _core.PercolationCheck(geom, ba, dm, mf, 0, _core.Direction.X, 0)
         assert pc.percolates is False
+
+        del pc, mf, dm, ba, geom
 
     def test_direction_string(self):
         assert _core.PercolationCheck.direction_string(_core.Direction.X) == "X"

--- a/python/tests/test_tortuosity.py
+++ b/python/tests/test_tortuosity.py
@@ -35,6 +35,9 @@ class TestTortuosityHypreCore:
         expected = (N - 1.0) / N
         assert tau == pytest.approx(expected, rel=1e-6)
 
+        # Explicitly clean up C++ objects before pytest caches the frame
+        del solver, mf, dm, ba, geom
+
     def test_solver_diagnostics(self):
         N = 8
         data = np.zeros((N, N, N), dtype=np.int32)
@@ -49,6 +52,9 @@ class TestTortuosityHypreCore:
         assert solver.iterations >= 0
         assert solver.residual_norm >= 0.0
         assert abs(solver.flux_in) > 0.0
+
+        # Explicitly clean up C++ objects before pytest caches the frame
+        del solver, mf, dm, ba, geom
 
 
 class TestTortuosityFacade:


### PR DESCRIPTION
pytest caches local variables from the last test frame for introspection. When amrex.finalize() tears down memory arenas before pytest releases these cached C++ objects, their destructors attempt to free already-destroyed arena memory, causing "double free or corruption (!prev)".

Explicitly del C++ solver/geometry objects at end of core test methods so they are destroyed while AMReX is still initialized. Applied to both test_tortuosity.py and test_percolation.py.