### PR TITLE
move EffDiff setupMatrixEquation/generateActiveMask to public section

### DIFF
--- a/src/props/EffectiveDiffusivityHypre.H
+++ b/src/props/EffectiveDiffusivityHypre.H
@@ -121,12 +121,16 @@ public:
         return HypreStructSolver::hiV(b);
     }
 
-
-private:
-    // --- Private Methods ---
+    // Implementation methods. They are nominally internal but must live in
+    // the public section because nvcc forbids extended __device__ lambdas in
+    // private/protected member functions (see CUDA Programming Guide §I.4.1).
+    // Compare TortuosityHypre.H, which exposes the same methods publicly for
+    // the same reason.
     void setupMatrixEquation();
     void generateActiveMask(); // Simpler version for D=0/1 based on phase_id
 
+
+private:
     // --- Member Variables ---
     // Configuration (solver config m_solvertype/m_eps/m_maxiter/m_verbose are in base class)
     std::string m_resultspath;


### PR DESCRIPTION
CUDA build of openimpala-cuda failed in 6ea391c with three nvcc errors:

    error: The enclosing parent function ("generateActiveMask") for an
    extended __device__ lambda cannot have private or protected access
    within its class

The pre-existing LoopOnCpu calls compiled fine because they don't use extended __device__ lambdas. My new ParallelFor / ReduceOps::eval calls do, and the CUDA Programming Guide §I.4.1 forbids that inside private or protected member functions: nvcc cannot emit the necessary internal linkage for the lambda's hidden context capture.

TortuosityHypre.H already exposes setupMatrixEquation, initializeDiffCoeff, buildTraversableMask, preconditionPhaseFab as public for exactly this reason (line 159+). Match that pattern for the EffDiff equivalents: move setupMatrixEquation and generateActiveMask out of `private:` and into the public section, with a comment explaining the constraint.

These methods aren't part of any user-facing API — the EffectiveDiffusivityHypre class is consumed via solve() / value() / getChiSolution() — so widening their visibility has no semantic impact, only relaxes the visibility on internal helpers that user code shouldn't be calling anyway.
