### PR TITLE
Add missing AMReX_SPACE.H include in ResultsJSON.H

### DIFF
--- a/src/props/ResultsJSON.H
+++ b/src/props/ResultsJSON.H
@@ -32,6 +32,7 @@
 
 #include "PhysicsConfig.H"
 
+#include <AMReX_SPACE.H>
 #include <nlohmann/json.hpp>
 
 #include <cmath>


### PR DESCRIPTION
ResultsJSON.H uses AMREX_SPACEDIM and AMREX_D_DECL but did not include AMReX_SPACE.H, causing build failures when included without other AMReX headers pulling it in transitively.

https://claude.ai/code/session_012awTC848VbvuhVZzFhNCDC