### PR TITLE
fix GPU wheel: patch AMReX C++ sources for CUDA 12 NVTX header

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3-v4
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3-v5
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -118,6 +118,7 @@ jobs:
             cd ../.. &&
             git clone --depth 1 --branch 25.03 https://github.com/AMReX-Codes/amrex.git /tmp/amrex &&
             sed -i 's|CUDA::nvToolsExt|CUDA::nvtx3|g' /tmp/amrex/Tools/CMake/AMReXParallelBackends.cmake &&
+            grep -rl 'include.*<nvToolsExt\.h>' /tmp/amrex/Src | xargs -r sed -i 's|<nvToolsExt\.h>|<nvtx3/nvToolsExt.h>|g' &&
             cmake -S /tmp/amrex -B /tmp/amrex/build
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Previous fix rewrote CUDA::nvToolsExt -> CUDA::nvtx3 in the AMReX CMake target, but AMReX 25.03 also has a bare

    #  include <nvToolsExt.h>

in Src/Base/AMReX_GpuDevice.cpp (and a few other places). CUDA 12 ships the header-only NVTX3 replacement at <nvtx3/nvToolsExt.h> instead, so the bare include fails with

    fatal error: nvToolsExt.h: No such file or directory

Add a second sed pass over /tmp/amrex/Src that rewrites every

    #include <nvToolsExt.h>

to

    #include <nvtx3/nvToolsExt.h>

regardless of whitespace between `#` and `include`. The anchor `<` in the pattern prevents double-prefixing files that already use the nvtx3/ path. Bumped the cache key to v5 to force a clean AMReX rebuild.

Verified locally: mixed whitespace forms get rewritten, files already using <nvtx3/nvToolsExt.h> are untouched.
