### PR TITLE
Fix GPU wheel Docker image and add FloodFill/MLMG solver tests

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v1
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v1
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -42,7 +42,7 @@ jobs:
 
           # Use NVIDIA's CUDA-enabled manylinux image (CUDA 12.6, AlmaLinux 8)
           # This provides nvcc, CUDA runtime, and cuBLAS/cuSPARSE out of the box.
-          CIBW_MANYLINUX_X86_64_IMAGE: sameli/manylinux_2_28_x86_64_cuda_12.6
+          CIBW_MANYLINUX_X86_64_IMAGE: sameli/manylinux_2_34_x86_64_cuda_12.6
 
           # Build all dependencies with CUDA support.
           # HDF5 and libtiff are CPU-only (no GPU path needed).
@@ -50,7 +50,7 @@ jobs:
           # AMReX is built with -DAMReX_GPU_BACKEND=CUDA for device kernels.
           CIBW_BEFORE_ALL_LINUX: >
             dnf install -y epel-release &&
-            dnf --enablerepo=powertools install -y
+            dnf --enablerepo=crb install -y
             openmpi-devel gcc-gfortran gcc-c++ wget git
             zlib-devel libjpeg-turbo-devel python3-pip &&
             pip3 install "cmake>=3.28,<4" &&

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -422,6 +422,49 @@ set_tests_properties(tDiffusion_hdf5 PROPERTIES
 )
 
 # ==============================================================================
+# FloodFill Tests (Issue #170 — shared GPU-compatible flood fill utility)
+# ==============================================================================
+openimpala_add_test(tFloodFill  "${CMAKE_CURRENT_SOURCE_DIR}/tFloodFill.cpp")
+
+# ==============================================================================
+# TortuosityMLMG Tests (Issue #171 — matrix-free MLMG solver)
+#
+# Validates the AMReX-native MLMG solver against the same analytical
+# solutions used for the HYPRE-based solver.
+# ==============================================================================
+openimpala_add_test(tTortuosityMLMG  "${CMAKE_CURRENT_SOURCE_DIR}/tTortuosityMLMG.cpp")
+
+# MLMG uniform block: tau = (N-1)/N = 0.96875
+add_test(
+    NAME tTortuosityMLMG_uniform
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+            ${MPIEXEC_PREFLAGS}
+            $<TARGET_FILE:tTortuosityMLMG>
+            ${CMAKE_SOURCE_DIR}/tests/inputs/tTortuosityMLMG_uniform.inputs
+            amrex.verbose=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(tTortuosityMLMG_uniform PROPERTIES
+    ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
+    TIMEOUT 300
+)
+
+# MLMG Y-direction symmetry: same tau as X
+add_test(
+    NAME tTortuosityMLMG_dirY
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1
+            ${MPIEXEC_PREFLAGS}
+            $<TARGET_FILE:tTortuosityMLMG>
+            ${CMAKE_SOURCE_DIR}/tests/inputs/tTortuosityMLMG_dirY.inputs
+            amrex.verbose=0
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+set_tests_properties(tTortuosityMLMG_dirY PROPERTIES
+    ENVIRONMENT "OMPI_ALLOW_RUN_AS_ROOT=1;OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1"
+    TIMEOUT 300
+)
+
+# ==============================================================================
 # Unit Tests (Catch2 — fast, no MPI/AMReX required)
 # ==============================================================================
 add_subdirectory(unit)

--- a/tests/inputs/tTortuosityMLMG_dirY.inputs
+++ b/tests/inputs/tTortuosityMLMG_dirY.inputs
@@ -1,0 +1,21 @@
+# TortuosityMLMG Test: Y Direction
+#
+# Same as uniform test but in Y direction — validates directional symmetry.
+
+domain_size = 32
+box_size = 16
+verbose = 2
+num_phases_fill = 1
+direction = Y
+
+expected_tau = 0.96875
+tau_tolerance = 0.001
+
+resultsdir = ./tTortuosityMLMG_dirY_results
+
+mlmg.eps = 1e-9
+mlmg.maxiter = 200
+
+tortuosity.active_phases = 0
+tortuosity.phase_diffusivities = 1.0
+tortuosity.remspot_passes = 0

--- a/tests/inputs/tTortuosityMLMG_uniform.inputs
+++ b/tests/inputs/tTortuosityMLMG_uniform.inputs
@@ -1,0 +1,25 @@
+# TortuosityMLMG Test: Uniform Dense Block
+#
+# Geometry:  32^3 domain, all voxels = single conducting phase (D=1.0)
+# Analytical: tau = (N-1)/N = 31/32 = 0.96875
+# Validates: TortuosityMLMG solver + TortuositySolverBase infrastructure
+
+domain_size = 32
+box_size = 16
+verbose = 2
+num_phases_fill = 1
+direction = X
+
+expected_tau = 0.96875
+tau_tolerance = 0.001
+
+resultsdir = ./tTortuosityMLMG_uniform_results
+
+# --- MLMG Solver Controls ---
+mlmg.eps = 1e-9
+mlmg.maxiter = 200
+
+# --- Multi-phase configuration ---
+tortuosity.active_phases = 0
+tortuosity.phase_diffusivities = 1.0
+tortuosity.remspot_passes = 0

--- a/tests/tFloodFill.cpp
+++ b/tests/tFloodFill.cpp
@@ -1,0 +1,307 @@
+// tests/tFloodFill.cpp
+//
+// Direct tests for the shared FloodFill utility (FloodFill.H/cpp).
+//
+// Validates:
+//   1. Full flood on uniform domain — all cells reachable from a single seed
+//   2. Partial flood — two isolated blocks, only seeded block is reached
+//   3. collectBoundarySeeds — correct inlet/outlet seed collection
+//   4. Multi-label flood — two separate floods with distinct labels
+
+#include "FloodFill.H"
+#include "Tortuosity.H"
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_Print.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Loop.H>
+
+#include <cstdlib>
+#include <string>
+
+namespace {
+
+struct TestStatus {
+    bool passed = true;
+    std::string fail_reason;
+
+    void recordFail(const std::string& reason) {
+        if (passed) {
+            passed = false;
+            fail_reason = reason;
+        }
+    }
+};
+
+} // anonymous namespace
+
+
+int main(int argc, char* argv[]) {
+    amrex::Initialize(argc, argv);
+    {
+        TestStatus status;
+        int verbose = 1;
+        int domain_size = 16;
+        int box_size = 8;
+
+        {
+            amrex::ParmParse pp;
+            pp.query("verbose", verbose);
+            pp.query("domain_size", domain_size);
+            pp.query("box_size", box_size);
+        }
+
+        const int N = domain_size;
+
+        // Setup geometry and grid
+        amrex::Box domain_box(amrex::IntVect(0, 0, 0), amrex::IntVect(N - 1, N - 1, N - 1));
+        amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
+                          {AMREX_D_DECL(amrex::Real(N), amrex::Real(N), amrex::Real(N))});
+        amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
+        amrex::Geometry geom;
+        geom.define(domain_box, &rb, 0, is_periodic.data());
+
+        amrex::BoxArray ba(domain_box);
+        ba.maxSize(box_size);
+        amrex::DistributionMapping dm(ba);
+
+        // ================================================================
+        // Test 1: Full flood on uniform domain
+        // ================================================================
+        if (status.passed) {
+            amrex::iMultiFab mf_phase(ba, dm, 1, 1);
+            mf_phase.setVal(0); // all phase 0
+            mf_phase.FillBoundary(geom.periodicity());
+
+            amrex::iMultiFab mask(ba, dm, 1, 1);
+            mask.setVal(OpenImpala::FLOOD_INACTIVE);
+
+            amrex::Vector<amrex::IntVect> seeds = {amrex::IntVect(0, 0, 0)};
+            OpenImpala::parallelFloodFill(mask, mf_phase, 0, seeds, geom, verbose);
+
+            // Count reachable cells
+            long long reached = 0;
+            for (amrex::MFIter mfi(mask); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.validbox();
+                const auto arr = mask.const_array(mfi);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    if (arr(i, j, k, 0) == OpenImpala::FLOOD_ACTIVE) {
+                        reached++;
+                    }
+                });
+            }
+            amrex::ParallelAllReduce::Sum(reached, amrex::ParallelContext::CommunicatorSub());
+
+            long long expected = static_cast<long long>(N) * N * N;
+            if (reached != expected) {
+                status.recordFail("Test 1 (full flood): reached=" + std::to_string(reached) +
+                                  ", expected=" + std::to_string(expected));
+            }
+            if (status.passed && verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Test 1 (full flood):       PASS (" << reached << "/" << expected
+                               << " cells)\n";
+            }
+        }
+
+        // ================================================================
+        // Test 2: Partial flood — two isolated blocks
+        // ================================================================
+        if (status.passed) {
+            amrex::iMultiFab mf_phase(ba, dm, 1, 1);
+            mf_phase.setVal(1); // background = phase 1
+
+            int cube_size = 3;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.growntilebox();
+                auto arr = mf_phase.array(mfi);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    // Block A at corner (1,1,1)
+                    if (i >= 1 && i < 1 + cube_size && j >= 1 && j < 1 + cube_size && k >= 1 &&
+                        k < 1 + cube_size) {
+                        arr(i, j, k, 0) = 0;
+                    }
+                    // Block B at far corner, separated by gap
+                    int lo2 = N - 1 - cube_size;
+                    if (i >= lo2 && i < lo2 + cube_size && j >= lo2 && j < lo2 + cube_size &&
+                        k >= lo2 && k < lo2 + cube_size) {
+                        arr(i, j, k, 0) = 0;
+                    }
+                });
+            }
+            mf_phase.FillBoundary(geom.periodicity());
+
+            // Seed only in block A
+            amrex::iMultiFab mask(ba, dm, 1, 1);
+            mask.setVal(OpenImpala::FLOOD_INACTIVE);
+
+            amrex::Vector<amrex::IntVect> seeds = {amrex::IntVect(1, 1, 1)};
+            OpenImpala::parallelFloodFill(mask, mf_phase, 0, seeds, geom, verbose);
+
+            long long reached = 0;
+            for (amrex::MFIter mfi(mask); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.validbox();
+                const auto arr = mask.const_array(mfi);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    if (arr(i, j, k, 0) == OpenImpala::FLOOD_ACTIVE) {
+                        reached++;
+                    }
+                });
+            }
+            amrex::ParallelAllReduce::Sum(reached, amrex::ParallelContext::CommunicatorSub());
+
+            long long expected_block_vol = static_cast<long long>(cube_size) * cube_size * cube_size;
+            if (reached != expected_block_vol) {
+                status.recordFail("Test 2 (partial flood): reached=" + std::to_string(reached) +
+                                  ", expected=" + std::to_string(expected_block_vol));
+            }
+            if (status.passed && verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Test 2 (partial flood):    PASS (" << reached << " cells, "
+                               << "only block A)\n";
+            }
+        }
+
+        // ================================================================
+        // Test 3: collectBoundarySeeds
+        // ================================================================
+        if (status.passed) {
+            amrex::iMultiFab mf_phase(ba, dm, 1, 1);
+            mf_phase.setVal(0); // all phase 0
+            mf_phase.FillBoundary(geom.periodicity());
+
+            amrex::Vector<amrex::IntVect> inletSeeds, outletSeeds;
+            OpenImpala::collectBoundarySeeds(mf_phase, 0, 0 /* X direction */, geom, inletSeeds,
+                                             outletSeeds);
+
+            // For X direction: inlet = i=0 face, outlet = i=N-1 face
+            // Each face has N*N cells
+            long long expected_seeds = static_cast<long long>(N) * N;
+            if (static_cast<long long>(inletSeeds.size()) != expected_seeds) {
+                status.recordFail(
+                    "Test 3 (boundary seeds): inlet seeds=" + std::to_string(inletSeeds.size()) +
+                    ", expected=" + std::to_string(expected_seeds));
+            }
+            if (static_cast<long long>(outletSeeds.size()) != expected_seeds) {
+                status.recordFail(
+                    "Test 3 (boundary seeds): outlet seeds=" + std::to_string(outletSeeds.size()) +
+                    ", expected=" + std::to_string(expected_seeds));
+            }
+
+            // Verify all inlet seeds have i=0
+            for (const auto& s : inletSeeds) {
+                if (s[0] != 0) {
+                    status.recordFail("Test 3 (boundary seeds): inlet seed with i=" +
+                                      std::to_string(s[0]) + " (expected 0)");
+                    break;
+                }
+            }
+            // Verify all outlet seeds have i=N-1
+            for (const auto& s : outletSeeds) {
+                if (s[0] != N - 1) {
+                    status.recordFail("Test 3 (boundary seeds): outlet seed with i=" +
+                                      std::to_string(s[0]) + " (expected " + std::to_string(N - 1) +
+                                      ")");
+                    break;
+                }
+            }
+
+            if (status.passed && verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Test 3 (boundary seeds):   PASS (inlet=" << inletSeeds.size()
+                               << ", outlet=" << outletSeeds.size() << ")\n";
+            }
+        }
+
+        // ================================================================
+        // Test 4: Multi-label flood (two labels on same mask)
+        // ================================================================
+        if (status.passed) {
+            amrex::iMultiFab mf_phase(ba, dm, 1, 1);
+            mf_phase.setVal(1); // background
+
+            int cube_size = 3;
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.growntilebox();
+                auto arr = mf_phase.array(mfi);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    if (i >= 1 && i < 1 + cube_size && j >= 1 && j < 1 + cube_size && k >= 1 &&
+                        k < 1 + cube_size) {
+                        arr(i, j, k, 0) = 0;
+                    }
+                    int lo2 = N - 1 - cube_size;
+                    if (i >= lo2 && i < lo2 + cube_size && j >= lo2 && j < lo2 + cube_size &&
+                        k >= lo2 && k < lo2 + cube_size) {
+                        arr(i, j, k, 0) = 0;
+                    }
+                });
+            }
+            mf_phase.FillBoundary(geom.periodicity());
+
+            amrex::iMultiFab mask(ba, dm, 1, 1);
+            mask.setVal(OpenImpala::FLOOD_INACTIVE);
+
+            // Flood block A with label=1
+            amrex::Vector<amrex::IntVect> seeds_a = {amrex::IntVect(1, 1, 1)};
+            OpenImpala::parallelFloodFill(mask, mf_phase, 0, seeds_a, geom, verbose, 1);
+
+            // Flood block B with label=2
+            int lo2 = N - 1 - cube_size;
+            amrex::Vector<amrex::IntVect> seeds_b = {amrex::IntVect(lo2, lo2, lo2)};
+            OpenImpala::parallelFloodFill(mask, mf_phase, 0, seeds_b, geom, verbose, 2);
+
+            long long count_1 = 0, count_2 = 0;
+            for (amrex::MFIter mfi(mask); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.validbox();
+                const auto arr = mask.const_array(mfi);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    if (arr(i, j, k, 0) == 1) count_1++;
+                    if (arr(i, j, k, 0) == 2) count_2++;
+                });
+            }
+            amrex::ParallelAllReduce::Sum(count_1, amrex::ParallelContext::CommunicatorSub());
+            amrex::ParallelAllReduce::Sum(count_2, amrex::ParallelContext::CommunicatorSub());
+
+            long long expected_vol = static_cast<long long>(cube_size) * cube_size * cube_size;
+            if (count_1 != expected_vol) {
+                status.recordFail("Test 4 (multi-label): label 1 count=" + std::to_string(count_1) +
+                                  ", expected=" + std::to_string(expected_vol));
+            }
+            if (count_2 != expected_vol) {
+                status.recordFail("Test 4 (multi-label): label 2 count=" + std::to_string(count_2) +
+                                  ", expected=" + std::to_string(expected_vol));
+            }
+
+            if (status.passed && verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Test 4 (multi-label):      PASS (label1=" << count_1
+                               << ", label2=" << count_2 << ")\n";
+            }
+        }
+
+        // ================================================================
+        // Final summary
+        // ================================================================
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            if (status.passed) {
+                amrex::Print() << "\n--- TEST RESULT: PASS ---\n";
+            } else {
+                amrex::Print() << "\n--- TEST RESULT: FAIL ---\n";
+                amrex::Print() << "  Reason: " << status.fail_reason << "\n";
+            }
+        }
+
+        if (!status.passed) {
+            amrex::Abort("tFloodFill Test FAILED.");
+        }
+    }
+    amrex::Finalize();
+    return 0;
+}

--- a/tests/tTortuosityMLMG.cpp
+++ b/tests/tTortuosityMLMG.cpp
@@ -1,0 +1,219 @@
+// tests/tTortuosityMLMG.cpp
+//
+// Validates the TortuosityMLMG matrix-free solver against known analytical
+// solutions. Uses the same synthetic geometry approach as tMultiPhaseTransport.
+//
+// Test cases (selected via inputs):
+//   uniform:  All cells = phase 0, tau = (N-1)/N
+//   twophase: Alternating layers with equal D, tau = (N-1)/N
+
+#include "TortuosityMLMG.H"
+#include "Tortuosity.H"
+#include "SolverConfig.H"
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_Utility.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_iMultiFab.H>
+#include <AMReX_Print.H>
+#include <AMReX_Loop.H>
+
+#include <cstdlib>
+#include <string>
+#include <cmath>
+#include <limits>
+#include <memory>
+
+
+int main(int argc, char* argv[]) {
+    amrex::Initialize(argc, argv);
+    {
+        amrex::Real strt_time = amrex::second();
+        bool test_passed = true;
+        std::string fail_reason;
+
+        // --- Configuration via ParmParse ---
+        int domain_size = 32;
+        int box_size = 16;
+        int verbose = 1;
+        int num_phases_fill = 1;
+        std::string direction_str = "X";
+        amrex::Real expected_tau = 1.0;
+        amrex::Real tau_tolerance = 1e-3;
+        std::string resultsdir = "./tTortuosityMLMG_results";
+
+        {
+            amrex::ParmParse pp;
+            pp.query("domain_size", domain_size);
+            pp.query("box_size", box_size);
+            pp.query("verbose", verbose);
+            pp.query("num_phases_fill", num_phases_fill);
+            pp.query("direction", direction_str);
+            pp.query("expected_tau", expected_tau);
+            pp.query("tau_tolerance", tau_tolerance);
+            pp.query("resultsdir", resultsdir);
+        }
+
+        OpenImpala::Direction direction = OpenImpala::parseDirection(direction_str);
+
+        if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "\n--- TortuosityMLMG Test ---\n";
+            amrex::Print() << "  Domain Size:       " << domain_size << "^3\n";
+            amrex::Print() << "  Direction:         " << direction_str << "\n";
+            amrex::Print() << "  Expected Tau:      " << expected_tau << "\n";
+            amrex::Print() << "  Tau Tolerance:     " << tau_tolerance << "\n";
+            amrex::Print() << "-------------------------------\n\n";
+        }
+
+        // --- Create synthetic domain ---
+        amrex::Box domain_box(amrex::IntVect(0, 0, 0),
+                              amrex::IntVect(domain_size - 1, domain_size - 1, domain_size - 1));
+        amrex::RealBox rb({AMREX_D_DECL(0.0, 0.0, 0.0)},
+                          {AMREX_D_DECL(amrex::Real(domain_size), amrex::Real(domain_size),
+                                        amrex::Real(domain_size))});
+        amrex::Array<int, AMREX_SPACEDIM> is_periodic{AMREX_D_DECL(0, 0, 0)};
+        amrex::Geometry geom;
+        geom.define(domain_box, &rb, 0, is_periodic.data());
+
+        amrex::BoxArray ba(domain_box);
+        ba.maxSize(box_size);
+        amrex::DistributionMapping dm(ba);
+
+        // --- Create and fill phase field ---
+        amrex::iMultiFab mf_phase(ba, dm, 1, 1);
+
+        if (num_phases_fill == 1) {
+            mf_phase.setVal(0);
+        } else {
+            // Alternating layers along X
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for (amrex::MFIter mfi(mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                const amrex::Box& bx = mfi.growntilebox();
+                amrex::Array4<int> const phase_arr = mf_phase.array(mfi);
+                int dir_idx = static_cast<int>(direction);
+                amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
+                    int coord = (dir_idx == 0) ? i : (dir_idx == 1) ? j : k;
+                    phase_arr(i, j, k, 0) = (coord % 2 == 0) ? 0 : 1;
+                });
+            }
+        }
+        mf_phase.FillBoundary(geom.periodicity());
+
+        amrex::Real vf = 1.0;
+
+        // --- Create results directory ---
+        if (!resultsdir.empty() && amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::UtilCreateDirectory(resultsdir, 0755);
+        }
+        amrex::ParallelDescriptor::Barrier();
+
+        // --- Construct and run TortuosityMLMG ---
+        std::unique_ptr<OpenImpala::TortuosityMLMG> tort;
+        try {
+            tort = std::make_unique<OpenImpala::TortuosityMLMG>(
+                geom, ba, dm, mf_phase, vf, 0 /* phase_id */, direction, resultsdir,
+                0.0 /* vlo */, 1.0 /* vhi */, verbose, false /* write_plotfile */);
+        } catch (const std::exception& e) {
+            test_passed = false;
+            fail_reason = "TortuosityMLMG construction failed: " + std::string(e.what());
+        }
+
+        // --- Calculate tortuosity ---
+        amrex::Real actual_tau = std::numeric_limits<amrex::Real>::quiet_NaN();
+        if (test_passed && tort) {
+            try {
+                actual_tau = tort->value();
+                if (std::isnan(actual_tau) || std::isinf(actual_tau)) {
+                    test_passed = false;
+                    fail_reason = "Tortuosity value is NaN or Inf";
+                }
+            } catch (const std::exception& e) {
+                test_passed = false;
+                fail_reason = "Exception during solve: " + std::string(e.what());
+            }
+        }
+
+        // --- Check solver convergence ---
+        if (test_passed && tort) {
+            if (!tort->getSolverConverged()) {
+                test_passed = false;
+                fail_reason = "MLMG solver did not converge (residual=" +
+                              std::to_string(tort->getFinalRelativeResidualNorm()) + ")";
+            } else if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Solver convergence:       PASS (" << tort->getSolverIterations()
+                               << " iterations, residual=" << tort->getFinalRelativeResidualNorm()
+                               << ")\n";
+            }
+        }
+
+        // --- Validate tortuosity against expected value ---
+        if (test_passed) {
+            amrex::Real diff = std::abs(actual_tau - expected_tau);
+            if (diff > tau_tolerance) {
+                test_passed = false;
+                fail_reason = "Tortuosity mismatch. Expected: " + std::to_string(expected_tau) +
+                              ", Got: " + std::to_string(actual_tau) +
+                              ", Diff: " + std::to_string(diff);
+            } else if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Tortuosity value check:   PASS (tau=" << actual_tau
+                               << ", expected=" << expected_tau << ", diff=" << diff << ")\n";
+            }
+        }
+
+        // --- Check active volume fraction ---
+        if (test_passed && tort) {
+            amrex::Real active_vf = tort->getActiveVolumeFraction();
+            if (active_vf < 0.99) {
+                test_passed = false;
+                fail_reason =
+                    "Active volume fraction unexpectedly low: " + std::to_string(active_vf);
+            } else if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Active VF check:          PASS (active_vf=" << active_vf
+                               << ")\n";
+            }
+        }
+
+        // --- Check plane flux conservation ---
+        if (test_passed && tort) {
+            const auto& plane_fluxes = tort->getPlaneFluxes();
+            amrex::Real max_dev = tort->getPlaneFluxMaxDeviation();
+            constexpr amrex::Real plane_flux_tol = 1.0e-6;
+
+            if (!plane_fluxes.empty() && max_dev > plane_flux_tol) {
+                test_passed = false;
+                fail_reason = "Plane flux conservation failed. Max deviation: " +
+                              std::to_string(max_dev);
+            } else if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
+                amrex::Print() << " Plane flux conservation:  PASS (" << plane_fluxes.size()
+                               << " faces, max_dev=" << std::scientific << max_dev
+                               << std::defaultfloat << ")\n";
+            }
+        }
+
+        // --- Final summary ---
+        amrex::Real stop_time = amrex::second() - strt_time;
+        amrex::ParallelDescriptor::ReduceRealMax(stop_time,
+                                                 amrex::ParallelDescriptor::IOProcessorNumber());
+
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            amrex::Print() << "\n Run time = " << stop_time << " sec\n";
+            if (test_passed) {
+                amrex::Print() << "\n--- TEST RESULT: PASS ---\n";
+            } else {
+                amrex::Print() << "\n--- TEST RESULT: FAIL ---\n";
+                amrex::Print() << "  Reason: " << fail_reason << "\n";
+            }
+        }
+
+        if (!test_passed) {
+            amrex::Abort("TortuosityMLMG Test FAILED.");
+        }
+    }
+    amrex::Finalize();
+    return 0;
+}


### PR DESCRIPTION
- Fix GPU wheel CI: use sameli/manylinux_2_34_x86_64_cuda_12.6 (the manylinux_2_28 variant with CUDA 12.6 does not exist on Docker Hub)
- Update dnf repo from 'powertools' to 'crb' for RHEL 9-based image
- Add tFloodFill integration test: validates parallelFloodFill and collectBoundarySeeds with 4 test cases (full flood, partial flood, boundary seeds, multi-label)
- Add tTortuosityMLMG integration test: validates MLMG matrix-free solver against analytical tau=(N-1)/N on uniform block, with directional symmetry test (Y direction)

https://claude.ai/code/session_01WR9HkUD95rp3XzZU95j2y7