### PR TITLE
Fix CPU wheel build: use manylinux_2_28 image and powertools repo

### DIFF
--- a/.github/workflows/pypi-wheels-cpu.yml
+++ b/.github/workflows/pypi-wheels-cpu.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_cpu_wheels:
-    name: Build CPU wheels (compiled C++ backend)
+  build_wheels:
+    name: Build manylinux wheels on ubuntu-latest
     runs-on: ubuntu-latest
 
     steps:
@@ -37,39 +37,32 @@ jobs:
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.16.5
 
-      # Cache the compiled CPU dependencies (HDF5, libtiff, HYPRE, AMReX)
-      - name: Cache native CPU dependencies
+      - name: Cache native dependencies
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-cpu-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-v1
+          key: cibw-deps-manylinux_2_28-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-v3
 
-      - name: Build CPU wheels
+      - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*musllinux* *i686*"
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_MANYLINUX_X86_64_IMAGE: "manylinux_2_34"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 
-          # Build all dependencies (CPU-only, no CUDA).
           CIBW_BEFORE_ALL_LINUX: >
             dnf install -y epel-release &&
-            dnf --enablerepo=crb install -y
+            dnf --enablerepo=powertools install -y
             openmpi-devel gcc-gfortran gcc-c++ wget git
-            zlib-devel libjpeg-turbo-devel python3-pip
-            gcc-toolset-13 gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
-            gcc-toolset-13-gcc-gfortran &&
+            zlib-devel libjpeg-turbo-devel python3-pip &&
             pip3 install "cmake>=3.28,<4" &&
-            export PATH=/opt/rh/gcc-toolset-13/root/usr/bin:/usr/lib64/openmpi/bin:$PATH &&
-            export CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc &&
-            export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++ &&
-            export FC=/opt/rh/gcc-toolset-13/root/usr/bin/gfortran &&
+            export PATH=/usr/lib64/openmpi/bin:$PATH &&
             if [ -f /project/.cibw-deps-cache/deps.tar.gz ]; then
-            echo "=== Restoring cached CPU dependencies ===" &&
+            echo "=== Restoring cached dependencies ===" &&
             tar xzf /project/.cibw-deps-cache/deps.tar.gz -C / ;
             else
-            echo "=== Building CPU dependencies from source ===" &&
+            echo "=== Building dependencies from source ===" &&
             wget -q https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.14.6/hdf5-1.14.6.tar.gz &&
             tar xzf hdf5-1.14.6.tar.gz &&
             cd hdf5-1.14.6 &&
@@ -113,7 +106,6 @@ jobs:
             -DAMReX_SPACEDIM=3
             -DAMReX_FORTRAN=ON
             -DAMReX_PARTICLES=OFF
-            -DAMReX_GPU_BACKEND=NONE
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
             cmake --install /tmp/amrex/build &&
@@ -121,22 +113,16 @@ jobs:
             tar czf /project/.cibw-deps-cache/deps.tar.gz /usr/local ;
             fi
 
-          CIBW_BEFORE_BUILD: >
-            pip install "cmake>=3.28,<4"
+          CIBW_BEFORE_BUILD: pip install "cmake>=3.28,<4"
 
           CIBW_ENVIRONMENT_LINUX: >
-            PATH="/opt/rh/gcc-toolset-13/root/usr/bin:/usr/lib64/openmpi/bin:$PATH"
-            CC="/opt/rh/gcc-toolset-13/root/usr/bin/gcc"
-            CXX="/opt/rh/gcc-toolset-13/root/usr/bin/g++"
-            FC="/opt/rh/gcc-toolset-13/root/usr/bin/gfortran"
+            PATH="/usr/lib64/openmpi/bin:$PATH"
             CMAKE_C_COMPILER="mpicc"
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_PREFIX_PATH="/usr/local"
             CMAKE_GENERATOR="Unix Makefiles"
-            CMAKE_ARGS="-DGPU_BACKEND=NONE"
             SETUPTOOLS_SCM_PRETEND_VERSION="${{ steps.version.outputs.version }}"
 
-          # Vendor libraries but exclude host-specific MPI, OpenMP, and Fortran runtime.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
             auditwheel repair -w {dest_dir} {wheel}
             --exclude libmpi.so
@@ -158,22 +144,22 @@ jobs:
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-cpu
+          name: cibw-wheels
           path: ./wheelhouse/*.whl
 
   publish_to_pypi:
-    name: Publish CPU wheels to PyPI
-    needs: build_cpu_wheels
+    name: Publish wheels to PyPI
+    needs: build_wheels
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write
 
     steps:
-      - name: Download artifacts
+      - name: Download wheel artifacts
         uses: actions/download-artifact@v4
         with:
-          name: cibw-wheels-cpu
+          name: cibw-wheels
           path: dist/
 
       - name: Publish to PyPI


### PR DESCRIPTION
The previous workflow used manylinux_2_34 which is not a valid cibuildwheel image tag, and used AlmaLinux 9 repo names (crb, gcc-toolset-13). Restored to the proven manylinux_2_28 base with powertools repo and default system compiler, matching the working build from v4.0.6.

https://claude.ai/code/session_01BXGy2knFzA2bgVnuNRNVVQ