### PR TITLE
Fix SSA face counting at box boundaries and EffDiff PFMG divergence

### DIFF
--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -622,8 +622,11 @@ bool EffectiveDiffusivityHypre::solve() {
         return m_converged;
     }
 
-    // Delegate solver dispatch to base class (PFMG preconditioner for periodic problems)
-    runSolver(PrecondType::PFMG);
+    // Delegate solver dispatch to base class.
+    // SMG is used instead of PFMG because the periodic cell problem with a
+    // pinned null-space cell can cause PFMG to diverge (NaN at iteration 1).
+    // SMG handles periodic structured grids more robustly.
+    runSolver(PrecondType::SMG);
 
     if (m_converged) {
         getChiSolution(m_mf_chi);

--- a/src/props/SpecificSurfaceArea.cpp
+++ b/src/props/SpecificSurfaceArea.cpp
@@ -41,7 +41,6 @@ void SpecificSurfaceArea::value(long long& face_count, long long& total_count, b
 
     for (amrex::MFIter mfi(m_mf); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.validbox();
-        const amrex::Box& vbx = mfi.validbox();
         const auto& fab = m_mf.const_array(mfi, phase_comp);
 
         // Count total cells in padded interior
@@ -59,9 +58,10 @@ void SpecificSurfaceArea::value(long long& face_count, long long& total_count, b
             if (!check_bx.ok()) {
                 continue;
             }
-            // The +d neighbor must be in padded_domain and in the valid box
+            // The +d neighbor must be in padded_domain; clamp so cell+1 is also valid.
+            // The +d neighbor accesses a ghost cell at the FAB boundary, which is
+            // correctly filled via FillBoundary (asserted nGrow >= 1 above).
             int hi_limit = std::min(check_bx.bigEnd(d), padded_domain.bigEnd(d) - 1);
-            hi_limit = std::min(hi_limit, vbx.bigEnd(d) - 1);
             check_bx.setBig(d, hi_limit);
 
             if (check_bx.ok()) {


### PR DESCRIPTION
SSA: Remove overly aggressive vbx.bigEnd(d)-1 clamping that prevented face counting at multi-box boundaries. The interface at the box boundary was missed because the check box was shrunk below the valid cell range. Ghost cells are already guaranteed filled (nGrow>=1 asserted).

EffDiff: Switch preconditioner from PFMG to SMG for the periodic cell problem. PFMG diverges (NaN at iteration 1) on the periodic structured grid with a pinned null-space cell. SMG handles periodic grids more robustly, matching the approach used by TortuosityHypre.
