### PR TITLE
Add Fortran to project languages to fix AMReX CMake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.18)
 
 project(OpenImpala
     VERSION 0.1.0
-    LANGUAGES C CXX
+    LANGUAGES C CXX Fortran
     DESCRIPTION "Image-based simulation of transport properties in porous media"
 )
 


### PR DESCRIPTION
AMReX was built with AMReX_FORTRAN=ON, so the project must enable Fortran before find_package(AMReX). Added Fortran to the LANGUAGES list in the project() declaration.

https://claude.ai/code/session_012awTC848VbvuhVZzFhNCDC