### PR TITLE
fix build_info() reporting tiny_profile=False on TINY_PROFILE-on builds

### DIFF
--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -106,7 +106,7 @@ static py::dict build_info() {
     info["mpi_enabled"] = false;
 #endif
 
-#ifdef AMREX_TINY_PROFILE
+#ifdef AMREX_TINY_PROFILING
     info["tiny_profile"] = true;
 #else
     info["tiny_profile"] = false;


### PR DESCRIPTION
oi.build_info() was reporting "TinyProfile: False" on the openimpala-cuda 4.2.9 wheel, even though the AMReX dep was built with -DAMReX_TINY_PROFILE=ON. The reason: AMReX's CMake option name and the compile-definition it emits are different.

  AMReXSetDefines.cmake:37
    add_amrex_define( AMREX_TINY_PROFILING NO_LEGACY IF AMReX_TINY_PROFILE )

So with the option ON, the macro AMReX puts on the AMReX::amrex target's INTERFACE_COMPILE_DEFINITIONS is `AMREX_TINY_PROFILING`, not `AMREX_TINY_PROFILE`. My #ifdef in module.cpp::build_info() was checking the option name and so always evaluated false.

One-line fix: AMREX_TINY_PROFILE -> AMREX_TINY_PROFILING. The actual runtime profiling instrumentation in AMReX (BL_PROFILE macros) and our build settings are unchanged — this only affects what build_info() reports.
