### PR TITLE
Fix CUDA: make device-lambda methods public and fix setVal template deduction

### DIFF
--- a/src/props/EffectiveDiffusivityHypre.H
+++ b/src/props/EffectiveDiffusivityHypre.H
@@ -99,6 +99,9 @@ public:
     void getChiSolution(amrex::MultiFab& chi_field);
 
 
+    // --- Public for CUDA __device__ lambda compatibility ---
+    void initializeDiffCoeff();
+
     // --- Public Getters for Status and Solver Information ---
     // Solver statistics are inherited from HypreStructSolver:
     //   getSolverConverged(), getFinalRelativeResidualNorm(), getSolverIterations()
@@ -122,7 +125,6 @@ public:
 private:
     // --- Private Methods ---
     void setupMatrixEquation();
-    void initializeDiffCoeff();
     void generateActiveMask(); // Simpler version for D=0/1 based on phase_id
 
     // --- Member Variables ---

--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -713,8 +713,8 @@ void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field) {
                                                             soln_buffer.data());
         if (get_ierr != 0) {
             amrex::Warning("HYPRE_StructVectorGetBoxValues failed during getChiSolution!");
-            chi_field[mfi].setVal(0.0, bx_getsol, amrex::DestComp{ChiComp},
-                                   amrex::NumComps{numComponentsChi});
+            chi_field[mfi].template setVal<amrex::RunOn::Host>(0.0, bx_getsol, ChiComp,
+                                                                numComponentsChi);
             continue;
         }
 


### PR DESCRIPTION

NVCC also requires that enclosing functions for __device__ lambdas have public access within their class. Move initializeDiffCoeff and buildTraversableMask to public sections. For setVal, explicitly specify the RunOn::Host template parameter to resolve deduction failure.

