### PR TITLE
Fix CUDA: make methods with __device__ lambdas publicly accessible

### DIFF
--- a/src/props/ConnectedComponents.H
+++ b/src/props/ConnectedComponents.H
@@ -59,12 +59,13 @@ public:
         return m_labels;
     }
 
-private:
+    // --- Implementation methods (public for CUDA __device__ lambda compatibility) ---
     void run(const amrex::iMultiFab& mf_phase, int phase_id);
 
     amrex::IntVect findNextUnlabeled(const amrex::iMultiFab& labelMF,
                                      const amrex::iMultiFab& phaseFab, int phaseID) const;
 
+private:
     amrex::Geometry m_geom;
     amrex::BoxArray m_ba;
     amrex::DistributionMapping m_dm;

--- a/src/props/PercolationCheck.H
+++ b/src/props/PercolationCheck.H
@@ -56,9 +56,10 @@ public:
     /** @brief Returns a human-readable direction string ("X", "Y", or "Z"). */
     static std::string directionString(OpenImpala::Direction dir);
 
-private:
+    // --- Implementation methods (public for CUDA __device__ lambda compatibility) ---
     void run(const amrex::iMultiFab& mf_phase, int phase_id, OpenImpala::Direction dir);
 
+private:
     amrex::Geometry m_geom;
     amrex::BoxArray m_ba;
     amrex::DistributionMapping m_dm;

--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -152,8 +152,7 @@ public:
     }
 
 
-private:
-    // --- Private Methods ---
+    // --- Implementation methods (public for CUDA __device__ lambda compatibility) ---
     bool solve();
     void setupMatrixEquation();
     void preconditionPhaseFab();
@@ -164,6 +163,7 @@ private:
     void global_fluxes();
     void computePlaneFluxes(const amrex::MultiFab& mf_soln);
 
+private:
     // --- Member Variables ---
     // Configuration (solver config m_solvertype/m_eps/m_maxiter/m_verbose are in base class)
     std::string m_resultspath;

--- a/src/props/TortuositySolverBase.H
+++ b/src/props/TortuositySolverBase.H
@@ -112,7 +112,9 @@ public:
         return m_phase_coeff_map;
     }
 
-protected:
+    // --- Implementation methods (public for CUDA __device__ lambda compatibility) ---
+    // These methods contain GPU device lambdas and must be publicly accessible for nvcc.
+
     /** @brief Run the linear solver, populating m_mf_solution.
      *
      *  Subclasses must:
@@ -137,6 +139,7 @@ protected:
     void computePlaneFluxes(const amrex::MultiFab& mf_soln);
     void writeSolutionPlotfile(const std::string& label);
 
+protected:
     // --- Grid data (stored by value to avoid dangling references) ---
     amrex::Geometry m_geom;
     amrex::BoxArray m_ba;


### PR DESCRIPTION
CUDA's extended __device__ lambdas cannot appear inside private or protected member functions. The error:
  "The enclosing parent function for an extended __device__ lambda
   cannot have private or protected access within its class"

Move methods containing AMREX_GPU_DEVICE lambdas from private/protected to public in:
- ConnectedComponents.H: run(), findNextUnlabeled()
- PercolationCheck.H: run()
- TortuositySolverBase.H: buildDiffusionCoeffField(), generateActivityMask(), globalFluxes(), computePlaneFluxes(), solve(), preconditionPhaseFab(), parallelFloodFill(), writeSolutionPlotfile()
- TortuosityHypre.H: solve(), setupMatrixEquation(), preconditionPhaseFab(), generateActivityMask(), global_fluxes(), computePlaneFluxes()

Data members remain private/protected. This is the standard pattern for AMReX-based GPU codes.