### PR TITLE
Disable tests and target only _core in wheel builds to prevent OOM

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -135,7 +135,7 @@ jobs:
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_Fortran_COMPILER="mpif90"
             CMAKE_PREFIX_PATH="/usr/local"
-            SKBUILD_CMAKE_ARGS="-DOPENIMPALA_PYTHON=ON;-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
+            SKBUILD_CMAKE_ARGS="-DOPENIMPALA_PYTHON=ON;-DBUILD_TESTING=OFF;-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
 
           # Vendor libraries into the wheel, but exclude host-specific MPI and
           # runtime libraries that users must provide on their system.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,8 @@ all = [
 openimpala = "openimpala.cli:main"
 
 [tool.scikit-build]
-cmake.args = ["-DOPENIMPALA_PYTHON=ON"]
-wheel.packages = ["python/openimpala"]
+cmake.args = ["-DOPENIMPALA_PYTHON=ON", "-DBUILD_TESTING=OFF"]
+build.targets = ["_core"]
 install.components = ["python"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
The wheel build was compiling all 167 targets (including Catch2 test suite and the standalone Diffusion binary) which exhausted the 7GB RAM on GitHub Actions runners. The OOM killer silently terminated the compiler, leaving _core.so unbuilt.

Fix by adding -DBUILD_TESTING=OFF and build.targets = ["_core"] so only the Python extension module is compiled. Also removed wheel.packages to avoid double-packaging Python files already handled by CMake install.