### PR TITLE
Guard AMReX includes in ResultsJSON.H for unit test mode

### DIFF
--- a/src/props/ResultsJSON.H
+++ b/src/props/ResultsJSON.H
@@ -32,7 +32,17 @@
 
 #include "PhysicsConfig.H"
 
+#ifndef OPENIMPALA_UNIT_TEST
 #include <AMReX_SPACE.H>
+#else
+#ifndef AMREX_SPACEDIM
+#define AMREX_SPACEDIM 3
+#endif
+#ifndef AMREX_D_DECL
+#define AMREX_D_DECL(a, b, c) a, b, c
+#endif
+#endif
+
 #include <nlohmann/json.hpp>
 
 #include <cmath>


### PR DESCRIPTION
The unit test compiles without AMReX (OPENIMPALA_UNIT_TEST defined). Guard the AMReX_SPACE.H include and provide fallback definitions for AMREX_SPACEDIM and AMREX_D_DECL, matching the pattern in PhysicsConfig.H.

https://claude.ai/code/session_012awTC848VbvuhVZzFhNCDC