### PR TITLE
strip _core.so explicitly to fight 3 GB GPU wheel bloat

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-arch70-90-v7
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-arch75-80-stripped-v8
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -134,12 +134,13 @@ jobs:
             -DAMReX_PARTICLES=OFF
             -DAMReX_TINY_PROFILE=ON
             -DAMReX_GPU_BACKEND=CUDA
-            '-DAMReX_CUDA_ARCH=70;75;80;89;90'
+            '-DAMReX_CUDA_ARCH=75;80'
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            '-DCMAKE_CUDA_ARCHITECTURES=70-real;75-real;80-real;89-real;90-real;90-virtual'
+            '-DCMAKE_CUDA_ARCHITECTURES=75-real;80-real;90-virtual'
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++ &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
             cmake --install /tmp/amrex/build &&
+            strip --strip-debug /usr/local/lib/libamrex_3d.a /usr/local/lib/libHYPRE.a /usr/local/lib/libhdf5*.a /usr/local/lib/libtiff.a 2>/dev/null || true &&
             mkdir -p /project/.cibw-deps-cache &&
             tar czf /project/.cibw-deps-cache/deps.tar.gz /usr/local ;
             fi
@@ -167,13 +168,18 @@ jobs:
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_PREFIX_PATH="/usr/local"
             CMAKE_GENERATOR="Unix Makefiles"
-            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=70-real;75-real;80-real;89-real;90-real;90-virtual' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=75-real;80-real;90-virtual' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
             SETUPTOOLS_SCM_PRETEND_VERSION="${{ steps.version.outputs.version }}"
 
           # Vendor libraries but exclude host-specific MPI, OpenMP, Fortran runtime,
           # and CUDA runtime libraries (users must have CUDA toolkit installed).
+          # auditwheel --strip only touches vendored libs, NOT the main extension
+          # _core.so where most of the bloat lives. After auditwheel, unpack the
+          # wheel, run strip --strip-all on every .so (including _core.so), then
+          # repack via `wheel pack` so RECORD hashes regenerate.
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >
-            auditwheel repair --strip -w {dest_dir} {wheel}
+            mkdir -p /tmp/repaired &&
+            auditwheel repair --strip -w /tmp/repaired {wheel}
             --exclude libmpi.so
             --exclude libmpi.so.12
             --exclude libmpi.so.40
@@ -202,7 +208,16 @@ jobs:
             --exclude libcurand.so
             --exclude libcurand.so.10
             --exclude libnvJitLink.so
-            --exclude libnvJitLink.so.12
+            --exclude libnvJitLink.so.12 &&
+            for whl in /tmp/repaired/*.whl; do
+              echo "Pre-strip wheel size:" && ls -lh "$whl" &&
+              d=$(mktemp -d) &&
+              python3 -m wheel unpack --dest "$d" "$whl" &&
+              find "$d" -type f \( -name '*.so' -o -name '*.so.*' \) -print -exec strip --strip-all {} + &&
+              python3 -m wheel pack --dest-dir {dest_dir} "$d"/*/ &&
+              echo "Post-strip wheel size:" && ls -lh {dest_dir}/*.whl &&
+              rm -rf "$d" "$whl";
+            done
 
       - name: Upload wheels as artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
CPU wheel: 30 MB. GPU wheel: 3 GB. The 100x ratio doesn't match anything even remotely reasonable (pytorch-cuda is 750 MB max). Diagnosis:

1. auditwheel --strip only touches the *vendored* .so files in the wheel's .libs/ folder. It does NOT strip the main extension module (_core.so), which is where ~99% of the bloat lives — every templated AMReX device-kernel instantiation, with debug symbols, profile name strings, and architecture fat-binary slices, all linked together by RDC + CUDA_RESOLVE_DEVICE_SYMBOLS across 27 translation units.

2. CUDA architectures: dropped from 5 SASS + 1 PTX (70/75/80/89/90) to 2 SASS + 1 PTX (75/80 + 90-virtual). T4 + A100 ship as native SASS (the actual GPUs Colab/HPC use day-to-day), V100/L4/H100/RTX JIT-compile from PTX on first kernel launch (~2-5s startup, then cached). This is the same model pytorch-cuda uses.

3. Strip the static deps before linking: strip --strip-debug on libamrex_3d.a, libHYPRE.a, libhdf5*.a, libtiff.a kills any debug symbols that snuck through Release before the device linker has a chance to embed them in _core.so.

4. New post-auditwheel pass: for whl in /tmp/repaired/*.whl; do wheel unpack find ... -name '*.so*' -exec strip --strip-all {} + wheel pack  # regenerates RECORD hashes done echoes pre/post wheel size to the build log for sanity.

Cache key bumped to v8 with arch+stripped tags so the next build can't restore the 2.4 GB deps tarball.

If this is still too big, next levers (in order of impact-to-risk):
  - Drop AMReX_TINY_PROFILE=ON (wheel-only; native build keeps it)
  - Set AMReX_GPU_RDC=OFF (risk: breaks AMReX features that need RDC)
  - Drop arch 80, ship 75-real + 90-virtual only
