### PR TITLE
fix GPU wheel: install upstream NVTX3 headers for CUDA 12 compat

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3-v5
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-v6
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -116,9 +116,13 @@ jobs:
             make -j$(nproc) &&
             make install &&
             cd ../.. &&
+            wget -q https://github.com/NVIDIA/NVTX/archive/refs/tags/v3.1.1.tar.gz -O nvtx.tar.gz &&
+            tar xzf nvtx.tar.gz &&
+            mkdir -p /usr/local/cuda/include/nvtx3 /usr/local/include/nvtx3 &&
+            cp -rf NVTX-3.1.1/c/include/nvtx3/. /usr/local/cuda/include/nvtx3/ &&
+            cp -rf NVTX-3.1.1/c/include/nvtx3/. /usr/local/include/nvtx3/ &&
             git clone --depth 1 --branch 25.03 https://github.com/AMReX-Codes/amrex.git /tmp/amrex &&
             sed -i 's|CUDA::nvToolsExt|CUDA::nvtx3|g' /tmp/amrex/Tools/CMake/AMReXParallelBackends.cmake &&
-            grep -rl 'include.*<nvToolsExt\.h>' /tmp/amrex/Src | xargs -r sed -i 's|<nvToolsExt\.h>|<nvtx3/nvToolsExt.h>|g' &&
             cmake -S /tmp/amrex -B /tmp/amrex/build
             -DCMAKE_INSTALL_PREFIX=/usr/local
             -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Previous fix forced AMReX to include <nvtx3/nvToolsExt.h>, and that header was findable in the sameli/manylinux_2_34_x86_64_cuda_12.6 image (build got past the "file not found" stage), but the shipped version must be stripped or minimal — it didn't expose the legacy C API macros:

    /tmp/amrex/Src/Base/AMReX_GpuDevice.cpp(159):
      error: identifier "nvtxRangePush" is undefined
    /tmp/amrex/Src/Base/AMReX_GpuDevice.cpp(366):
      error: identifier "nvtxRangePop" is undefined

AMReX 25.03 calls these under the TINY_PROFILE path (lines 158-160, 366-368 in 25.03), guarded by
`AMREX_USE_CUDA && (AMREX_PROFILING || AMREX_TINY_PROFILING)`, and relies on the NVTX3 header's own macro indirection (`#define nvtxRangePush nvtxRangePushA`) to resolve the symbol. That macro is at line 1599 of the upstream NVTX3 v3.1.1 header, but missing from whatever the sameli image ships.

Drop the known-good NVTX3 v3.1.1 header-only release into both /usr/local/cuda/include/nvtx3/ (the winning search path for nvcc) and /usr/local/include/nvtx3/ (fallback for host-only compiles), using `cp -rf src/. dst/` so the overwrite doesn't nest as dst/src/. With real headers in place, AMReX's existing `__has_include` fallback resolves to the correct path on its own, so drop the now-redundant C++ source sed pass.

Bumped cache key to -v6 and embedded nvtx3.1.1 in the key so the next bump obvious.

