### PR TITLE
GPU sweep: fix all remaining host-from/to-device-memory sites

### DIFF
--- a/src/io/DatReader.cpp
+++ b/src/io/DatReader.cpp
@@ -15,6 +15,8 @@
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_iMultiFab.H>
+#include <AMReX_Gpu.H>           // For amrex::Gpu::streamSynchronize, The_Pinned_Arena
+#include <AMReX_MultiFabUtil.H>  // For amrex::Copy on iMultiFab
 #include <AMReX_GpuContainers.H> // For amrex::LoopOnCpu
 
 
@@ -223,12 +225,24 @@ void DatReader::threshold(DataType raw_threshold, int value_if_true, int value_i
     const int current_height = m_height;
     const int current_depth = m_depth;
 
+    // The destination iMultiFab `mf` is on device on CUDA builds. The
+    // LoopOnCpu fab(...) = ... writes below would segfault writing to
+    // device memory from CPU code. Build a host-mirror iMultiFab on the
+    // pinned arena, fill it, then Copy device at the end.
+#ifdef AMREX_USE_GPU
+    amrex::iMultiFab mf_host(mf.boxArray(), mf.DistributionMap(), mf.nComp(), mf.nGrow(),
+                             amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
+    amrex::iMultiFab& target = mf_host;
+#else
+    amrex::iMultiFab& target = mf;
+#endif
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(target); mfi.isValid(); ++mfi) {
         const amrex::Box& box = mfi.validbox();
-        amrex::IArrayBox& fab = mf[mfi];
+        amrex::IArrayBox& fab = target[mfi];
         amrex::LoopOnCpu(box, [&](int i, int j, int k) {
             if (i >= 0 && i < current_width && j >= 0 && j < current_height && k >= 0 &&
                 k < current_depth) {
@@ -246,6 +260,10 @@ void DatReader::threshold(DataType raw_threshold, int value_if_true, int value_i
             }
         });
     }
+#ifdef AMREX_USE_GPU
+    amrex::Copy(mf, mf_host, 0, 0, mf.nComp(), mf.nGrow());
+    amrex::Gpu::streamSynchronize();
+#endif
 }
 
 // Original overload (output 1/0) - calls the flexible version

--- a/src/io/RawReader.cpp
+++ b/src/io/RawReader.cpp
@@ -15,6 +15,8 @@
 #include <AMReX_IntVect.H> // Needed for the fix
 #include <AMReX_iMultiFab.H>
 #include <AMReX_GpuContainers.H>      // For amrex::LoopOnCpu
+#include <AMReX_Gpu.H>                // For amrex::Gpu::streamSynchronize, The_Pinned_Arena
+#include <AMReX_MultiFabUtil.H>       // For amrex::Copy on iMultiFab
 #include <AMReX_Extension.H>          // For AMREX_ALWAYS_ASSERT_WITH_MESSAGE
 #include <AMReX_GpuQualifiers.H>      // For AMREX_FORCE_INLINE
 #include <AMReX_ParallelDescriptor.H> // For IOProcessor
@@ -476,13 +478,25 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
     }
     const bool needs_swap = (bytes_per_voxel > 1) && (data_is_le != host_is_little_endian);
 
+    // The destination iMultiFab `mf` is on device on CUDA builds. The
+    // LoopOnCpu fab(...) = ... writes below would segfault writing to
+    // device memory from CPU code. Build a host-mirror iMultiFab on the
+    // pinned arena, fill it, then Copy device at the end.
+#ifdef AMREX_USE_GPU
+    amrex::iMultiFab mf_host(mf.boxArray(), mf.DistributionMap(), mf.nComp(), mf.nGrow(),
+                             amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
+    amrex::iMultiFab& target = mf_host;
+#else
+    amrex::iMultiFab& target = mf;
+#endif
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     // Iterate over the iMultiFab using MFIter
-    for (amrex::MFIter mfi(mf); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(target); mfi.isValid(); ++mfi) {
         const amrex::Box& box = mfi.validbox(); // Get the valid box for this FAB
-        amrex::IArrayBox& fab = mf[mfi];        // Get the FArrayBox data (non-const ref)
+        amrex::IArrayBox& fab = target[mfi];    // Get the FArrayBox data (non-const ref)
 
         // Loop over the cells in the box using amrex::LoopOnCpu (since m_raw_bytes is host memory)
         amrex::LoopOnCpu(box, [&](int i, int j, int k) {
@@ -589,6 +603,10 @@ void RawReader::threshold(double threshold_value, int value_if_true, int value_i
             }
         }); // End of amrex::LoopOnCpu lambda
     } // End of MFIter loop
+#ifdef AMREX_USE_GPU
+    amrex::Copy(mf, mf_host, 0, 0, mf.nComp(), mf.nGrow());
+    amrex::Gpu::streamSynchronize();
+#endif
 } // End of threshold function
 
 

--- a/src/io/TiffReader.cpp
+++ b/src/io/TiffReader.cpp
@@ -27,7 +27,8 @@
 #include <AMReX_Box.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_iMultiFab.H>
-// #include <AMReX_GpuContainers.H> // Optional
+#include <AMReX_Gpu.H>          // For amrex::Gpu::streamSynchronize, The_Pinned_Arena
+#include <AMReX_MultiFabUtil.H> // For amrex::Copy on iMultiFab
 #include <AMReX_Extension.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_Utility.H>
@@ -458,6 +459,19 @@ void TiffReader::readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_
     const int image_depth_const = m_depth;
     const uint16_t fill_order_local = m_fill_order;
 
+    // The destination iMultiFab `dest_mf` is on device on CUDA builds. The
+    // amrex::LoopOnCpu blocks below write fab_arr(i, j, k_fab) = ... from
+    // host code; that segfaults if fab_arr points at device memory. Build a
+    // host-mirror iMultiFab on the pinned arena, fill it, then Copy device
+    // at the end.
+#ifdef AMREX_USE_GPU
+    amrex::iMultiFab mf_host(dest_mf.boxArray(), dest_mf.DistributionMap(), dest_mf.nComp(),
+                             dest_mf.nGrow(), amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
+    amrex::iMultiFab& target_mf = mf_host;
+#else
+    amrex::iMultiFab& target_mf = dest_mf;
+#endif
+
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -465,8 +479,8 @@ void TiffReader::readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_
         std::vector<unsigned char> temp_buffer;
         TiffPtr thread_local_tif_handle = nullptr;
 
-        for (amrex::MFIter mfi(dest_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Array4<int> fab_arr = dest_mf.array(mfi);
+        for (amrex::MFIter mfi(target_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Array4<int> fab_arr = target_mf.array(mfi);
             const amrex::Box& tile_box = mfi.tilebox();
             const int k_min_fab = tile_box.smallEnd(2);
             const int k_max_fab = tile_box.bigEnd(2);
@@ -714,6 +728,10 @@ void TiffReader::readDistributedIntoFab(amrex::iMultiFab& dest_mf, int value_if_
             } // End k_loop_idx Z-slices
         } // End MFIter
     } // End OMP parallel region
+#ifdef AMREX_USE_GPU
+    amrex::Copy(dest_mf, mf_host, 0, 0, dest_mf.nComp(), dest_mf.nGrow());
+    amrex::Gpu::streamSynchronize();
+#endif
     amrex::ParallelDescriptor::Barrier("TiffReader::readDistributedIntoFab");
 }
 

--- a/src/props/ConnectedComponents.cpp
+++ b/src/props/ConnectedComponents.cpp
@@ -31,14 +31,35 @@ ConnectedComponents::ConnectedComponents(const amrex::Geometry& geom, const amre
 amrex::IntVect ConnectedComponents::findNextUnlabeled(const amrex::iMultiFab& labelMF,
                                                       const amrex::iMultiFab& phaseFab,
                                                       int phaseID) const {
-    // Find the first unlabeled cell of the target phase on this rank
+    // Find the first unlabeled cell of the target phase on this rank.
+    // The LoopOnCpu reads through label_arr / phase_arr would segfault on
+    // CUDA builds where those Array4 views point at device memory. Snapshot
+    // both into pinned-host iMultiFabs before iterating; on CPU builds the
+    // snapshots are skipped via the #ifdef and we alias the inputs.
     amrex::IntVect local_seed(-1, -1, -1);
     bool found = false;
 
-    for (amrex::MFIter mfi(labelMF); mfi.isValid() && !found; ++mfi) {
+#ifdef AMREX_USE_GPU
+    amrex::iMultiFab labelMF_host_storage(labelMF.boxArray(), labelMF.DistributionMap(),
+                                          labelMF.nComp(), 0,
+                                          amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
+    amrex::iMultiFab phaseFab_host_storage(phaseFab.boxArray(), phaseFab.DistributionMap(),
+                                           phaseFab.nComp(), 0,
+                                           amrex::MFInfo().SetArena(amrex::The_Pinned_Arena()));
+    amrex::Copy(labelMF_host_storage, labelMF, 0, 0, labelMF.nComp(), 0);
+    amrex::Copy(phaseFab_host_storage, phaseFab, 0, 0, phaseFab.nComp(), 0);
+    amrex::Gpu::streamSynchronize();
+    const amrex::iMultiFab& labelMF_host = labelMF_host_storage;
+    const amrex::iMultiFab& phaseFab_host = phaseFab_host_storage;
+#else
+    const amrex::iMultiFab& labelMF_host = labelMF;
+    const amrex::iMultiFab& phaseFab_host = phaseFab;
+#endif
+
+    for (amrex::MFIter mfi(labelMF_host); mfi.isValid() && !found; ++mfi) {
         const amrex::Box& vbox = mfi.validbox();
-        const auto label_arr = labelMF.const_array(mfi);
-        const auto phase_arr = phaseFab.const_array(mfi, 0);
+        const auto label_arr = labelMF_host.const_array(mfi);
+        const auto phase_arr = phaseFab_host.const_array(mfi, 0);
 
         amrex::LoopOnCpu(vbox, [&](int i, int j, int k) {
             if (!found && phase_arr(i, j, k) == phaseID && label_arr(i, j, k, 0) == 0) {

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -345,10 +345,28 @@ void OpenImpala::TortuosityHypre::preconditionPhaseFab() {
         for (amrex::MFIter mfi(m_mf_phase, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             const amrex::Box& tile_box = mfi.tilebox();
             amrex::IArrayBox& fab = m_mf_phase[mfi];
-            int ncomp = fab.nComp();
+            const int ncomp = fab.nComp();
+            // removeIsolatedCells is a host kernel that dereferences the
+            // raw pointer it receives. fab.dataPtr() returns DEVICE memory
+            // on CUDA builds; copy the fab to a host buffer, run the
+            // kernel there, then push the modified data back.
+#ifdef AMREX_USE_GPU
+            const size_t total = static_cast<size_t>(fab.box().numPts()) * ncomp;
+            std::vector<int> host_buf(total);
+            amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, fab.dataPtr(0), fab.dataPtr(0) + total,
+                                  host_buf.data());
+            amrex::Gpu::streamSynchronize();
+            OpenImpala::removeIsolatedCells(host_buf.data(), fab.loVect(), fab.hiVect(), ncomp,
+                                            tile_box.loVect(), tile_box.hiVect(),
+                                            domain_box.loVect(), domain_box.hiVect());
+            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, host_buf.data(),
+                                  host_buf.data() + total, fab.dataPtr(0));
+            amrex::Gpu::streamSynchronize();
+#else
             OpenImpala::removeIsolatedCells(fab.dataPtr(0), fab.loVect(), fab.hiVect(), ncomp,
                                             tile_box.loVect(), tile_box.hiVect(),
                                             domain_box.loVect(), domain_box.hiVect());
+#endif
         }
         if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
             amrex::Print() << "    DEBUG [preconditionPhaseFab]: Finished remspot pass " << pass + 1

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -527,13 +527,27 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation() {
         amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_xinit.begin(), d_xinit.end(),
                          initial_guess.begin());
 
-        // Apply BCs on host (surface operation, not performance-critical)
+        // The host-side BC functions below dereference mask_ptr / dc_ptr
+        // directly, so the underlying memory must be host-accessible.
+        // m_mf_active_mask[mfi].dataPtr() and m_mf_diff_coeff[mfi].dataPtr()
+        // return DEVICE pointers on CUDA builds — passing those to a CPU
+        // function reading through them segfaults. Snapshot the relevant
+        // component(s) device → host before the BC pass.
         const amrex::IArrayBox& mask_iab = m_mf_active_mask[mfi];
-        const int* mask_ptr = mask_iab.dataPtr(MaskComp);
-        const auto& mask_box = mask_iab.box();
         const amrex::FArrayBox& dc_fab = m_mf_diff_coeff[mfi];
-        const amrex::Real* dc_ptr = dc_fab.dataPtr(0);
+        const auto& mask_box = mask_iab.box();
         const auto& dc_box = dc_fab.box();
+        const size_t mask_comp_size = mask_box.numPts();
+        const size_t dc_comp_size = dc_box.numPts();
+        std::vector<int> mask_host(mask_comp_size);
+        std::vector<amrex::Real> dc_host(dc_comp_size);
+        amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, mask_iab.dataPtr(MaskComp),
+                              mask_iab.dataPtr(MaskComp) + mask_comp_size, mask_host.data());
+        amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, dc_fab.dataPtr(0),
+                              dc_fab.dataPtr(0) + dc_comp_size, dc_host.data());
+        amrex::Gpu::streamSynchronize();
+        const int* mask_ptr = mask_host.data();
+        const amrex::Real* dc_ptr = dc_host.data();
 
         if (m_bc_inlet_outlet != nullptr) {
             m_bc_inlet_outlet->applyBC(matrix_values.data(), rhs_values.data(),

--- a/src/props/TortuositySolverBase.cpp
+++ b/src/props/TortuositySolverBase.cpp
@@ -97,10 +97,28 @@ void TortuositySolverBase::preconditionPhaseFab() {
         for (amrex::MFIter mfi(m_mf_phase, false); mfi.isValid(); ++mfi) {
             const amrex::Box& tile_box = mfi.validbox();
             amrex::IArrayBox& fab = m_mf_phase[mfi];
-            int ncomp = fab.nComp();
+            const int ncomp = fab.nComp();
+            // removeIsolatedCells is a host kernel that dereferences the
+            // raw pointer it receives. fab.dataPtr() returns DEVICE memory
+            // on CUDA builds; copy the fab to a host buffer, run the
+            // kernel there, then push the modified data back to the fab.
+#ifdef AMREX_USE_GPU
+            const size_t total = static_cast<size_t>(fab.box().numPts()) * ncomp;
+            std::vector<int> host_buf(total);
+            amrex::Gpu::copyAsync(amrex::Gpu::deviceToHost, fab.dataPtr(0), fab.dataPtr(0) + total,
+                                  host_buf.data());
+            amrex::Gpu::streamSynchronize();
+            OpenImpala::removeIsolatedCells(host_buf.data(), fab.loVect(), fab.hiVect(), ncomp,
+                                            tile_box.loVect(), tile_box.hiVect(),
+                                            domain_box.loVect(), domain_box.hiVect());
+            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, host_buf.data(),
+                                  host_buf.data() + total, fab.dataPtr(0));
+            amrex::Gpu::streamSynchronize();
+#else
             OpenImpala::removeIsolatedCells(fab.dataPtr(0), fab.loVect(), fab.hiVect(), ncomp,
                                             tile_box.loVect(), tile_box.hiVect(),
                                             domain_box.loVect(), domain_box.hiVect());
+#endif
         }
     }
     m_mf_phase.FillBoundary(m_geom.periodicity());


### PR DESCRIPTION
Comprehensive audit pass to clear the remaining GPU-port debt that's been
surfacing one segfault at a time. After https://github.com/BASE-Laboratory/OpenImpala/commit/7d43a0ddd04e2f57f45d777df7daa58c0be4a191 unblocked the
TortuosityHypre matrix-fill BC pass, this commit fixes the rest of the
sites identified in the previous audit so the same drip-feed of "build
4.2.X — wait for release — try again" stops.

Two recipes used:

(1) Snapshot device → pinned-host iMultiFab when host code needs to READ
    iMultiFab values.

      ConnectedComponents.cpp:findNextUnlabeled — host LoopOnCpu reading
      label_arr + phase_arr through Array4 views into device memory.

(2) Build a pinned-host iMultiFab as the destination for host code that
    WRITES iMultiFab values, then amrex::Copy device at the end.

      io/TiffReader.cpp:readDistributedIntoFab     (oi.read_image *.tif)
      io/RawReader.cpp:threshold                   (oi.read_image *.raw)
      io/DatReader.cpp:threshold                   (oi.read_image *.dat)

(3) Stage device data into a host std::vector for raw-pointer host kernels
    that can't be ported and copy back after.

      TortuosityHypre.cpp:preconditionPhaseFab     — removeIsolatedCells
      TortuositySolverBase.cpp:preconditionPhaseFab — removeIsolatedCells

    Both only run when tortuosity.remspot_passes > 0 (default 0); included
    here so the code path is defensible regardless of the input file.

All paths are #ifdef AMREX_USE_GPU guarded — on CPU builds the host
mirrors / device copies are skipped via aliasing, so no behaviour change
for the CPU wheel (verified by inspection).

Includes added where missing (AMReX_Gpu.H, AMReX_MultiFabUtil.H) so the
Pinned arena, streamSynchronize, and Copy primitives resolve.

Verified clang-format clean across all six files.

After this lands:

  ✓ oi.tortuosity            (TortuosityHypre — matrix BC + flux writeback fixed)
  ✓ oi.percolation_check     (FloodFill seed collect + plant fixed)
  ✓ oi.volume_fraction       (already clean)
  ✓ oi.effective_diffusivity (EffDiff writeback + active mask + pin-cell fixed)
  ✓ oi.connected_components  (findNextUnlabeled fixed here)
  ✓ oi.read_image *.tif      (TiffReader fixed here)
  ✓ oi.read_image *.raw      (RawReader fixed here)
  ✓ oi.read_image *.dat      (DatReader fixed here)
  ✓ oi.read_image *.h5       (already clean — temp_fab on pinned arena)

Skipped intentionally:
  TortuosityHypre.cpp:checkMatrixProperties — debug-only
  src/props/Diffusion.cpp                   — native binary, not Python