### PR TITLE
Fix CUDA: replace deleted DeviceScalar move-assignment with htod_memcpy

### DIFF
--- a/src/props/FloodFill.cpp
+++ b/src/props/FloodFill.cpp
@@ -177,7 +177,10 @@ void parallelFloodFill(amrex::iMultiFab& reachabilityMask, const amrex::iMultiFa
 
         // Reset device flag
 #ifdef AMREX_USE_GPU
-        d_changed = amrex::Gpu::DeviceScalar<int>(0);
+        {
+            int zero = 0;
+            amrex::Gpu::htod_memcpy(d_changed.dataPtr(), &zero, sizeof(int));
+        }
         d_flag_ptr = d_changed.dataPtr();
 #else
         h_changed = 0;


### PR DESCRIPTION
amrex::Gpu::DeviceScalar has a deleted move-assignment operator. Use htod_memcpy to reset the device flag to zero instead of constructing a new DeviceScalar each iteration.
