### PR TITLE
Fix CUDA: extract device lambda from ThroughThicknessProfile constructor

### DIFF
--- a/src/props/ThroughThicknessProfile.H
+++ b/src/props/ThroughThicknessProfile.H
@@ -54,6 +54,10 @@ public:
         return static_cast<int>(m_vf_profile.size());
     }
 
+    /** @brief Compute the profile (public for CUDA __device__ lambda compatibility). */
+    void compute(const amrex::Geometry& geom, const amrex::iMultiFab& mf_phase, int phase_id,
+                 OpenImpala::Direction dir, int comp);
+
 private:
     std::vector<amrex::Real> m_vf_profile;
 };

--- a/src/props/ThroughThicknessProfile.cpp
+++ b/src/props/ThroughThicknessProfile.cpp
@@ -12,6 +12,12 @@ namespace OpenImpala {
 ThroughThicknessProfile::ThroughThicknessProfile(const amrex::Geometry& geom,
                                                  const amrex::iMultiFab& mf_phase, int phase_id,
                                                  OpenImpala::Direction dir, int comp) {
+    compute(geom, mf_phase, phase_id, dir, comp);
+}
+
+void ThroughThicknessProfile::compute(const amrex::Geometry& geom,
+                                      const amrex::iMultiFab& mf_phase, int phase_id,
+                                      OpenImpala::Direction dir, int comp) {
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(comp >= 0 && comp < mf_phase.nComp(),
                                      "ThroughThicknessProfile: Component index out of bounds.");
 


### PR DESCRIPTION
NVCC forbids extended __device__ lambdas in constructors. Move the ParallelFor kernel into a public compute() method called from the constructor.
