### PR TITLE
fix AMReXConfig.cmake unquoted variable expansion (real root cause)

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cibw-deps-cache
-          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-arch75-80-archfix-v9
+          key: cibw-deps-gpu-cuda12.6-manylinux_2_34-x86_64-hdf5_1.14.6-tiff_4.6.0-hypre_2.31.0-amrex_25.03-gcc13-nvtx3.1.1-arch75-80-quotefix-v10
 
       - name: Build GPU wheels
         run: python -m cibuildwheel --output-dir wheelhouse
@@ -141,11 +141,14 @@ jobs:
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++ &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
             cmake --install /tmp/amrex/build &&
-            sed -i 's|set(AMREX_CUDA_ARCHS  CACHE INTERNAL|set(AMREX_CUDA_ARCHS "75;80" CACHE INTERNAL|' /usr/local/lib/cmake/AMReX/AMReXConfig.cmake &&
             strip --strip-debug /usr/local/lib/libamrex_3d.a /usr/local/lib/libHYPRE.a /usr/local/lib/libhdf5*.a /usr/local/lib/libtiff.a 2>/dev/null || true &&
             mkdir -p /project/.cibw-deps-cache &&
             tar czf /project/.cibw-deps-cache/deps.tar.gz /usr/local ;
-            fi
+            fi &&
+            echo "=== Patching installed AMReXConfig.cmake (runs on cache hit AND miss) ===" &&
+            sed -i 's|set(AMREX_CUDA_ARCHS  CACHE INTERNAL|set(AMREX_CUDA_ARCHS "75;80" CACHE INTERNAL|' /usr/local/lib/cmake/AMReX/AMReXConfig.cmake &&
+            sed -i 's|CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS})|CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}")|' /usr/local/lib/cmake/AMReX/AMReXConfig.cmake &&
+            grep -n 'AMREX_CUDA_ARCHS' /usr/local/lib/cmake/AMReX/AMReXConfig.cmake
 
           # Rename the package to openimpala-cuda and uncomment the nvidia-*-cu12
           # runtime deps (kept commented in pyproject.toml so they don't pollute


### PR DESCRIPTION
Previous "fix" only addressed half the problem. The actual bug is at AMReXConfig.cmake.in:277:

    CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS})

Note the *unquoted* ${...}. With AMREX_CUDA_ARCHS="75;80" (a CMake list of two elements), this expands as TWO arguments — set_target_properties parses them as `CUDA_ARCHITECTURES=75, then property "80" with no value`, which trips:

    CMake Error at AMReXConfig.cmake:289 (set_target_properties):
      set_target_properties called with incorrect number of arguments.

AMReX itself uses the QUOTED form internally
(AMReXParallelBackends.cmake:103) but the export template forgot the quotes — upstream bug. Confirmed locally:

    set_target_properties(... CUDA_ARCHITECTURES ${AMREX_CUDA_ARCHS})  → ERROR
    set_target_properties(... CUDA_ARCHITECTURES "${AMREX_CUDA_ARCHS}") → OK

Two structural changes:

1. Add a sed that wraps ${AMREX_CUDA_ARCHS} in quotes in the installed config. Belt for new builds, braces for cached.

2. Move BOTH AMReXConfig patches outside the if/else cache branch. actions/cache@v4 saves on cache-miss regardless of job outcome, so the previous failed v9 run could have cached a deps.tar.gz with a half-fixed config; an else-branch-only patch would skip it on restore. Now both seds run unconditionally — `if AMReX cache hit: patch the restored file; else: patch the freshly-installed file`.

Also added a `grep -n 'AMREX_CUDA_ARCHS' ...` after the patches so the build log shows exactly what the lines look like before configure runs.

Cache key bumped to v10 with -quotefix tag to force a fresh build at least once with the new sed chain.
