### PR TITLE
Fix CUDA build: compile all sources as CUDA when GPU backend is enabled

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
 find_package(pybind11 2.11 CONFIG REQUIRED)
 
 # --- Build the extension module ---
-pybind11_add_module(_core
+set(BINDING_SOURCES
     bindings/module.cpp
     bindings/enums.cpp
     bindings/io.cpp
@@ -29,6 +29,13 @@ pybind11_add_module(_core
     bindings/solvers.cpp
     bindings/config.cpp
 )
+pybind11_add_module(_core ${BINDING_SOURCES})
+
+# When CUDA is enabled, AMReX headers contain __host__/__device__ attributes
+# that require compilation by nvcc.
+if(GPU_BACKEND STREQUAL "CUDA")
+    set_source_files_properties(${BINDING_SOURCES} PROPERTIES LANGUAGE CUDA)
+endif()
 
 target_link_libraries(_core PRIVATE
     openimpala_io

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 # IO Library
 # ==============================================================================
 # Library sources (exclude test drivers that start with 't')
-add_library(openimpala_io OBJECT
+set(IO_SOURCES
     io/CathodeWrite.cpp
     io/DatReader.cpp
     io/HDF5Reader.cpp
@@ -15,6 +15,7 @@ add_library(openimpala_io OBJECT
     io/RawReader.cpp
     io/TiffReader.cpp
 )
+add_library(openimpala_io OBJECT ${IO_SOURCES})
 
 target_include_directories(openimpala_io PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/io
@@ -36,7 +37,7 @@ target_include_directories(openimpala_io PUBLIC
 # ==============================================================================
 # Props Library (C++ only — Fortran kernels migrated to native C++)
 # ==============================================================================
-add_library(openimpala_props OBJECT
+set(PROPS_SOURCES
     props/ConnectedComponents.cpp
     props/DeffTensor.cpp
     props/EffectiveDiffusivityHypre.cpp
@@ -53,6 +54,7 @@ add_library(openimpala_props OBJECT
     props/TortuositySolverBase.cpp
     props/VolumeFraction.cpp
 )
+add_library(openimpala_props OBJECT ${PROPS_SOURCES})
 
 target_include_directories(openimpala_props PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/props
@@ -100,6 +102,20 @@ target_include_directories(Diffusion PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/props
     ${HDF5_INCLUDE_DIRS}
 )
+
+# ==============================================================================
+# CUDA: compile all C++ sources as CUDA when GPU backend is enabled
+# ==============================================================================
+# AMReX headers use __host__/__device__ attributes (AMREX_GPU_HOST_DEVICE)
+# when built with CUDA. Any translation unit that includes AMReX headers must
+# therefore be compiled by nvcc. We achieve this by setting the LANGUAGE
+# property to CUDA on all .cpp source files.
+if(GPU_BACKEND STREQUAL "CUDA")
+    set_source_files_properties(
+        ${IO_SOURCES} ${PROPS_SOURCES} props/Diffusion.cpp
+        PROPERTIES LANGUAGE CUDA
+    )
+endif()
 
 # Install the main executable
 install(TARGETS Diffusion RUNTIME DESTINATION bin)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,10 @@ set(OPENIMPALA_TEST_INCLUDES
 # Helper: define a test executable and register it with CTest.
 # If an inputs file exists in tests/inputs/<name>.inputs, it is passed as an argument.
 function(openimpala_add_test TEST_NAME SOURCE_FILE)
+    # When CUDA is enabled, AMReX headers require nvcc compilation
+    if(GPU_BACKEND STREQUAL "CUDA")
+        set_source_files_properties(${SOURCE_FILE} PROPERTIES LANGUAGE CUDA)
+    endif()
     add_executable(${TEST_NAME} ${SOURCE_FILE})
     target_link_libraries(${TEST_NAME} PRIVATE ${OPENIMPALA_TEST_LIBS})
     target_include_directories(${TEST_NAME} PRIVATE ${OPENIMPALA_TEST_INCLUDES})


### PR DESCRIPTION
AMReX built with CUDA defines AMREX_GPU_HOST_DEVICE as __host__ __device__ in all its headers. Any .cpp file that includes AMReX headers must be compiled by nvcc, not the regular C++ compiler, or the CUDA keywords cause "does not name a type" errors.

Fix by setting LANGUAGE CUDA on all source files when GPU_BACKEND=CUDA:
- src/CMakeLists.txt: IO_SOURCES, PROPS_SOURCES, Diffusion.cpp
- python/CMakeLists.txt: BINDING_SOURCES
- tests/CMakeLists.txt: test source files via openimpala_add_test()

https://claude.ai/code/session_01WR9HkUD95rp3XzZU95j2y7