### PR TITLE
Fix MLMG test expected tau and apply clang-format

### DIFF
--- a/tests/inputs/tTortuosityMLMG_dirY.inputs
+++ b/tests/inputs/tTortuosityMLMG_dirY.inputs
@@ -8,7 +8,7 @@ verbose = 2
 num_phases_fill = 1
 direction = Y
 
-expected_tau = 0.96875
+expected_tau = 1.0
 tau_tolerance = 0.001
 
 resultsdir = ./tTortuosityMLMG_dirY_results

--- a/tests/inputs/tTortuosityMLMG_uniform.inputs
+++ b/tests/inputs/tTortuosityMLMG_uniform.inputs
@@ -1,7 +1,9 @@
 # TortuosityMLMG Test: Uniform Dense Block
 #
 # Geometry:  32^3 domain, all voxels = single conducting phase (D=1.0)
-# Analytical: tau = (N-1)/N = 31/32 = 0.96875
+# Analytical: MLMG applies Dirichlet BCs at the domain face (external boundary),
+#             not at cell centers like HYPRE. For a uniform medium this gives
+#             tau = 1.0 exactly.
 # Validates: TortuosityMLMG solver + TortuositySolverBase infrastructure
 
 domain_size = 32
@@ -10,7 +12,7 @@ verbose = 2
 num_phases_fill = 1
 direction = X
 
-expected_tau = 0.96875
+expected_tau = 1.0
 tau_tolerance = 0.001
 
 resultsdir = ./tTortuosityMLMG_uniform_results

--- a/tests/tFloodFill.cpp
+++ b/tests/tFloodFill.cpp
@@ -157,7 +157,8 @@ int main(int argc, char* argv[]) {
             }
             amrex::ParallelAllReduce::Sum(reached, amrex::ParallelContext::CommunicatorSub());
 
-            long long expected_block_vol = static_cast<long long>(cube_size) * cube_size * cube_size;
+            long long expected_block_vol =
+                static_cast<long long>(cube_size) * cube_size * cube_size;
             if (reached != expected_block_vol) {
                 status.recordFail("Test 2 (partial flood): reached=" + std::to_string(reached) +
                                   ", expected=" + std::to_string(expected_block_vol));
@@ -205,9 +206,9 @@ int main(int argc, char* argv[]) {
             // Verify all outlet seeds have i=N-1
             for (const auto& s : outletSeeds) {
                 if (s[0] != N - 1) {
-                    status.recordFail("Test 3 (boundary seeds): outlet seed with i=" +
-                                      std::to_string(s[0]) + " (expected " + std::to_string(N - 1) +
-                                      ")");
+                    status.recordFail(
+                        "Test 3 (boundary seeds): outlet seed with i=" + std::to_string(s[0]) +
+                        " (expected " + std::to_string(N - 1) + ")");
                     break;
                 }
             }
@@ -263,8 +264,10 @@ int main(int argc, char* argv[]) {
                 const amrex::Box& bx = mfi.validbox();
                 const auto arr = mask.const_array(mfi);
                 amrex::LoopOnCpu(bx, [&](int i, int j, int k) {
-                    if (arr(i, j, k, 0) == 1) count_1++;
-                    if (arr(i, j, k, 0) == 2) count_2++;
+                    if (arr(i, j, k, 0) == 1)
+                        count_1++;
+                    if (arr(i, j, k, 0) == 2)
+                        count_2++;
                 });
             }
             amrex::ParallelAllReduce::Sum(count_1, amrex::ParallelContext::CommunicatorSub());

--- a/tests/tTortuosityMLMG.cpp
+++ b/tests/tTortuosityMLMG.cpp
@@ -116,8 +116,8 @@ int main(int argc, char* argv[]) {
         std::unique_ptr<OpenImpala::TortuosityMLMG> tort;
         try {
             tort = std::make_unique<OpenImpala::TortuosityMLMG>(
-                geom, ba, dm, mf_phase, vf, 0 /* phase_id */, direction, resultsdir,
-                0.0 /* vlo */, 1.0 /* vhi */, verbose, false /* write_plotfile */);
+                geom, ba, dm, mf_phase, vf, 0 /* phase_id */, direction, resultsdir, 0.0 /* vlo */,
+                1.0 /* vhi */, verbose, false /* write_plotfile */);
         } catch (const std::exception& e) {
             test_passed = false;
             fail_reason = "TortuosityMLMG construction failed: " + std::string(e.what());
@@ -186,8 +186,8 @@ int main(int argc, char* argv[]) {
 
             if (!plane_fluxes.empty() && max_dev > plane_flux_tol) {
                 test_passed = false;
-                fail_reason = "Plane flux conservation failed. Max deviation: " +
-                              std::to_string(max_dev);
+                fail_reason =
+                    "Plane flux conservation failed. Max deviation: " + std::to_string(max_dev);
             } else if (verbose >= 1 && amrex::ParallelDescriptor::IOProcessor()) {
                 amrex::Print() << " Plane flux conservation:  PASS (" << plane_fluxes.size()
                                << " faces, max_dev=" << std::scientific << max_dev


### PR DESCRIPTION
MLMG applies Dirichlet BCs at domain faces (external), not at cell centers like HYPRE, so tau=1.0 for a uniform block (not (N-1)/N).
