### PR TITLE
shrink GPU wheel under PyPI 320 MiB limit

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-v6
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-arch70-90-v7
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -134,9 +134,9 @@ jobs:
             -DAMReX_PARTICLES=OFF
             -DAMReX_TINY_PROFILE=ON
             -DAMReX_GPU_BACKEND=CUDA
-            '-DAMReX_CUDA_ARCH=60;70;75;80;86;89;90'
+            '-DAMReX_CUDA_ARCH=70;75;80;89;90'
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            '-DCMAKE_CUDA_ARCHITECTURES=60;70;75;80;86;89;90'
+            '-DCMAKE_CUDA_ARCHITECTURES=70-real;75-real;80-real;89-real;90-real;90-virtual'
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++ &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
             cmake --install /tmp/amrex/build &&
@@ -167,13 +167,13 @@ jobs:
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_PREFIX_PATH="/usr/local"
             CMAKE_GENERATOR="Unix Makefiles"
-            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=60;70;75;80;86;89;90' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=70-real;75-real;80-real;89-real;90-real;90-virtual' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
             SETUPTOOLS_SCM_PRETEND_VERSION="${{ steps.version.outputs.version }}"
 
           # Vendor libraries but exclude host-specific MPI, OpenMP, Fortran runtime,
           # and CUDA runtime libraries (users must have CUDA toolkit installed).
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel repair -w {dest_dir} {wheel}
+            auditwheel repair --strip -w {dest_dir} {wheel}
             --exclude libmpi.so
             --exclude libmpi.so.12
             --exclude libmpi.so.40


### PR DESCRIPTION
Previous build succeeded and produced a valid wheel but PyPI rejected the upload with HTTP 400 "File too large. Limit for project 'openimpala-cuda' is 320 MB." Two levers bring it under the cap:

1) Trim CUDA architectures from 7 to 5, keep SASS-only
   Before: 60;70;75;80;86;89;90 (each arch compiles SASS + PTX ≈ 7×2
   fat-binary slices per kernel).
   After:  70-real;75-real;80-real;89-real;90-real;90-virtual (5 SASS
   slices + one PTX for forward-compat / JIT on any new arch).

   Drops Pascal P100 (60 — obsolete, 2016) and Ampere consumer RTX 30
   (86 — JITs fine from 80 PTX via 90-virtual). Keeps the actually-used
   cloud/HPC GPUs: V100 (70), T4 (75), A100 (80), L4 (89), H100 (90).
   The -real suffix suppresses PTX emission per arch, and the single
   90-virtual entry gives future-arch JIT without embedding 6 redundant
   PTX slices.

2) auditwheel repair --strip
   Strips ELF debug symbols from every bundled .so in the wheel. No
   effect on runtime behaviour; typical 20-40% size reduction on C++
   scientific libraries.

Cache key bumped to reflect the arch change so the next build can't restore the oversized deps.tar.gz.
