### PR TITLE
Use Git tags for versioning via setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,13 @@
 requires = [
     "scikit-build-core>=0.8",
     "pybind11>=2.11,<3",
+    "setuptools_scm>=8",
 ]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "openimpala"
-version = "3.0.0"
+dynamic = ["version"]
 description = "Python bindings for OpenImpala — transport-property computation on 3-D voxel images"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
@@ -41,6 +42,9 @@ openimpala = "openimpala.cli:main"
 cmake.args = ["-DOPENIMPALA_PYTHON=ON", "-DBUILD_TESTING=OFF"]
 build.targets = ["_core"]
 install.components = ["python"]
+
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.pytest.ini_options]
 testpaths = ["python/tests"]

--- a/python/openimpala/__init__.py
+++ b/python/openimpala/__init__.py
@@ -24,7 +24,12 @@ import importlib
 import os
 import sys
 
-__version__ = "0.1.0"
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("openimpala")
+except PackageNotFoundError:
+    __version__ = "unknown"
 
 # Session context manager (pure Python — always available)
 from .session import Session


### PR DESCRIPTION
Replace hardcoded version strings with dynamic versioning from Git tags using setuptools_scm. This means tagging a release (e.g. v3.0.1) on GitHub automatically sets the version in the PyPI wheel — no manual edits needed across pyproject.toml, __init__.py, or CMakeLists.txt.

Changes:
- pyproject.toml: add setuptools_scm build dep, use dynamic = ["version"], configure scikit-build-core metadata provider
- __init__.py: read version from package metadata via importlib.metadata instead of hardcoding it
