### PR TITLE
Remove pyamrex dependency: native C++ NumPy ingestion via VoxelImage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
 
 [project.optional-dependencies]
 mpi = ["mpi4py"]
-amrex = ["pyamrex"]
 progress = ["tqdm"]
 jupyter = ["matplotlib", "ipywidgets"]
 test = [
@@ -28,7 +27,6 @@ test = [
 ]
 all = [
     "mpi4py",
-    "pyamrex",
     "tqdm",
     "matplotlib",
     "ipywidgets",

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -3,8 +3,8 @@
 # ==============================================================================
 #
 # Builds the _core pybind11 extension module, linking against the existing
-# openimpala_io and openimpala_props OBJECT libraries and pyAMReX for AMReX
-# type interop.
+# openimpala_io and openimpala_props OBJECT libraries.  AMReX types are
+# managed natively — no pyamrex dependency.
 #
 # Usage (from the top-level build directory):
 #   cmake .. -DOPENIMPALA_PYTHON=ON
@@ -43,6 +43,7 @@ target_link_libraries(_core PRIVATE
 )
 
 target_include_directories(_core PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/bindings
     ${CMAKE_SOURCE_DIR}/src/io
     ${CMAKE_SOURCE_DIR}/src/props
     ${HDF5_INCLUDE_DIRS}
@@ -111,7 +112,7 @@ if(BUILD_TESTING)
         openimpala_add_pytest(pytest_cli
             "${PYTHON_TEST_DIR}/test_cli.py")
 
-        # --- Tests requiring _core module + pyAMReX ---
+        # --- Tests requiring _core module ---
         openimpala_add_pytest(pytest_enums
             "${PYTHON_TEST_DIR}/test_enums.py")
         openimpala_add_pytest(pytest_facade_helpers

--- a/python/bindings/VoxelImage.H
+++ b/python/bindings/VoxelImage.H
@@ -1,0 +1,35 @@
+/** @file VoxelImage.H
+ *  @brief Opaque container for AMReX grid objects, exposed to Python via pybind11.
+ *
+ *  Encapsulates the Geometry, BoxArray, DistributionMapping, and iMultiFab
+ *  so that Python users never need to interact with AMReX types directly.
+ *  This eliminates the pyamrex dependency entirely.
+ */
+#ifndef OPENIMPALA_VOXEL_IMAGE_H
+#define OPENIMPALA_VOXEL_IMAGE_H
+
+#include <memory>
+
+#include <AMReX.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_iMultiFab.H>
+
+namespace OpenImpala {
+
+/** @brief Opaque handle that bundles AMReX grid infrastructure for a 3-D voxel image.
+ *
+ *  Created from a NumPy array (via pybind11) or from a native C++ reader.
+ *  Passed by shared_ptr so pybind11 can safely prevent premature destruction.
+ */
+struct VoxelImage {
+    amrex::Geometry geom;
+    amrex::BoxArray ba;
+    amrex::DistributionMapping dm;
+    std::shared_ptr<amrex::iMultiFab> mf;
+};
+
+} // namespace OpenImpala
+
+#endif // OPENIMPALA_VOXEL_IMAGE_H

--- a/python/bindings/io.cpp
+++ b/python/bindings/io.cpp
@@ -1,17 +1,82 @@
 /** @file io.cpp
  *  @brief pybind11 bindings for OpenImpala I/O readers.
+ *
+ *  Readers produce VoxelImage handles natively — no pyamrex dependency.
  */
+
+#include <memory>
+#include <string>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_CoordSys.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_RealBox.H>
+#include <AMReX_iMultiFab.H>
 
 #include "TiffReader.H"
 #include "HDF5Reader.H"
 #include "RawReader.H"
 #include "DatReader.H"
+#include "VoxelImage.H"
 
 namespace py = pybind11;
 using namespace OpenImpala;
+
+/** @brief Build a VoxelImage from a reader's Box, then run threshold to fill it. */
+template <typename ReaderT, typename ThreshT>
+static std::shared_ptr<VoxelImage> reader_to_voxelimage(const ReaderT& reader,
+                                                         ThreshT threshold_value,
+                                                         int max_grid_size) {
+    auto img = std::make_shared<VoxelImage>();
+
+    const amrex::Box& box = reader.box();
+    img->ba.define(box);
+    img->ba.maxSize(max_grid_size);
+    img->dm.define(img->ba);
+    img->mf = std::make_shared<amrex::iMultiFab>(img->ba, img->dm, 1, 1);
+
+    int nx = box.length(0);
+    int ny = box.length(1);
+    int nz = box.length(2);
+    amrex::RealBox rb({0.0, 0.0, 0.0},
+                      {static_cast<double>(nx), static_cast<double>(ny), static_cast<double>(nz)});
+    amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
+    img->geom.define(box, rb, amrex::CoordSys::cartesian, is_periodic.data());
+
+    reader.threshold(threshold_value, *(img->mf));
+    return img;
+}
+
+/** @brief Build a VoxelImage with custom threshold output values. */
+template <typename ReaderT, typename ThreshT>
+static std::shared_ptr<VoxelImage> reader_to_voxelimage_custom(const ReaderT& reader,
+                                                                ThreshT threshold_value,
+                                                                int value_if_true,
+                                                                int value_if_false,
+                                                                int max_grid_size) {
+    auto img = std::make_shared<VoxelImage>();
+
+    const amrex::Box& box = reader.box();
+    img->ba.define(box);
+    img->ba.maxSize(max_grid_size);
+    img->dm.define(img->ba);
+    img->mf = std::make_shared<amrex::iMultiFab>(img->ba, img->dm, 1, 1);
+
+    int nx = box.length(0);
+    int ny = box.length(1);
+    int nz = box.length(2);
+    amrex::RealBox rb({0.0, 0.0, 0.0},
+                      {static_cast<double>(nx), static_cast<double>(ny), static_cast<double>(nz)});
+    amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
+    img->geom.define(box, rb, amrex::CoordSys::cartesian, is_periodic.data());
+
+    reader.threshold(threshold_value, value_if_true, value_if_false, *(img->mf));
+    return img;
+}
 
 void init_io(py::module_& m) {
     // =========================================================================
@@ -40,26 +105,26 @@ void init_io(py::module_& m) {
              py::arg("suffix") = ".tif",
              "Read metadata from a TIFF sequence (clears previous state).")
 
-        // Two-arg threshold (binary 0/1 output)
+        // Two-arg threshold → VoxelImage
         .def(
             "threshold",
-            [](const TiffReader& self, double raw_threshold, py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, mf);
+            [](const TiffReader& self, double raw_threshold, int max_grid_size) {
+                return reader_to_voxelimage(self, raw_threshold, max_grid_size);
             },
-            py::arg("raw_threshold"), py::arg("mf"),
-            "Fill *mf* with 1 where pixel > threshold, else 0.")
+            py::arg("raw_threshold"), py::arg("max_grid_size") = 32,
+            "Threshold the image and return a VoxelImage (1 where pixel > threshold, else 0).")
 
-        // Four-arg threshold (custom output values)
+        // Four-arg threshold → VoxelImage
         .def(
             "threshold",
             [](const TiffReader& self, double raw_threshold, int value_if_true, int value_if_false,
-               py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+               int max_grid_size) {
+                return reader_to_voxelimage_custom(self, raw_threshold, value_if_true,
+                                                   value_if_false, max_grid_size);
             },
             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-            py::arg("mf"), "Fill *mf* with custom values based on threshold comparison.")
+            py::arg("max_grid_size") = 32,
+            "Threshold the image with custom output values and return a VoxelImage.")
 
         // Metadata properties
         .def_property_readonly("box", &TiffReader::box)
@@ -95,21 +160,20 @@ void init_io(py::module_& m) {
 
         .def(
             "threshold",
-            [](const HDF5Reader& self, double raw_threshold, py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, mf);
+            [](const HDF5Reader& self, double raw_threshold, int max_grid_size) {
+                return reader_to_voxelimage(self, raw_threshold, max_grid_size);
             },
-            py::arg("raw_threshold"), py::arg("mf"))
+            py::arg("raw_threshold"), py::arg("max_grid_size") = 32)
 
         .def(
             "threshold",
             [](const HDF5Reader& self, double raw_threshold, int value_if_true, int value_if_false,
-               py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+               int max_grid_size) {
+                return reader_to_voxelimage_custom(self, raw_threshold, value_if_true,
+                                                   value_if_false, max_grid_size);
             },
             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-            py::arg("mf"))
+            py::arg("max_grid_size") = 32)
 
         .def_property_readonly("box", &HDF5Reader::box)
         .def_property_readonly("width", &HDF5Reader::width)
@@ -146,21 +210,20 @@ void init_io(py::module_& m) {
 
         .def(
             "threshold",
-            [](const RawReader& self, double threshold_value, py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(threshold_value, mf);
+            [](const RawReader& self, double threshold_value, int max_grid_size) {
+                return reader_to_voxelimage(self, threshold_value, max_grid_size);
             },
-            py::arg("threshold_value"), py::arg("mf"))
+            py::arg("threshold_value"), py::arg("max_grid_size") = 32)
 
         .def(
             "threshold",
             [](const RawReader& self, double threshold_value, int value_if_true, int value_if_false,
-               py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(threshold_value, value_if_true, value_if_false, mf);
+               int max_grid_size) {
+                return reader_to_voxelimage_custom(self, threshold_value, value_if_true,
+                                                   value_if_false, max_grid_size);
             },
             py::arg("threshold_value"), py::arg("value_if_true"), py::arg("value_if_false"),
-            py::arg("mf"))
+            py::arg("max_grid_size") = 32)
 
         .def_property_readonly("box", &RawReader::box)
         .def_property_readonly("width", &RawReader::width)
@@ -192,21 +255,20 @@ void init_io(py::module_& m) {
 
         .def(
             "threshold",
-            [](const DatReader& self, DatReader::DataType raw_threshold, py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, mf);
+            [](const DatReader& self, DatReader::DataType raw_threshold, int max_grid_size) {
+                return reader_to_voxelimage(self, raw_threshold, max_grid_size);
             },
-            py::arg("raw_threshold"), py::arg("mf"))
+            py::arg("raw_threshold"), py::arg("max_grid_size") = 32)
 
         .def(
             "threshold",
             [](const DatReader& self, DatReader::DataType raw_threshold, int value_if_true,
-               int value_if_false, py::object mf_obj) {
-                auto& mf = py::cast<amrex::iMultiFab&>(mf_obj);
-                self.threshold(raw_threshold, value_if_true, value_if_false, mf);
+               int value_if_false, int max_grid_size) {
+                return reader_to_voxelimage_custom(self, raw_threshold, value_if_true,
+                                                   value_if_false, max_grid_size);
             },
             py::arg("raw_threshold"), py::arg("value_if_true"), py::arg("value_if_false"),
-            py::arg("mf"))
+            py::arg("max_grid_size") = 32)
 
         .def_property_readonly("box", &DatReader::box)
         .def_property_readonly("width", &DatReader::width)

--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -1,11 +1,30 @@
 /** @file module.cpp
  *  @brief Top-level pybind11 module definition for OpenImpala Python bindings.
  *
- *  Defines the PYBIND11_MODULE entry point and delegates to per-subsystem
- *  init functions declared in the other binding translation units.
+ *  Defines the PYBIND11_MODULE entry point, AMReX lifecycle helpers,
+ *  the VoxelImage opaque handle, and delegates to per-subsystem init functions.
  */
 
+#include <cstddef>
+#include <memory>
+#include <string>
+
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <AMReX.H>
+#include <AMReX_Box.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_CoordSys.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_ParallelFor.H>
+#include <AMReX_RealBox.H>
+#include <AMReX_iMultiFab.H>
+
+#include "VoxelImage.H"
 
 namespace py = pybind11;
 
@@ -16,12 +35,119 @@ void init_props(py::module_& m);
 void init_solvers(py::module_& m);
 void init_config(py::module_& m);
 
-PYBIND11_MODULE(_core, m) {
-    // Import pyAMReX's exact C++ extension to merge the pybind11 type registries.
-    py::module_::import("amrex.space3d.amrex_3d_pybind");
+// =========================================================================
+// AMReX lifecycle — replaces amrex.initialize() / amrex.finalize()
+// =========================================================================
+static void init_amrex() {
+    if (!amrex::Initialized()) {
+        // Initialise with an empty argument list (no ParmParse input)
+        int argc = 0;
+        char** argv = nullptr;
+        amrex::Initialize(argc, argv);
+    }
+}
 
+static void finalize_amrex() {
+    if (amrex::Initialized()) {
+        amrex::Finalize();
+    }
+}
+
+static bool amrex_initialized() { return amrex::Initialized(); }
+
+// =========================================================================
+// NumPy → VoxelImage factory
+// =========================================================================
+static std::shared_ptr<OpenImpala::VoxelImage>
+voxelimage_from_numpy(py::array_t<int32_t, py::array::c_style | py::array::forcecast> arr,
+                      int max_grid_size) {
+    py::buffer_info buf = arr.request();
+
+    if (buf.ndim != 3) {
+        throw std::runtime_error("Input must be a 3-D NumPy array, got ndim=" +
+                                 std::to_string(buf.ndim));
+    }
+
+    // NumPy C-contiguous arrays are shaped (Z, Y, X)
+    int nz = static_cast<int>(buf.shape[0]);
+    int ny = static_cast<int>(buf.shape[1]);
+    int nx = static_cast<int>(buf.shape[2]);
+
+    amrex::Box domain(amrex::IntVect(0, 0, 0), amrex::IntVect(nx - 1, ny - 1, nz - 1));
+    amrex::RealBox rb({0.0, 0.0, 0.0}, {static_cast<double>(nx), static_cast<double>(ny),
+                                          static_cast<double>(nz)});
+    amrex::Array<int, AMREX_SPACEDIM> is_periodic{0, 0, 0};
+
+    auto img = std::make_shared<OpenImpala::VoxelImage>();
+    img->geom.define(domain, rb, amrex::CoordSys::cartesian, is_periodic.data());
+    img->ba.define(domain);
+    img->ba.maxSize(max_grid_size);
+    img->dm.define(img->ba);
+    img->mf = std::make_shared<amrex::iMultiFab>(img->ba, img->dm, 1, 1);
+
+    const auto* ptr = static_cast<const int32_t*>(buf.ptr);
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(*(img->mf), amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto fab = img->mf->array(mfi);
+        const auto lo = amrex::lbound(bx);
+        const auto hi = amrex::ubound(bx);
+
+        for (int k = lo.z; k <= hi.z; ++k) {
+            for (int j = lo.y; j <= hi.y; ++j) {
+                for (int i = lo.x; i <= hi.x; ++i) {
+                    std::size_t idx =
+                        static_cast<std::size_t>(k) * static_cast<std::size_t>(ny) *
+                            static_cast<std::size_t>(nx) +
+                        static_cast<std::size_t>(j) * static_cast<std::size_t>(nx) +
+                        static_cast<std::size_t>(i);
+                    fab(i, j, k) = ptr[idx];
+                }
+            }
+        }
+    }
+
+    img->mf->FillBoundary(img->geom.periodicity());
+    return img;
+}
+
+// =========================================================================
+// PYBIND11_MODULE
+// =========================================================================
+PYBIND11_MODULE(_core, m) {
     m.doc() = "OpenImpala C++ backend — low-level bindings for transport property "
               "computation on 3-D voxel images of porous microstructures.";
+
+    // --- AMReX lifecycle ---
+    m.def("init_amrex", &init_amrex,
+          "Initialise the AMReX runtime (no-op if already initialised).");
+    m.def("finalize_amrex", &finalize_amrex,
+          "Shut down the AMReX runtime (no-op if not initialised).");
+    m.def("amrex_initialized", &amrex_initialized,
+          "Return True if the AMReX runtime is currently active.");
+
+    // --- VoxelImage opaque handle ---
+    py::class_<OpenImpala::VoxelImage, std::shared_ptr<OpenImpala::VoxelImage>>(
+        m, "VoxelImage",
+        "Opaque container for a 3-D voxel image stored natively in AMReX memory.\n\n"
+        "Create from a NumPy array via ``VoxelImage.from_numpy(arr)`` or receive\n"
+        "one from ``read_image()``.  Pass to solver functions directly.")
+
+        .def_static("from_numpy", &voxelimage_from_numpy, py::arg("arr"),
+                     py::arg("max_grid_size") = 32,
+                     "Construct a VoxelImage from a 3-D int32 NumPy array (Z, Y, X order).")
+
+        .def("__repr__",
+             [](const OpenImpala::VoxelImage& v) {
+                 if (!v.mf)
+                     return std::string("<VoxelImage (empty)>");
+                 const auto& bx = v.ba.minimalBox();
+                 return "<VoxelImage " + std::to_string(bx.length(0)) + "x" +
+                        std::to_string(bx.length(1)) + "x" + std::to_string(bx.length(2)) + ">";
+             });
 
     // Register enums first (used by everything else)
     init_enums(m);

--- a/python/bindings/props.cpp
+++ b/python/bindings/props.cpp
@@ -1,12 +1,17 @@
 /** @file props.cpp
  *  @brief pybind11 bindings for lightweight property calculators.
+ *
+ *  Accepts VoxelImage handles — no pyamrex dependency.
  */
+
+#include <memory>
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include "VolumeFraction.H"
 #include "PercolationCheck.H"
+#include "VoxelImage.H"
 
 namespace py = pybind11;
 using namespace OpenImpala;
@@ -16,16 +21,15 @@ void init_props(py::module_& m) {
     // VolumeFraction
     // =========================================================================
     py::class_<VolumeFraction>(m, "VolumeFraction",
-                               "Computes volume fraction of a phase within an iMultiFab.")
+                               "Computes volume fraction of a phase within a VoxelImage.")
 
-        .def(py::init([](py::object mf_obj, int phase, int comp) {
-                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
-                 return new VolumeFraction(mf, phase, comp);
+        .def(py::init([](std::shared_ptr<VoxelImage> img, int phase, int comp) {
+                 return new VolumeFraction(*(img->mf), phase, comp);
              }),
-             py::arg("mf"), py::arg("phase") = 0, py::arg("comp") = 0,
-             // keep mf alive while this object lives
+             py::arg("img"), py::arg("phase") = 0, py::arg("comp") = 0,
+             // keep VoxelImage alive while this object lives
              py::keep_alive<1, 2>(),
-             "Create a volume-fraction calculator for *phase* in component *comp* of *mf*.")
+             "Create a volume-fraction calculator for *phase* in component *comp* of *img*.")
 
         // C++ signature: void value(long long&, long long&, bool) const
         // Python: returns (phase_count, total_count) tuple
@@ -50,21 +54,15 @@ void init_props(py::module_& m) {
         m, "PercolationCheck",
         "Parallel flood-fill connectivity check for a phase in a given direction.")
 
-        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
-                         py::object mf_obj, int phase_id, OpenImpala::Direction dir, int verbose) {
-                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
-                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
-                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
-                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
-                 return new PercolationCheck(geom, ba, dm, mf, phase_id, dir, verbose);
+        .def(py::init([](std::shared_ptr<VoxelImage> img, int phase_id,
+                         OpenImpala::Direction dir, int verbose) {
+                 return new PercolationCheck(img->geom, img->ba, img->dm, *(img->mf),
+                                            phase_id, dir, verbose);
              }),
-             py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"),
-             py::arg("phase_id"), py::arg("dir"), py::arg("verbose") = 0,
-             // prevent GC of referenced AMReX objects
-             py::keep_alive<1, 2>(), // geom
-             py::keep_alive<1, 3>(), // ba
-             py::keep_alive<1, 4>(), // dm
-             py::keep_alive<1, 5>(), // mf_phase
+             py::arg("img"), py::arg("phase_id"), py::arg("dir"),
+             py::arg("verbose") = 0,
+             // keep VoxelImage alive while this object lives
+             py::keep_alive<1, 2>(),
              "Run a percolation check on construction.  Query results via properties.")
 
         .def_property_readonly(

--- a/python/bindings/solvers.cpp
+++ b/python/bindings/solvers.cpp
@@ -1,8 +1,11 @@
 /** @file solvers.cpp
  *  @brief pybind11 bindings for OpenImpala transport-property solvers.
+ *
+ *  Accepts VoxelImage handles — no pyamrex dependency.
  */
 
 #include <cmath>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -12,6 +15,7 @@
 #include "TortuosityHypre.H"
 #include "TortuosityDirect.H"
 #include "EffectiveDiffusivityHypre.H"
+#include "VoxelImage.H"
 
 namespace py = pybind11;
 using namespace OpenImpala;
@@ -25,26 +29,20 @@ void init_solvers(py::module_& m) {
                                 "equation on a masked phase and computes tortuosity from the "
                                 "resulting flux.")
 
-        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
-                         py::object mf_obj, amrex::Real vf, int phase, OpenImpala::Direction dir,
-                         TortuosityHypre::SolverType solver_type, const std::string& results_path,
-                         amrex::Real vlo, amrex::Real vhi, int verbose, bool write_plotfile) {
-                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
-                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
-                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
-                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
-                 return new TortuosityHypre(geom, ba, dm, mf, vf, phase, dir, solver_type,
-                                            results_path, vlo, vhi, verbose, write_plotfile);
+        .def(py::init([](std::shared_ptr<VoxelImage> img, amrex::Real vf, int phase,
+                         OpenImpala::Direction dir, TortuosityHypre::SolverType solver_type,
+                         const std::string& results_path, amrex::Real vlo, amrex::Real vhi,
+                         int verbose, bool write_plotfile) {
+                 return new TortuosityHypre(img->geom, img->ba, img->dm, *(img->mf), vf, phase,
+                                            dir, solver_type, results_path, vlo, vhi, verbose,
+                                            write_plotfile);
              }),
-             py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"), py::arg("vf"),
-             py::arg("phase"), py::arg("dir"), py::arg("solver_type"), py::arg("results_path"),
+             py::arg("img"), py::arg("vf"), py::arg("phase"), py::arg("dir"),
+             py::arg("solver_type"), py::arg("results_path"),
              py::arg("vlo") = 0.0, py::arg("vhi") = 1.0, py::arg("verbose") = 0,
              py::arg("write_plotfile") = false,
-             // prevent GC of referenced AMReX objects
-             py::keep_alive<1, 2>(), // geom
-             py::keep_alive<1, 3>(), // ba
-             py::keep_alive<1, 4>(), // dm
-             py::keep_alive<1, 5>()) // mf_phase
+             // keep VoxelImage alive while this object lives
+             py::keep_alive<1, 2>())
 
         // value() — translate NaN-on-failure into a Python exception
         .def(
@@ -89,24 +87,17 @@ void init_solvers(py::module_& m) {
         m, "TortuosityDirect",
         "Legacy iterative tortuosity solver using Forward-Euler time-stepping.")
 
-        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
-                         py::object mf_obj, int phase, OpenImpala::Direction dir, amrex::Real eps,
-                         int n_steps, int plot_interval, const std::string& plot_basename,
-                         amrex::Real vlo, amrex::Real vhi) {
-                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
-                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
-                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
-                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
-                 return new TortuosityDirect(geom, ba, dm, mf, phase, dir, eps, n_steps,
-                                             plot_interval, plot_basename, vlo, vhi);
+        .def(py::init([](std::shared_ptr<VoxelImage> img, int phase, OpenImpala::Direction dir,
+                         amrex::Real eps, int n_steps, int plot_interval,
+                         const std::string& plot_basename, amrex::Real vlo, amrex::Real vhi) {
+                 return new TortuosityDirect(img->geom, img->ba, img->dm, *(img->mf), phase, dir,
+                                             eps, n_steps, plot_interval, plot_basename, vlo, vhi);
              }),
-             py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"), py::arg("phase"),
-             py::arg("dir"), py::arg("eps"), py::arg("n_steps"), py::arg("plot_interval"),
-             py::arg("plot_basename"), py::arg("vlo"), py::arg("vhi"),
-             py::keep_alive<1, 2>(), // geom
-             py::keep_alive<1, 3>(), // ba
-             py::keep_alive<1, 4>(), // dm
-             py::keep_alive<1, 5>()) // mf_phase
+             py::arg("img"), py::arg("phase"), py::arg("dir"), py::arg("eps"),
+             py::arg("n_steps"), py::arg("plot_interval"), py::arg("plot_basename"),
+             py::arg("vlo"), py::arg("vhi"),
+             // keep VoxelImage alive while this object lives
+             py::keep_alive<1, 2>())
 
         .def(
             "value",
@@ -135,24 +126,17 @@ void init_solvers(py::module_& m) {
         m, "EffectiveDiffusivityHypre",
         "Solves the cell problem for effective diffusivity via HYPRE.")
 
-        .def(py::init([](py::object geom_obj, py::object ba_obj, py::object dm_obj,
-                         py::object mf_obj, int phase_id, OpenImpala::Direction dir,
+        .def(py::init([](std::shared_ptr<VoxelImage> img, int phase_id, OpenImpala::Direction dir,
                          EffectiveDiffusivityHypre::SolverType solver_type,
                          const std::string& results_path, int verbose, bool write_plotfile) {
-                 auto& geom = py::cast<const amrex::Geometry&>(geom_obj);
-                 auto& ba = py::cast<const amrex::BoxArray&>(ba_obj);
-                 auto& dm = py::cast<const amrex::DistributionMapping&>(dm_obj);
-                 auto& mf = py::cast<const amrex::iMultiFab&>(mf_obj);
-                 return new EffectiveDiffusivityHypre(geom, ba, dm, mf, phase_id, dir, solver_type,
-                                                      results_path, verbose, write_plotfile);
+                 return new EffectiveDiffusivityHypre(img->geom, img->ba, img->dm, *(img->mf),
+                                                      phase_id, dir, solver_type, results_path,
+                                                      verbose, write_plotfile);
              }),
-             py::arg("geom"), py::arg("ba"), py::arg("dm"), py::arg("mf_phase"),
-             py::arg("phase_id"), py::arg("dir"), py::arg("solver_type"), py::arg("results_path"),
-             py::arg("verbose") = 1, py::arg("write_plotfile") = false,
-             py::keep_alive<1, 2>(), // geom
-             py::keep_alive<1, 3>(), // ba
-             py::keep_alive<1, 4>(), // dm
-             py::keep_alive<1, 5>()) // mf_phase
+             py::arg("img"), py::arg("phase_id"), py::arg("dir"), py::arg("solver_type"),
+             py::arg("results_path"), py::arg("verbose") = 1, py::arg("write_plotfile") = false,
+             // keep VoxelImage alive while this object lives
+             py::keep_alive<1, 2>())
 
         .def("solve", &EffectiveDiffusivityHypre::solve,
              "Solve the cell problem.  Returns True if the solver converged.")

--- a/python/openimpala/__init__.py
+++ b/python/openimpala/__init__.py
@@ -3,7 +3,7 @@
 Two layers are provided:
 
 * **Low-level (power-user) API** — ``openimpala.core``
-  Direct pybind11 wrappers around C++ classes; interoperates with pyAMReX types.
+  Direct pybind11 wrappers around C++ classes; operates via ``VoxelImage`` handles.
 
 * **High-level (general) API** — module-level functions
   NumPy-native helpers that set up AMReX objects automatically.
@@ -21,8 +21,6 @@ Quick-start::
 """
 
 import importlib
-import os
-import sys
 
 from importlib.metadata import version, PackageNotFoundError
 
@@ -43,19 +41,11 @@ from .exceptions import (
 
 
 def _load_core():
-    """Load the _core C extension with the correct dlopen flags.
+    """Load the _core C extension.
 
-    Must be called after amrex.space3d is loaded (e.g. inside a Session).
     Repeated calls are cheap — Python caches the import.
     """
-    old_flags = sys.getdlopenflags()
-    sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_NOW)
-    try:
-        import amrex.space3d  # noqa: F401 — load pyAMReX globally first
-        _core = importlib.import_module("openimpala._core")
-    finally:
-        sys.setdlopenflags(old_flags)
-    return _core
+    return importlib.import_module("openimpala._core")
 
 
 def __getattr__(name):
@@ -66,7 +56,7 @@ def __getattr__(name):
     """
     # Symbols that live in the _core C extension
     _CORE_ATTRS = {
-        "core", "_core", "Direction", "CellType", "RawDataType",
+        "core", "_core", "VoxelImage", "Direction", "CellType", "RawDataType",
         "SolverType", "EffDiffSolverType", "PhysicsType",
     }
     # Symbols that live in the facade module
@@ -91,6 +81,7 @@ def __getattr__(name):
 __all__ = [
     "__version__",
     "core",
+    "VoxelImage",
     "Direction",
     "CellType",
     "RawDataType",

--- a/python/openimpala/cli.py
+++ b/python/openimpala/cli.py
@@ -78,12 +78,12 @@ def main(argv: list[str] | None = None) -> int:
 def _cmd_vf(args: argparse.Namespace) -> int:
     import openimpala as oi
 
-    _, _, _, _, mf = oi.read_image(
+    _, img = oi.read_image(
         args.image,
         threshold=args.threshold,
         max_grid_size=args.max_grid_size,
     )
-    vf = oi.core.VolumeFraction(mf, args.phase, 0)
+    vf = oi.core.VolumeFraction(img, args.phase, 0)
     pc, tc = vf.value()
     frac = pc / tc if tc > 0 else 0.0
     result = {"phase": args.phase, "phase_count": pc, "total_count": tc, "volume_fraction": frac}
@@ -94,13 +94,13 @@ def _cmd_vf(args: argparse.Namespace) -> int:
 def _cmd_percolation(args: argparse.Namespace) -> int:
     import openimpala as oi
 
-    _, geom, ba, dm, mf = oi.read_image(
+    _, img = oi.read_image(
         args.image,
         threshold=args.threshold,
         max_grid_size=args.max_grid_size,
     )
     d = oi.facade._parse_direction(args.direction)
-    pc = oi.core.PercolationCheck(geom, ba, dm, mf, args.phase, d, args.verbose)
+    pc = oi.core.PercolationCheck(img, args.phase, d, args.verbose)
     result = {
         "phase": args.phase,
         "direction": args.direction.upper(),
@@ -114,7 +114,7 @@ def _cmd_percolation(args: argparse.Namespace) -> int:
 def _cmd_analyze(args: argparse.Namespace) -> int:
     import openimpala as oi
 
-    _, geom, ba, dm, mf = oi.read_image(
+    _, img = oi.read_image(
         args.image,
         threshold=args.threshold,
         max_grid_size=args.max_grid_size,
@@ -123,11 +123,11 @@ def _cmd_analyze(args: argparse.Namespace) -> int:
     d = oi.facade._parse_direction(args.direction)
 
     # Volume fraction
-    vf_calc = oi.core.VolumeFraction(mf, args.phase, 0)
+    vf_calc = oi.core.VolumeFraction(img, args.phase, 0)
     vf_val = vf_calc.value_vf()
 
     # Percolation
-    pc = oi.core.PercolationCheck(geom, ba, dm, mf, args.phase, d, args.verbose)
+    pc = oi.core.PercolationCheck(img, args.phase, d, args.verbose)
 
     result: dict = {
         "input_file": args.image,
@@ -141,8 +141,7 @@ def _cmd_analyze(args: argparse.Namespace) -> int:
     if pc.percolates:
         st = oi.facade._parse_solver(args.solver)
         solver = oi.core.TortuosityHypre(
-            geom, ba, dm, mf,
-            vf_val, args.phase, d, st, ".",
+            img, vf_val, args.phase, d, st, ".",
             0.0, 1.0, args.verbose, False,
         )
         try:

--- a/python/openimpala/facade.py
+++ b/python/openimpala/facade.py
@@ -98,8 +98,8 @@ def _parse_direction(d):
 
 
 def _ensure_initialized():
-    import amrex.space3d as amrex
-    if not amrex.initialized():
+    _core = _get_core()
+    if not _core.amrex_initialized():
         raise RuntimeError(
             "OpenImpala is not initialized! Please wrap your code in a session block:\n\n"
             "with openimpala.Session():\n"
@@ -128,46 +128,21 @@ def _parse_solver(s):
     return solver_map[key]
 
 
-def _numpy_to_imultifab(
+def _numpy_to_voxelimage(
     data: np.ndarray,
     max_grid_size: int = 32,
 ):
-    """Convert a 3-D int32 NumPy array to an AMReX iMultiFab + supporting objects.
+    """Convert a 3-D int32 NumPy array to a VoxelImage (native C++ ingestion).
 
-    Returns (geom, ba, dm, mf).
+    Returns a VoxelImage handle that encapsulates all AMReX objects.
     """
-    import amrex.space3d as amrex
+    _core = _get_core()
 
     if data.ndim != 3:
         raise ValueError(f"Expected a 3-D array, got shape {data.shape}")
 
     data = np.ascontiguousarray(data, dtype=np.int32)
-    nz, ny, nx = data.shape  # numpy is (z, y, x) order
-
-    # Build AMReX domain
-    domain = amrex.Box(amrex.IntVect(0, 0, 0), amrex.IntVect(nx - 1, ny - 1, nz - 1))
-    real_box = amrex.RealBox(0.0, 0.0, 0.0, float(nx), float(ny), float(nz))
-    geom = amrex.Geometry(domain, real_box, 0, [0, 0, 0])  # non-periodic
-
-    ba = amrex.BoxArray(domain)
-    ba.max_size(max_grid_size)
-    dm = amrex.DistributionMapping(ba)
-
-    mf = amrex.iMultiFab(ba, dm, 1, 1)  # 1 component, 1 ghost cell
-
-    # Fill the iMultiFab from the numpy array
-    for mfi in mf:
-        bx = mfi.validbox()
-        lo = bx.small_end
-        hi = bx.big_end
-        arr = mf.array(mfi)
-        for k in range(lo[2], hi[2] + 1):
-            for j in range(lo[1], hi[1] + 1):
-                for i in range(lo[0], hi[0] + 1):
-                    arr[i, j, k, 0] = int(data[k, j, i])
-
-    mf.fill_boundary(geom.periodicity())
-    return geom, ba, dm, mf
+    return _core.VoxelImage.from_numpy(data, max_grid_size)
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +172,15 @@ def volume_fraction(
     """
     _ensure_initialized()
     _core = _get_core()
-    _, _, _, mf = _numpy_to_imultifab(data, max_grid_size)
-    vf = _core.VolumeFraction(mf, phase, 0)
+
+    if isinstance(data, np.ndarray):
+        img = _numpy_to_voxelimage(data, max_grid_size)
+    elif isinstance(data, _core.VoxelImage):
+        img = data
+    else:
+        raise TypeError("data must be a NumPy array or a VoxelImage")
+
+    vf = _core.VolumeFraction(img, phase, 0)
     pc, tc = vf.value()
     frac = pc / tc if tc > 0 else 0.0
     return VolumeFractionResult(phase_count=pc, total_count=tc, fraction=frac)
@@ -230,8 +212,15 @@ def percolation_check(
     _ensure_initialized()
     _core = _get_core()
     d = _parse_direction(direction)
-    geom, ba, dm, mf = _numpy_to_imultifab(data, max_grid_size)
-    pc = _core.PercolationCheck(geom, ba, dm, mf, phase, d, verbose)
+
+    if isinstance(data, np.ndarray):
+        img = _numpy_to_voxelimage(data, max_grid_size)
+    elif isinstance(data, _core.VoxelImage):
+        img = data
+    else:
+        raise TypeError("data must be a NumPy array or a VoxelImage")
+
+    pc = _core.PercolationCheck(img, phase, d, verbose)
     return PercolationResult(
         percolates=pc.percolates,
         active_volume_fraction=pc.active_volume_fraction,
@@ -277,10 +266,16 @@ def tortuosity(
     _core = _get_core()
     d = _parse_direction(direction)
     st = _parse_solver(solver)
-    geom, ba, dm, mf = _numpy_to_imultifab(data, max_grid_size)
+
+    if isinstance(data, np.ndarray):
+        img = _numpy_to_voxelimage(data, max_grid_size)
+    elif isinstance(data, _core.VoxelImage):
+        img = data
+    else:
+        raise TypeError("data must be a NumPy array or a VoxelImage")
 
     # Percolation check first
-    pc = _core.PercolationCheck(geom, ba, dm, mf, phase, d, verbose)
+    pc = _core.PercolationCheck(img, phase, d, verbose)
     if not pc.percolates:
         raise PercolationError(
             f"Phase {phase} does not percolate in direction "
@@ -288,13 +283,12 @@ def tortuosity(
         )
 
     # Volume fraction
-    vf_calc = _core.VolumeFraction(mf, phase, 0)
+    vf_calc = _core.VolumeFraction(img, phase, 0)
     vf_val = vf_calc.value_vf()
 
     # Solve
     solver_obj = _core.TortuosityHypre(
-        geom, ba, dm, mf,
-        vf_val, phase, d, st, results_path,
+        img, vf_val, phase, d, st, results_path,
         0.0, 1.0, verbose, False,
     )
 
@@ -323,10 +317,10 @@ def read_image(
     raw_width: int = 0,
     raw_height: int = 0,
     raw_depth: int = 0,
-    raw_data_type = None,
+    raw_data_type=None,
     max_grid_size: int = 32,
 ) -> tuple:
-    """Read a 3-D image file and threshold it into an iMultiFab.
+    """Read a 3-D image file and threshold it into a VoxelImage.
 
     Automatically detects format from the file extension unless *file_format*
     is explicitly set.
@@ -344,12 +338,11 @@ def read_image(
 
     Returns
     -------
-    (reader, geom, ba, dm, mf)
-        The reader object and the AMReX infrastructure objects.
+    (reader, VoxelImage)
+        The reader object and the VoxelImage handle.
     """
     _ensure_initialized()
     _core = _get_core()
-    import amrex.space3d as amrex
 
     if raw_data_type is None:
         raw_data_type = _core.RawDataType.UINT8
@@ -380,22 +373,7 @@ def read_image(
     else:
         raise ValueError(f"Unknown file_format '{file_format}'")
 
-    # Build AMReX objects
-    box = reader.box
-    ba = amrex.BoxArray(box)
-    ba.max_size(max_grid_size)
-    dm = amrex.DistributionMapping(ba)
-    mf = amrex.iMultiFab(ba, dm, 1, 1)
+    # Threshold directly into a VoxelImage (all AMReX setup happens in C++)
+    img = reader.threshold(threshold, max_grid_size)
 
-    reader.threshold(threshold, mf)
-
-    # Build Geometry
-    lo = box.small_end
-    hi = box.big_end
-    nx = hi[0] - lo[0] + 1
-    ny = hi[1] - lo[1] + 1
-    nz = hi[2] - lo[2] + 1
-    real_box = amrex.RealBox(0.0, 0.0, 0.0, float(nx), float(ny), float(nz))
-    geom = amrex.Geometry(box, real_box, 0, [0, 0, 0])
-
-    return reader, geom, ba, dm, mf
+    return reader, img

--- a/python/openimpala/session.py
+++ b/python/openimpala/session.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 
 class Session:
-    """Ensures ``amrex.initialize()`` / ``amrex.finalize()`` are called exactly
-    once and in the correct order, even when *mpi4py* is also in use.
+    """Ensures AMReX ``initialize()`` / ``finalize()`` are called exactly once
+    and in the correct order, even when *mpi4py* is also in use.
 
     Usage::
 
@@ -35,28 +35,16 @@ class Session:
     # ------------------------------------------------------------------
     @staticmethod
     def _do_initialize() -> None:
-        import os
-        import sys
-
         # Import mpi4py first so MPI_Init happens before AMReX touches MPI.
         try:
             from mpi4py import MPI  # noqa: F401
         except ImportError:
             pass
 
-        # CRITICAL: Set RTLD_GLOBAL *before* the first import of amrex so that
-        # pyAMReX's C++ type registry is visible to openimpala._core.so.
-        # If amrex is loaded with RTLD_LOCAL (the default), pybind11 cross-module
-        # type casts will segfault.
-        old_flags = sys.getdlopenflags()
-        sys.setdlopenflags(os.RTLD_GLOBAL | os.RTLD_NOW)
-        try:
-            import amrex.space3d as amrex
-        finally:
-            sys.setdlopenflags(old_flags)
+        # Initialise AMReX natively via our C++ bindings — no pyamrex needed.
+        from openimpala._core import init_amrex
 
-        if not amrex.initialized():
-            amrex.initialize([])
+        init_amrex()
 
         # NOTE: HYPRE initialisation is handled automatically by the C++
         # solver constructors (TortuosityHypre, EffectiveDiffusivityHypre)
@@ -65,11 +53,12 @@ class Session:
     @staticmethod
     def _do_finalize() -> None:
         import gc
-        import amrex.space3d as amrex
 
-        if amrex.initialized():
+        from openimpala._core import amrex_initialized, finalize_amrex
+
+        if amrex_initialized():
             # Force Python to destroy all orphaned C++ pybind11 objects NOW
             gc.collect()
 
             # Now it is safe to shut down the C++ backend
-            amrex.finalize()
+            finalize_amrex()

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,8 +1,7 @@
 """Shared pytest fixtures for OpenImpala Python binding tests.
 
 Ensures AMReX is initialised exactly once per test session via
-``openimpala.Session``, which sets the required RTLD_GLOBAL dlopen
-flags before loading pyAMReX.
+``openimpala.Session``.
 """
 
 import pytest

--- a/python/tests/test_percolation.py
+++ b/python/tests/test_percolation.py
@@ -6,28 +6,26 @@ import pytest
 from openimpala import _core
 
 
-def _make_mf(data: np.ndarray, max_grid_size: int = 32):
-    from openimpala.facade import _numpy_to_imultifab
-
-    return _numpy_to_imultifab(data, max_grid_size)
+def _make_img(data: np.ndarray, max_grid_size: int = 32):
+    return _core.VoxelImage.from_numpy(np.ascontiguousarray(data, dtype=np.int32), max_grid_size)
 
 
 class TestPercolationCheckCore:
 
     def test_connected_channel_percolates(self, connected_channel):
-        geom, ba, dm, mf = _make_mf(connected_channel)
-        pc = _core.PercolationCheck(geom, ba, dm, mf, 0, _core.Direction.X, 0)
+        img = _make_img(connected_channel)
+        pc = _core.PercolationCheck(img, 0, _core.Direction.X, 0)
         assert pc.percolates is True
         assert pc.active_volume_fraction > 0.0
 
-        del pc, mf, dm, ba, geom
+        del pc, img
 
     def test_disconnected_does_not_percolate(self, disconnected_phase):
-        geom, ba, dm, mf = _make_mf(disconnected_phase)
-        pc = _core.PercolationCheck(geom, ba, dm, mf, 0, _core.Direction.X, 0)
+        img = _make_img(disconnected_phase)
+        pc = _core.PercolationCheck(img, 0, _core.Direction.X, 0)
         assert pc.percolates is False
 
-        del pc, mf, dm, ba, geom
+        del pc, img
 
     def test_direction_string(self):
         assert _core.PercolationCheck.direction_string(_core.Direction.X) == "X"

--- a/python/tests/test_tortuosity.py
+++ b/python/tests/test_tortuosity.py
@@ -10,10 +10,8 @@ from openimpala import _core
 from openimpala.exceptions import ConvergenceError, PercolationError
 
 
-def _make_mf(data: np.ndarray, max_grid_size: int = 32):
-    from openimpala.facade import _numpy_to_imultifab
-
-    return _numpy_to_imultifab(data, max_grid_size)
+def _make_img(data: np.ndarray, max_grid_size: int = 32):
+    return _core.VoxelImage.from_numpy(np.ascontiguousarray(data, dtype=np.int32), max_grid_size)
 
 
 class TestTortuosityHypreCore:
@@ -23,12 +21,11 @@ class TestTortuosityHypreCore:
         """tau = (N-1)/N for a uniform N-cell domain."""
         N = 16
         data = np.zeros((N, N, N), dtype=np.int32)
-        geom, ba, dm, mf = _make_mf(data, max_grid_size=N)
+        img = _make_img(data, max_grid_size=N)
 
         vf = 1.0  # all phase 0
         solver = _core.TortuosityHypre(
-            geom, ba, dm, mf,
-            vf, 0, _core.Direction.X, _core.SolverType.FlexGMRES, ".",
+            img, vf, 0, _core.Direction.X, _core.SolverType.FlexGMRES, ".",
             0.0, 1.0, 0, False,
         )
         tau = solver.value()
@@ -36,16 +33,15 @@ class TestTortuosityHypreCore:
         assert tau == pytest.approx(expected, rel=1e-6)
 
         # Explicitly clean up C++ objects before pytest caches the frame
-        del solver, mf, dm, ba, geom
+        del solver, img
 
     def test_solver_diagnostics(self):
         N = 8
         data = np.zeros((N, N, N), dtype=np.int32)
-        geom, ba, dm, mf = _make_mf(data, max_grid_size=N)
+        img = _make_img(data, max_grid_size=N)
 
         solver = _core.TortuosityHypre(
-            geom, ba, dm, mf,
-            1.0, 0, _core.Direction.X, _core.SolverType.FlexGMRES, ".",
+            img, 1.0, 0, _core.Direction.X, _core.SolverType.FlexGMRES, ".",
         )
         solver.value()
         assert solver.solver_converged is True
@@ -54,7 +50,7 @@ class TestTortuosityHypreCore:
         assert abs(solver.flux_in) > 0.0
 
         # Explicitly clean up C++ objects before pytest caches the frame
-        del solver, mf, dm, ba, geom
+        del solver, img
 
 
 class TestTortuosityFacade:

--- a/python/tests/test_volume_fraction.py
+++ b/python/tests/test_volume_fraction.py
@@ -6,38 +6,36 @@ import pytest
 from openimpala import _core
 
 
-def _make_mf(data: np.ndarray, max_grid_size: int = 32):
-    """Helper: convert ndarray to (geom, ba, dm, mf)."""
-    from openimpala.facade import _numpy_to_imultifab
-
-    return _numpy_to_imultifab(data, max_grid_size)
+def _make_img(data: np.ndarray, max_grid_size: int = 32):
+    """Helper: convert ndarray to VoxelImage."""
+    return _core.VoxelImage.from_numpy(np.ascontiguousarray(data, dtype=np.int32), max_grid_size)
 
 
 class TestVolumeFractionCore:
     """Tests using the low-level _core.VolumeFraction class."""
 
     def test_uniform_phase_zero(self, uniform_block):
-        _, _, _, mf = _make_mf(uniform_block)
-        vf = _core.VolumeFraction(mf, 0, 0)
+        img = _make_img(uniform_block)
+        vf = _core.VolumeFraction(img, 0, 0)
         pc, tc = vf.value()
         assert tc == 16 ** 3
         assert pc == 16 ** 3
 
     def test_uniform_vf(self, uniform_block):
-        _, _, _, mf = _make_mf(uniform_block)
-        vf = _core.VolumeFraction(mf, 0, 0)
+        img = _make_img(uniform_block)
+        vf = _core.VolumeFraction(img, 0, 0)
         assert vf.value_vf() == pytest.approx(1.0)
 
     def test_two_phase_half(self, two_phase_block):
-        _, _, _, mf = _make_mf(two_phase_block)
-        vf0 = _core.VolumeFraction(mf, 0, 0)
-        vf1 = _core.VolumeFraction(mf, 1, 0)
+        img = _make_img(two_phase_block)
+        vf0 = _core.VolumeFraction(img, 0, 0)
+        vf1 = _core.VolumeFraction(img, 1, 0)
         assert vf0.value_vf() == pytest.approx(0.5)
         assert vf1.value_vf() == pytest.approx(0.5)
 
     def test_absent_phase(self, uniform_block):
-        _, _, _, mf = _make_mf(uniform_block)
-        vf = _core.VolumeFraction(mf, 99, 0)
+        img = _make_img(uniform_block)
+        vf = _core.VolumeFraction(img, 99, 0)
         pc, tc = vf.value()
         assert pc == 0
         assert tc == 16 ** 3


### PR DESCRIPTION
Replace the pyamrex-based Python ↔ AMReX bridge with a fully native C++ approach using pybind11's numpy support. This eliminates the pyamrex dependency that blocked PyPI installs (pyamrex is not published on PyPI), enabling sub-5-second `pip install openimpala` on Google Colab.

Key changes:

- Add VoxelImage.H: opaque C++ container (Geometry, BoxArray, DistributionMapping, shared_ptr<iMultiFab>) exposed to Python via pybind11 as an opaque handle

- Rewrite module.cpp: remove `py::module_::import("amrex.space3d...")`, add native init_amrex()/finalize_amrex()/amrex_initialized() lifecycle functions, add VoxelImage.from_numpy() factory that copies NumPy data into iMultiFab using MFIter (MPI-safe, OpenMP-parallel)

- Update io.cpp: reader.threshold() now returns a VoxelImage instead of requiring a pre-built pyamrex iMultiFab argument

- Update props.cpp, solvers.cpp: constructors accept VoxelImage handles instead of separate pyamrex Geometry/BoxArray/DM/iMultiFab objects

- Rewrite session.py: call _core.init_amrex() instead of importing amrex.space3d; remove RTLD_GLOBAL flag manipulation

- Rewrite facade.py: replace _numpy_to_imultifab (slow Python loops via pyamrex) with _numpy_to_voxelimage (fast C++ ingestion); all public functions accept both numpy arrays and VoxelImage handles

- Update __init__.py: remove pyamrex dlopen workaround, export VoxelImage

- Update cli.py: use VoxelImage-based API for read_image results

- Remove pyamrex from pyproject.toml optional dependencies

- Update CMakeLists.txt: add bindings/ to include path for VoxelImage.H

- Update all tests to use VoxelImage API

Closes #165 