### PR TITLE
Fix cache tarball path: write to /project/ bind-mount, not /output/

### DIFF
--- a/.github/workflows/pypi-wheels.yml
+++ b/.github/workflows/pypi-wheels.yml
@@ -115,7 +115,8 @@ jobs:
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
             cmake --install /tmp/amrex/build &&
-            tar czf /output/deps.tar.gz /usr/local ;
+            mkdir -p /project/.cibw-deps-cache &&
+            tar czf /project/.cibw-deps-cache/deps.tar.gz /usr/local ;
             fi
 
           # Ensure each Python version has cmake >= 3.28 (needed by AMReX)
@@ -151,11 +152,6 @@ jobs:
             --exclude libgomp.so.1
             --exclude libgfortran.so.5
             --exclude libquadmath.so.0
-
-      - name: Rescue Cache Tarball
-        run: |
-          mkdir -p .cibw-deps-cache
-          mv wheelhouse/deps.tar.gz .cibw-deps-cache/ || true
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The deps cache tarball was being written to /output/deps.tar.gz which doesn't exist inside the manylinux container. Restore the correct path /project/.cibw-deps-cache/deps.tar.gz which uses the cibuildwheel project bind-mount to persist the tarball back to the host filesystem where actions/cache can pick it up.

Also removed the broken "Rescue Cache Tarball" step that tried to move from wheelhouse/ (wrong location).