### PR TITLE
Fix CUDA atomicAdd: replace long long with int for GPU atomic counters

### DIFF
--- a/src/props/ConnectedComponents.cpp
+++ b/src/props/ConnectedComponents.cpp
@@ -108,8 +108,8 @@ void ConnectedComponents::run(const amrex::iMultiFab& mf_phase, int phase_id) {
     // Compute volume of each component using GPU-compatible atomic scatter-add
     m_volumes.resize(m_num_components, 0);
 
-    amrex::Gpu::DeviceVector<long long> d_volumes(m_num_components, 0);
-    long long* d_vol_ptr = d_volumes.data();
+    amrex::Gpu::DeviceVector<int> d_volumes(m_num_components, 0);
+    int* d_vol_ptr = d_volumes.data();
     const int num_comp = m_num_components;
 
     for (amrex::MFIter mfi(m_labels); mfi.isValid(); ++mfi) {
@@ -119,12 +119,12 @@ void ConnectedComponents::run(const amrex::iMultiFab& mf_phase, int phase_id) {
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int lbl = label_arr(i, j, k, 0);
             if (lbl > 0 && lbl <= num_comp) {
-                amrex::Gpu::Atomic::Add(&d_vol_ptr[lbl - 1], 1LL);
+                amrex::Gpu::Atomic::Add(&d_vol_ptr[lbl - 1], 1);
             }
         });
     }
 
-    std::vector<long long> local_volumes(m_num_components);
+    std::vector<int> local_volumes(m_num_components);
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_volumes.begin(), d_volumes.end(),
                      local_volumes.begin());
 
@@ -132,7 +132,7 @@ void ConnectedComponents::run(const amrex::iMultiFab& mf_phase, int phase_id) {
         amrex::ParallelAllReduce::Sum(local_volumes.data(), m_num_components,
                                       amrex::ParallelContext::CommunicatorSub());
     }
-    m_volumes = local_volumes;
+    m_volumes.assign(local_volumes.begin(), local_volumes.end());
 }
 
 } // namespace OpenImpala

--- a/src/props/ThroughThicknessProfile.cpp
+++ b/src/props/ThroughThicknessProfile.cpp
@@ -20,10 +20,10 @@ ThroughThicknessProfile::ThroughThicknessProfile(const amrex::Geometry& geom,
     const int n_slices = domain.length(idir);
 
     // GPU-compatible per-slice accumulation using device vectors with atomic scatter-add
-    amrex::Gpu::DeviceVector<long long> d_slice_phase(n_slices, 0);
-    amrex::Gpu::DeviceVector<long long> d_slice_total(n_slices, 0);
-    long long* d_phase_ptr = d_slice_phase.data();
-    long long* d_total_ptr = d_slice_total.data();
+    amrex::Gpu::DeviceVector<int> d_slice_phase(n_slices, 0);
+    amrex::Gpu::DeviceVector<int> d_slice_total(n_slices, 0);
+    int* d_phase_ptr = d_slice_phase.data();
+    int* d_total_ptr = d_slice_total.data();
 
     const int target_phase = phase_id;
     const int phase_comp = comp;
@@ -36,16 +36,16 @@ ThroughThicknessProfile::ThroughThicknessProfile(const amrex::Geometry& geom,
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int coord = (idir == 0) ? i : (idir == 1) ? j : k;
             int idx = coord - slice_lo;
-            amrex::Gpu::Atomic::Add(&d_total_ptr[idx], 1LL);
+            amrex::Gpu::Atomic::Add(&d_total_ptr[idx], 1);
             if (fab(i, j, k) == target_phase) {
-                amrex::Gpu::Atomic::Add(&d_phase_ptr[idx], 1LL);
+                amrex::Gpu::Atomic::Add(&d_phase_ptr[idx], 1);
             }
         });
     }
 
     // Copy device results to host
-    std::vector<long long> slice_phase(n_slices);
-    std::vector<long long> slice_total(n_slices);
+    std::vector<int> slice_phase(n_slices);
+    std::vector<int> slice_total(n_slices);
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_slice_phase.begin(), d_slice_phase.end(),
                      slice_phase.begin());
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_slice_total.begin(), d_slice_total.end(),


### PR DESCRIPTION
CUDA's atomicAdd supports int, unsigned int, unsigned long long, float, and double — but NOT signed long long. When compiling with nvcc, the Gpu::Atomic::Add(&long_long_ptr, 1LL) calls fail.

Switch DeviceVector counters from long long to int in:
- ConnectedComponents.cpp: component volume counting
- ThroughThicknessProfile.cpp: per-slice phase counting

int is sufficient for voxel counts (max ~2 billion cells per component). The host-side m_volumes (vector<long long>) is populated via .assign() which widens int→long long safely.

https://claude.ai/code/session_01WR9HkUD95rp3XzZU95j2y7