### PR TITLE
Build HDF5 with autotools to fix missing H5Cpp.h in wheel builds

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-manylinux_2_28-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v2
+          key: cibw-deps-manylinux_2_28-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v3
 
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -72,17 +72,15 @@ jobs:
             wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz &&
             tar xzf hdf5-1.14.6.tar.gz &&
             cd hdf5-1.14.6 &&
-            cmake -S . -B build
-            -DCMAKE_INSTALL_PREFIX=/usr/local
-            -DCMAKE_BUILD_TYPE=Release
-            -DBUILD_SHARED_LIBS=OFF
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            -DHDF5_BUILD_CXX=ON
-            -DHDF5_ENABLE_PARALLEL=ON
-            -DCMAKE_C_COMPILER=mpicc
-            -DCMAKE_CXX_COMPILER=mpicxx &&
-            cmake --build build -j$(nproc) &&
-            cmake --install build &&
+            CC=mpicc CXX=mpicxx ./configure
+            --prefix=/usr/local
+            --enable-parallel
+            --enable-cxx
+            --enable-unsupported
+            --disable-shared
+            --with-pic &&
+            make -j$(nproc) &&
+            make install &&
             cd .. &&
             wget -q https://download.osgeo.org/libtiff/tiff-4.6.0.tar.gz &&
             tar xzf tiff-4.6.0.tar.gz &&
@@ -125,10 +123,6 @@ jobs:
           CIBW_BEFORE_BUILD: pip install "cmake>=3.28,<4"
 
           # Point scikit-build-core to our newly compiled dependencies and MPI compilers.
-          # CMAKE_FIND_PACKAGE_PREFER_CONFIG is passed via SKBUILD_CMAKE_ARGS so it
-          # reaches CMake as a -D flag. This makes find_package() use HDF5Config.cmake
-          # (installed by our CMake-built HDF5) instead of the FindHDF5.cmake module,
-          # which fails its compiler-wrapper test inside the manylinux container.
           CIBW_ENVIRONMENT_LINUX: >
             PATH="/usr/lib64/openmpi/bin:$PATH"
             CMAKE_C_COMPILER="mpicc"
@@ -136,7 +130,6 @@ jobs:
             CMAKE_Fortran_COMPILER="mpif90"
             CMAKE_PREFIX_PATH="/usr/local"
             CMAKE_GENERATOR="Unix Makefiles"
-            SKBUILD_CMAKE_ARGS="-DOPENIMPALA_PYTHON=ON;-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON;-DBUILD_TESTING=OFF"
 
           # Vendor libraries into the wheel, but exclude host-specific MPI and
           # runtime libraries that users must provide on their system.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,23 +74,6 @@ find_package(HYPRE REQUIRED)
 # We need the C++ bindings (hdf5_cpp).
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
 
-# Patch for HDF5Config.cmake (used in wheel builds) which uses different 
-# variable names than the standard CMake FindHDF5 module.
-if(NOT HDF5_INCLUDE_DIRS AND HDF5_INCLUDE_DIR)
-    set(HDF5_INCLUDE_DIRS ${HDF5_INCLUDE_DIR})
-endif()
-if(NOT HDF5_C_LIBRARIES AND HDF5_LIBRARIES)
-    set(HDF5_C_LIBRARIES ${HDF5_LIBRARIES})
-endif()
-if(NOT HDF5_CXX_LIBRARIES AND HDF5_LIBRARIES)
-    set(HDF5_CXX_LIBRARIES ${HDF5_LIBRARIES})
-endif()
-
-# Fallback for the isolated wheel container just in case
-if(NOT HDF5_INCLUDE_DIRS)
-    set(HDF5_INCLUDE_DIRS "/usr/local/include")
-endif()
-
 # --- Transitive dependencies for static TIFF ---
 find_package(ZLIB REQUIRED)
 find_package(JPEG REQUIRED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ all = [
 openimpala = "openimpala.cli:main"
 
 [tool.scikit-build]
-cmake.args =["-DOPENIMPALA_PYTHON=ON", "-DBUILD_TESTING=OFF"]
+cmake.args = ["-DOPENIMPALA_PYTHON=ON", "-DBUILD_TESTING=OFF"]
+build.targets = ["_core"]
 install.components = ["python"]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
HDF5's CMake build silently skips the C++ headers (H5Cpp.h) when parallel+CXX are both enabled, since it considers this "unsupported". Switch to autotools (./configure) with --enable-unsupported to force compilation of the C++ bindings alongside parallel support, matching the approach used in Singularity.deps.def.

This also:
- Removes the HDF5Config.cmake variable patching and SKBUILD_CMAKE_ARGS workaround from CMakeLists.txt (no longer needed since autotools doesn't install CMake config files, so FindHDF5.cmake module mode is used naturally)
- Adds build.targets = ["_core"] to pyproject.toml to only build the Python extension (avoids OOM on GitHub Actions runners)
- Bumps cache key to v3 to discard the broken CMake-built HDF5 cache