### PR TITLE
proper HYPRE-CUDA fix: device memory + device buffers end-to-end

### DIFF
--- a/notebooks/profiling_and_tuning.ipynb
+++ b/notebooks/profiling_and_tuning.ipynb
@@ -19,7 +19,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BASE-Laboratory/OpenImpala/blob/master/notebooks/profiling_and_tuning.ipynb)\n\n# OpenImpala — Profiling and Performance Tuning\n\nThis notebook is the diagnostic complement to the seven user tutorials. Where the tutorials show *what* to do, this one shows *why* a given solve takes the time it does — and what to change when it takes too long.\n\nEvery `oi.tortuosity(numpy_array, ...)` call rebuilds the full AMReX + HYPRE stack from scratch and runs a percolation flood fill before the linear solve. That per-call setup cost can dominate small and medium problems. The first half of the notebook isolates and quantifies that cost; the second half goes below the binding layer with C++ and GPU profilers.\n\n## Contents\n\n| Section | Topic |\n|---:|---|\n| 1 | Setup — environment detection and dependency install |\n| 1a | Build verification — confirm the GPU build is actually active |\n| 2 | Synthetic datasets at 16³ – 128³ |\n| 3 | Stage-by-stage timing of a single solve |\n| 3b | Per-stage scaling: O(N) compute vs constant overhead |\n| 4 | Fixed-overhead extraction via `t(N) = a + b·Nᵖ` |\n| 5 | Amortization: reusing the VoxelImage across solves |\n| 6 | cProfile — Python-level hot frames |\n| 7 | AMReX TinyProfiler — C++ function breakdown |\n| 8 | NVIDIA Nsight Systems — GPU kernel timeline |\n| 9 | Solver comparison and scaling validation |\n| 10 | `max_grid_size` tuning |\n| 11 | Native-binary comparison (optional) |\n| 12 | Summary and HPC recommendations |\n\nSections 1 – 6 run on any environment in a few minutes. Sections 7+ produce the most useful output on a Colab GPU runtime (T4 / A100 / L4)."
+   "source": "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/BASE-Laboratory/OpenImpala/blob/master/notebooks/profiling_and_tuning.ipynb)\n\n# OpenImpala \u2014 Profiling and Performance Tuning\n\nThis notebook is the diagnostic complement to the seven user tutorials. Where the tutorials show *what* to do, this one shows *why* a given solve takes the time it does \u2014 and what to change when it takes too long.\n\nEvery `oi.tortuosity(numpy_array, ...)` call rebuilds the full AMReX + HYPRE stack from scratch and runs a percolation flood fill before the linear solve. That per-call setup cost can dominate small and medium problems. The first half of the notebook isolates and quantifies that cost; the second half goes below the binding layer with C++ and GPU profilers.\n\n## Contents\n\n| Section | Topic |\n|---:|---|\n| 1 | Setup \u2014 environment detection and dependency install |\n| 1a | Build verification \u2014 confirm the GPU build is actually active |\n| 2 | Synthetic datasets at 16\u00b3 \u2013 128\u00b3 |\n| 3 | Stage-by-stage timing of a single solve |\n| 3b | Per-stage scaling: O(N) compute vs constant overhead |\n| 4 | Fixed-overhead extraction via `t(N) = a + b\u00b7N\u1d56` |\n| 5 | Amortization: reusing the VoxelImage across solves |\n| 6 | cProfile \u2014 Python-level hot frames |\n| 7 | AMReX TinyProfiler \u2014 C++ function breakdown |\n| 8 | NVIDIA Nsight Systems \u2014 GPU kernel timeline |\n| 9 | Solver comparison and scaling validation |\n| 10 | `max_grid_size` tuning |\n| 11 | Native-binary comparison (optional) |\n| 12 | Summary and HPC recommendations |\n\nSections 1 \u2013 6 run on any environment in a few minutes. Sections 7+ produce the most useful output on a Colab GPU runtime (T4 / A100 / L4)."
   },
   {
    "cell_type": "markdown",
@@ -41,10 +41,10 @@
     "    r = subprocess.run([\"nvidia-smi\", \"--query-gpu=name\", \"--format=csv,noheader\"],\n",
     "                       capture_output=True, text=True, timeout=10)\n",
     "    gpu_name = r.stdout.strip()\n",
-    "    print(f\"GPU detected: {gpu_name}\" if gpu_name else \"No GPU — CPU only.\")\n",
+    "    print(f\"GPU detected: {gpu_name}\" if gpu_name else \"No GPU \u2014 CPU only.\")\n",
     "except FileNotFoundError:\n",
     "    gpu_name = \"\"\n",
-    "    print(\"nvidia-smi not found — CPU only.\")\n"
+    "    print(\"nvidia-smi not found \u2014 CPU only.\")\n"
    ]
   },
   {
@@ -52,7 +52,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# OpenImpala ships two PyPI wheels:\n#   openimpala       — pure-Python + SciPy fallback (CPU only)\n#   openimpala-cuda  — compiled C++ HYPRE/AMReX backend with CUDA kernels\n#\n# On a GPU runtime we install the CUDA wheel; otherwise we fall back to the\n# pure-Python package.\n!apt-get install -y libopenmpi-dev > /dev/null 2>&1\nif gpu_name:\n    print(\"GPU detected — installing openimpala-cuda\")\n    !pip install -q openimpala-cuda porespy py-spy\nelse:\n    print(\"No GPU detected — installing openimpala (CPU)\")\n    !pip install -q openimpala porespy py-spy\nprint(\"Dependencies installed.\")"
+   "source": "# OpenImpala ships two PyPI wheels:\n#   openimpala       \u2014 pure-Python + SciPy fallback (CPU only)\n#   openimpala-cuda  \u2014 compiled C++ HYPRE/AMReX backend with CUDA kernels\n#\n# On a GPU runtime we install the CUDA wheel; otherwise we fall back to the\n# pure-Python package.\n!apt-get install -y libopenmpi-dev > /dev/null 2>&1\nif gpu_name:\n    print(\"GPU detected \u2014 installing openimpala-cuda\")\n    !pip install -q openimpala-cuda porespy py-spy\nelse:\n    print(\"No GPU detected \u2014 installing openimpala (CPU)\")\n    !pip install -q openimpala porespy py-spy\nprint(\"Dependencies installed.\")"
   },
   {
    "cell_type": "code",
@@ -86,19 +86,19 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 1a. Build verification\n\nBefore profiling anything, confirm that the wheel `pip` installed actually has the GPU backend you expect. The most common cause of \"OpenImpala feels slow on Colab\" is a CPU-only wheel running on a GPU-equipped host — every solve in the rest of the notebook would be CPU-bound and ~10–50× slower than necessary on a single-phase 3D diffusion problem at 128³+.\n\n`oi.build_info()` returns a dict of compile-time feature flags plus the runtime GPU device count. We check that the backend matches the hardware, and warn loudly if it doesn't."
+   "source": "## 1a. Build verification\n\nBefore profiling anything, confirm that the wheel `pip` installed actually has the GPU backend you expect. The most common cause of \"OpenImpala feels slow on Colab\" is a CPU-only wheel running on a GPU-equipped host \u2014 every solve in the rest of the notebook would be CPU-bound and ~10\u201350\u00d7 slower than necessary on a single-phase 3D diffusion problem at 128\u00b3+.\n\n`oi.build_info()` returns a dict of compile-time feature flags plus the runtime GPU device count. We check that the backend matches the hardware, and warn loudly if it doesn't."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "info = oi.build_info()\nbackend = info[\"backend\"]   # one of: cpp-cuda, cpp-hip, cpp-cpu, pure-python\n\nprint(f\"openimpala backend: {backend}\")\nprint(f\"  version:        {info.get('version', 'unknown')}\")\nprint(f\"  OpenMP threads: {info.get('openmp_max_threads', 1)}\")\nprint(f\"  MPI enabled:    {info.get('mpi_enabled', False)}\")\nprint(f\"  HYPRE CUDA:     {info.get('hypre_cuda', False)}\")\nprint(f\"  TinyProfile:    {info.get('tiny_profile', False)}\")\nif info.get(\"gpu_device_count\", -1) > 0:\n    print(f\"  GPU devices:    {info['gpu_device_count']}\")\n\nis_gpu_build = backend in (\"cpp-cuda\", \"cpp-hip\")\n\nif gpu_name and not is_gpu_build:\n    print()\n    print(\"=\" * 70)\n    print(\"  WARNING: CPU-only build detected on a GPU-equipped host\")\n    print(\"=\" * 70)\n    print(f\"  Host GPU:          {gpu_name}\")\n    print(f\"  openimpala build:  {backend}\")\n    print()\n    print(\"  The GPU is idle. Every solve in this notebook will run on the CPU,\")\n    print(\"  which is typically 10–50× slower than the CUDA build for\")\n    print(\"  single-phase 3D diffusion on 128³+ grids.\")\n    print()\n    print(\"  To fix:\")\n    print(\"    !pip uninstall -y openimpala\")\n    print(\"    !pip install openimpala-cuda\")\n    print(\"  Then Runtime → Restart session and re-run from the top.\")\n    print(\"=\" * 70)\nelif is_gpu_build:\n    print(f\"\\n{backend.upper()} build active on {gpu_name or 'accelerator'}.\")\nelse:\n    print(\"\\nCPU-only run (no accelerator detected).\")"
+   "source": "info = oi.build_info()\nbackend = info[\"backend\"]   # one of: cpp-cuda, cpp-hip, cpp-cpu, pure-python\n\nprint(f\"openimpala backend: {backend}\")\nprint(f\"  version:        {info.get('version', 'unknown')}\")\nprint(f\"  OpenMP threads: {info.get('openmp_max_threads', 1)}\")\nprint(f\"  MPI enabled:    {info.get('mpi_enabled', False)}\")\nprint(f\"  HYPRE CUDA:     {info.get('hypre_cuda', False)}\")\nprint(f\"  TinyProfile:    {info.get('tiny_profile', False)}\")\nif info.get(\"gpu_device_count\", -1) > 0:\n    print(f\"  GPU devices:    {info['gpu_device_count']}\")\n\nis_gpu_build = backend in (\"cpp-cuda\", \"cpp-hip\")\n\nif gpu_name and not is_gpu_build:\n    print()\n    print(\"=\" * 70)\n    print(\"  WARNING: CPU-only build detected on a GPU-equipped host\")\n    print(\"=\" * 70)\n    print(f\"  Host GPU:          {gpu_name}\")\n    print(f\"  openimpala build:  {backend}\")\n    print()\n    print(\"  The GPU is idle. Every solve in this notebook will run on the CPU,\")\n    print(\"  which is typically 10\u201350\u00d7 slower than the CUDA build for\")\n    print(\"  single-phase 3D diffusion on 128\u00b3+ grids.\")\n    print()\n    print(\"  To fix:\")\n    print(\"    !pip uninstall -y openimpala\")\n    print(\"    !pip install openimpala-cuda\")\n    print(\"  Then Runtime \u2192 Restart session and re-run from the top.\")\n    print(\"=\" * 70)\nelif is_gpu_build:\n    print(f\"\\n{backend.upper()} build active on {gpu_name or 'accelerator'}.\")\nelse:\n    print(\"\\nCPU-only run (no accelerator detected).\")"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 2. Synthetic datasets\n\nPoreSpy is used to generate five synthetic porous structures at 16³, 32³, 64³, 96³, and 128³. Sizes are kept small enough that a full profiling run completes in minutes rather than hours, and large enough that the cubic scaling of voxel count is visible in the timings.\n\nThe 16³ dataset is small enough that its solve time is dominated by per-call setup rather than compute — useful for extracting the fixed overhead in §4."
+   "source": "## 2. Synthetic datasets\n\nPoreSpy is used to generate five synthetic porous structures at 16\u00b3, 32\u00b3, 64\u00b3, 96\u00b3, and 128\u00b3. Sizes are kept small enough that a full profiling run completes in minutes rather than hours, and large enough that the cubic scaling of voxel count is visible in the timings.\n\nThe 16\u00b3 dataset is small enough that its solve time is dominated by per-call setup rather than compute \u2014 useful for extracting the fixed overhead in \u00a74."
   },
   {
    "cell_type": "code",
@@ -125,14 +125,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Python-level stage breakdown — one call, one bar chart\n",
+    "## 3. Python-level stage breakdown \u2014 one call, one bar chart\n",
     "\n",
     "`oi.tortuosity(numpy_array, ...)` is not a single operation. From\n",
     "`facade.py` it is roughly:\n",
     "\n",
     "```\n",
-    "numpy → VoxelImage.from_numpy    (copy + AMReX BoxArray/Geometry/iMultiFab build)\n",
-    "PercolationCheck(img, ...)        (flood fill — runs every call!)\n",
+    "numpy \u2192 VoxelImage.from_numpy    (copy + AMReX BoxArray/Geometry/iMultiFab build)\n",
+    "PercolationCheck(img, ...)        (flood fill \u2014 runs every call!)\n",
     "VolumeFraction(img, ...)          (cheap count)\n",
     "TortuosityHypre(img, ..., solver) (HYPRE grid/stencil/matrix assembly)\n",
     "solver.value()                    (actual linear solve + flux integration)\n",
@@ -140,7 +140,7 @@
     "\n",
     "We time each stage independently. Whichever bar dominates *is* the\n",
     "bottleneck. If `from_numpy` or `TortuosityHypre(...)` construction dominates,\n",
-    "your slowdown is in binding/setup — not the solver.\n"
+    "your slowdown is in binding/setup \u2014 not the solver.\n"
    ]
   },
   {
@@ -193,7 +193,7 @@
     "    out[\"_iters\"] = solver_obj.iterations\n",
     "    return out\n",
     "\n",
-    "# Warm-up — first call pays lazy-init inside AMReX/HYPRE\n",
+    "# Warm-up \u2014 first call pays lazy-init inside AMReX/HYPRE\n",
     "_ = time_stages(datasets[32])\n",
     "\n",
     "stages = time_stages(data_medium, solver=\"pcg\")\n",
@@ -223,24 +223,24 @@
     "ax.set_yticks(y)\n",
     "ax.set_yticklabels(stage_names, fontsize=9)\n",
     "ax.set_xlabel(\"Wall time (s)\")\n",
-    "ax.set_title(\"Single oi.tortuosity(64³) call — stage breakdown\", fontweight=\"bold\")\n",
+    "ax.set_title(\"Single oi.tortuosity(64\u00b3) call \u2014 stage breakdown\", fontweight=\"bold\")\n",
     "ax.invert_yaxis()\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
     "slowest = max(stage_names, key=lambda k: stages[k])\n",
-    "print(f\"\\nBottleneck at 64³: {slowest} ({100*stages[slowest]/stages['_total']:.1f}%)\")\n"
+    "print(f\"\\nBottleneck at 64\u00b3: {slowest} ({100*stages[slowest]/stages['_total']:.1f}%)\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### §3b Per-stage scaling — does this stage scale with N, or is it fixed overhead?\n",
+    "### \u00a73b Per-stage scaling \u2014 does this stage scale with N, or is it fixed overhead?\n",
     "\n",
-    "Run the same decomposition at 32³ and 128³ and plot the ratio per stage.\n",
-    "A stage with ratio ≈ `(128/32)³ = 64×` is doing O(N) work — legitimate\n",
-    "compute. A stage with ratio ≈ 1× is constant overhead — every call pays\n",
+    "Run the same decomposition at 32\u00b3 and 128\u00b3 and plot the ratio per stage.\n",
+    "A stage with ratio \u2248 `(128/32)\u00b3 = 64\u00d7` is doing O(N) work \u2014 legitimate\n",
+    "compute. A stage with ratio \u2248 1\u00d7 is constant overhead \u2014 every call pays\n",
     "the same price regardless of problem size, which is the *classic* signature\n",
     "of binding / setup cost.\n"
    ]
@@ -256,8 +256,8 @@
     "\n",
     "# Ideal O(N) ratio when scaling voxel count by (128/32)^3\n",
     "N_ratio = (128 / 32) ** 3\n",
-    "print(f\"Ideal O(N) work ratio for 32->128: {N_ratio:.0f}×\")\n",
-    "print(f\"{'stage':<55s} {'32³ (s)':>10s} {'128³ (s)':>10s} {'ratio':>8s}  behaviour\")\n",
+    "print(f\"Ideal O(N) work ratio for 32->128: {N_ratio:.0f}\u00d7\")\n",
+    "print(f\"{'stage':<55s} {'32\u00b3 (s)':>10s} {'128\u00b3 (s)':>10s} {'ratio':>8s}  behaviour\")\n",
     "print(\"-\" * 110)\n",
     "\n",
     "rows = []\n",
@@ -265,13 +265,13 @@
     "    ts, tb = stages_small[k], stages_big[k]\n",
     "    r = tb / max(ts, 1e-9)\n",
     "    if r > 0.5 * N_ratio:\n",
-    "        label = \"scales O(N) ✓\"\n",
+    "        label = \"scales O(N) \u2713\"\n",
     "    elif r < 2.0:\n",
     "        label = \"~constant (overhead)\"\n",
     "    else:\n",
     "        label = \"sub-linear\"\n",
     "    rows.append({\"stage\": k, \"t_32\": ts, \"t_128\": tb, \"ratio\": r, \"label\": label})\n",
-    "    print(f\"{k:<55s} {ts:>10.3f} {tb:>10.3f} {r:>8.1f}×  {label}\")\n",
+    "    print(f\"{k:<55s} {ts:>10.3f} {tb:>10.3f} {r:>8.1f}\u00d7  {label}\")\n",
     "\n",
     "df_scale = pd.DataFrame(rows)\n"
    ]
@@ -285,15 +285,15 @@
     "fig, ax = plt.subplots(figsize=(11, 4))\n",
     "y = np.arange(len(stage_names))\n",
     "w = 0.4\n",
-    "ax.barh(y - w/2, df_scale[\"t_32\"], w, color=\"#3498db\", alpha=0.85, label=\"32³\")\n",
-    "ax.barh(y + w/2, df_scale[\"t_128\"], w, color=\"#e74c3c\", alpha=0.85, label=\"128³\")\n",
+    "ax.barh(y - w/2, df_scale[\"t_32\"], w, color=\"#3498db\", alpha=0.85, label=\"32\u00b3\")\n",
+    "ax.barh(y + w/2, df_scale[\"t_128\"], w, color=\"#e74c3c\", alpha=0.85, label=\"128\u00b3\")\n",
     "for i, r in enumerate(df_scale[\"ratio\"]):\n",
-    "    ax.text(df_scale[\"t_128\"].iloc[i] * 1.02, i + w/2, f\"{r:.0f}×\",\n",
+    "    ax.text(df_scale[\"t_128\"].iloc[i] * 1.02, i + w/2, f\"{r:.0f}\u00d7\",\n",
     "            va=\"center\", fontsize=8, color=\"#2c3e50\")\n",
     "ax.set_yticks(y)\n",
     "ax.set_yticklabels(stage_names, fontsize=9)\n",
     "ax.set_xlabel(\"Wall time (s)\")\n",
-    "ax.set_title(f\"Per-stage scaling (ideal O(N) ratio = {N_ratio:.0f}×)\", fontweight=\"bold\")\n",
+    "ax.set_title(f\"Per-stage scaling (ideal O(N) ratio = {N_ratio:.0f}\u00d7)\", fontweight=\"bold\")\n",
     "ax.axvline(0, color=\"#bdc3c7\", linewidth=0.5)\n",
     "ax.invert_yaxis()\n",
     "ax.legend(loc=\"lower right\")\n",
@@ -302,9 +302,9 @@
     "\n",
     "constant_stages = df_scale[df_scale[\"ratio\"] < 2.0]\n",
     "if not constant_stages.empty:\n",
-    "    print(\"\\n⚠ Stages that DON'T scale with problem size (pure overhead):\")\n",
+    "    print(\"\\n\u26a0 Stages that DON'T scale with problem size (pure overhead):\")\n",
     "    for _, r in constant_stages.iterrows():\n",
-    "        print(f\"    {r['stage']:55s}  ratio={r['ratio']:.1f}×\")\n",
+    "        print(f\"    {r['stage']:55s}  ratio={r['ratio']:.1f}\u00d7\")\n",
     "    print(\"  Every oi.tortuosity() call pays these, regardless of image size.\")\n"
    ]
   },
@@ -316,7 +316,7 @@
     "\n",
     "A call's wall time has two parts: a fixed per-call overhead `a` (binding\n",
     "dispatch, AMReX/HYPRE setup, flood fill) and a size-dependent compute part\n",
-    "`b·Nᵖ`. Fit `t(N) = a + b·Nᵖ` across sizes.\n",
+    "`b\u00b7N\u1d56`. Fit `t(N) = a + b\u00b7N\u1d56` across sizes.\n",
     "\n",
     "If `a` is a meaningful fraction of the medium-size solve time, every solve\n",
     "you run is paying a tax that has nothing to do with the actual physics.\n"
@@ -330,7 +330,7 @@
    "source": [
     "overhead_rows = []\n",
     "for n, d in datasets.items():\n",
-    "    # Two trials — median to reduce jitter without paying for 3×\n",
+    "    # Two trials \u2014 median to reduce jitter without paying for 3\u00d7\n",
     "    ts = []\n",
     "    for _ in range(2):\n",
     "        t0 = time.perf_counter()\n",
@@ -365,7 +365,7 @@
     "    print(f\"Fit failed: {e}\")\n",
     "    a_raw, b_fit, p_fit = T.min(), 0.0, 1.0\n",
     "\n",
-    "# Clamp: a negative intercept means there is no meaningful fixed overhead —\n",
+    "# Clamp: a negative intercept means there is no meaningful fixed overhead \u2014\n",
     "# pretending otherwise misleads the summary.\n",
     "a_fit = max(a_raw, 0.0)\n",
     "overhead_meaningful = a_fit > 0.01 * T.max()\n",
@@ -376,10 +376,10 @@
     "ax.loglog(N, T, \"o\", color=\"#2c3e50\", markersize=10, label=\"Measured\")\n",
     "xs = np.logspace(np.log10(N.min()), np.log10(N.max()), 200)\n",
     "ax.loglog(xs, model(xs, a_fit, b_fit, p_fit), \"-\", color=\"#3498db\",\n",
-    "          label=f\"Fit: {a_fit:.2f}s + {b_fit:.2e}·N^{p_fit:.2f}\")\n",
+    "          label=f\"Fit: {a_fit:.2f}s + {b_fit:.2e}\u00b7N^{p_fit:.2f}\")\n",
     "if overhead_meaningful:\n",
     "    ax.axhline(a_fit, color=\"#e74c3c\", linestyle=\"--\",\n",
-    "               label=f\"Fixed overhead ≈ {a_fit:.2f}s\")\n",
+    "               label=f\"Fixed overhead \u2248 {a_fit:.2f}s\")\n",
     "ax.set_xlabel(\"Voxels (N)\")\n",
     "ax.set_ylabel(\"Wall time (s)\")\n",
     "ax.set_title(\"Fixed overhead vs compute\", fontweight=\"bold\")\n",
@@ -388,13 +388,13 @@
     "plt.show()\n",
     "\n",
     "if a_raw < 0:\n",
-    "    print(f\"\\nFit intercept was negative ({a_raw:.2f}s) — clamped to 0.\")\n",
+    "    print(f\"\\nFit intercept was negative ({a_raw:.2f}s) \u2014 clamped to 0.\")\n",
     "    print(\"Interpretation: no detectable per-call fixed overhead; all time is compute.\")\n",
     "print(f\"Estimated fixed overhead per call: {a_fit:.2f}s\")\n",
     "print(f\"Compute scaling:                  O(N^{p_fit:.2f})\")\n",
     "\n",
     "if p_fit > 1.2:\n",
-    "    print(f\"\\n⚠ Super-linear compute scaling (O(N^{p_fit:.2f}) vs ideal O(N)).\")\n",
+    "    print(f\"\\n\u26a0 Super-linear compute scaling (O(N^{p_fit:.2f}) vs ideal O(N)).\")\n",
     "    print(\"  Likely cause: Krylov iteration count growing with N. A multigrid\")\n",
     "    print(\"  preconditioner (SMG/PFMG) or MLMG would bring this closer to O(N).\")\n",
     "\n",
@@ -405,7 +405,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 5. Amortization test — reusing the VoxelImage\n\nIf most per-call time goes into rebuilding AMReX state, then running the solver multiple times against the *same* `VoxelImage` should be markedly cheaper than the equivalent number of calls through the high-level facade. This cell measures the gap.\n\nTwo paths are compared on `data_medium`, five calls each:\n\n* **Naive**: five calls to `oi.tortuosity(numpy_array, ...)`. Every call rebuilds the geometry, BoxArray, distribution mapping, iMultiFab, percolation mask, and HYPRE matrix from the bare NumPy input.\n* **Amortized**: one call to `_numpy_to_voxelimage` to build the `VoxelImage` once, then five direct calls to `_core.TortuosityHypre` reusing it.\n\nThe difference is the per-call setup tax. Sweeping (e.g. directional tortuosity, parameter studies) should always use the amortized pattern."
+   "source": "## 5. Amortization test \u2014 reusing the VoxelImage\n\nIf most per-call time goes into rebuilding AMReX state, then running the solver multiple times against the *same* `VoxelImage` should be markedly cheaper than the equivalent number of calls through the high-level facade. This cell measures the gap.\n\nTwo paths are compared on `data_medium`, five calls each:\n\n* **Naive**: five calls to `oi.tortuosity(numpy_array, ...)`. Every call rebuilds the geometry, BoxArray, distribution mapping, iMultiFab, percolation mask, and HYPRE matrix from the bare NumPy input.\n* **Amortized**: one call to `_numpy_to_voxelimage` to build the `VoxelImage` once, then five direct calls to `_core.TortuosityHypre` reusing it.\n\nThe difference is the per-call setup tax. Sweeping (e.g. directional tortuosity, parameter studies) should always use the amortized pattern."
   },
   {
    "cell_type": "code",
@@ -416,7 +416,7 @@
     "from openimpala.facade import _numpy_to_voxelimage, _parse_direction, _parse_solver\n",
     "\n",
     "def naive_repeat(data, n=5, solver=\"pcg\"):\n",
-    "    \"\"\"Top-level facade — rebuilds everything every call.\"\"\"\n",
+    "    \"\"\"Top-level facade \u2014 rebuilds everything every call.\"\"\"\n",
     "    ts = []\n",
     "    for _ in range(n):\n",
     "        t0 = time.perf_counter()\n",
@@ -444,11 +444,11 @@
     "naive = naive_repeat(data_medium, n_repeat)\n",
     "amort = amortized_repeat(data_medium, n_repeat)\n",
     "\n",
-    "print(f\"Naive  oi.tortuosity(numpy) × {n_repeat}: \" + \", \".join(f\"{t:.2f}s\" for t in naive))\n",
+    "print(f\"Naive  oi.tortuosity(numpy) \u00d7 {n_repeat}: \" + \", \".join(f\"{t:.2f}s\" for t in naive))\n",
     "print(f\"Amortized (reuse VoxelImage): \" + \", \".join(f\"{t:.2f}s\" for t in amort))\n",
     "print(f\"\\nNaive total:      {sum(naive):.2f}s  (mean {np.mean(naive):.2f}s/call)\")\n",
     "print(f\"Amortized total:  {sum(amort):.2f}s  (mean {np.mean(amort):.2f}s/call)\")\n",
-    "print(f\"Speedup from reuse: {sum(naive)/max(sum(amort), 1e-9):.2f}×\")\n"
+    "print(f\"Speedup from reuse: {sum(naive)/max(sum(amort), 1e-9):.2f}\u00d7\")\n"
    ]
   },
   {
@@ -478,7 +478,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 6. cProfile — Python-level hot frames\n\ncProfile captures cumulative time per Python frame, including time spent inside pybind11 wrappers around C++ calls. This is a different view from §3 — instead of timing named stages, it counts every function call and surfaces unexpected frame costs.\n\nThings to look for in the top 20 frames:\n\n* `_numpy_to_voxelimage`, `VoxelImage.from_numpy` — data ingestion\n* `PercolationCheck.__init__` — flood-fill setup\n* `TortuosityHypre.__init__` — HYPRE matrix assembly\n* `TortuosityHypre.value` — the linear solve\n\nIf pure-Python helpers like `_parse_direction` or `_parse_solver` show up high, the binding is doing too much Python-side dispatch."
+   "source": "## 6. cProfile \u2014 Python-level hot frames\n\ncProfile captures cumulative time per Python frame, including time spent inside pybind11 wrappers around C++ calls. This is a different view from \u00a73 \u2014 instead of timing named stages, it counts every function call and surfaces unexpected frame costs.\n\nThings to look for in the top 20 frames:\n\n* `_numpy_to_voxelimage`, `VoxelImage.from_numpy` \u2014 data ingestion\n* `PercolationCheck.__init__` \u2014 flood-fill setup\n* `TortuosityHypre.__init__` \u2014 HYPRE matrix assembly\n* `TortuosityHypre.value` \u2014 the linear solve\n\nIf pure-Python helpers like `_parse_direction` or `_parse_solver` show up high, the binding is doing too much Python-side dispatch."
   },
   {
    "cell_type": "code",
@@ -501,7 +501,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 7. AMReX TinyProfiler — C++ function breakdown\n\n§3 showed that `solver.value()` accounts for the bulk of wall time at 64³ and that it scales super-linearly to 128³. To break that down further we need to go below the binding layer, into AMReX's own profiler.\n\n`AMReX::TinyProfiler` instruments every `BL_PROFILE`-annotated function in the C++ source and prints a tabular breakdown when AMReX finalises. The compiled wheel sets `-DAMReX_TINY_PROFILE=ON`, so the instrumentation is always on.\n\nThe profiler writes to C++ streams on `amrex::Finalize()`, which Python's `sys.stdout` redirection can't capture from inside a long-running session. We therefore run a single profiled solve in a short-lived subprocess — Python's `capture_output=True` collects stdout and stderr at the OS level and gives us the complete table."
+   "source": "## 7. AMReX TinyProfiler \u2014 C++ function breakdown\n\n\u00a73 showed that `solver.value()` accounts for the bulk of wall time at 64\u00b3 and that it scales super-linearly to 128\u00b3. To break that down further we need to go below the binding layer, into AMReX's own profiler.\n\n`AMReX::TinyProfiler` instruments every `BL_PROFILE`-annotated function in the C++ source and prints a tabular breakdown when AMReX finalises. The compiled wheel sets `-DAMReX_TINY_PROFILE=ON`, so the instrumentation is always on.\n\nThe profiler writes to C++ streams on `amrex::Finalize()`, which Python's `sys.stdout` redirection can't capture from inside a long-running session. We therefore run a single profiled solve in a short-lived subprocess \u2014 Python's `capture_output=True` collects stdout and stderr at the OS level and gives us the complete table."
   },
   {
    "cell_type": "code",
@@ -517,7 +517,7 @@
     "    Why a subprocess: TinyProfiler prints via C++ streams on AMReX finalize,\n",
     "    which sys.stdout redirection can't capture. A subprocess gives us a clean\n",
     "    AMReX lifecycle and Python's ``capture_output=True`` grabs fd 1 + fd 2\n",
-    "    at the OS level — including everything TinyProfiler emits.\n",
+    "    at the OS level \u2014 including everything TinyProfiler emits.\n",
     "\n",
     "    Returns (result_dict, combined_stdout_stderr).\n",
     "    \"\"\"\n",
@@ -558,15 +558,15 @@
     "            break\n",
     "\n",
     "    if proc.returncode != 0:\n",
-    "        print(f\"⚠ subprocess exited with code {proc.returncode}\")\n",
+    "        print(f\"\u26a0 subprocess exited with code {proc.returncode}\")\n",
     "    return result, combined\n",
     "\n",
-    "print(\"Running a profiled solve on 64^3 in a subprocess…\")\n",
+    "print(\"Running a profiled solve on 64^3 in a subprocess\u2026\")\n",
     "prof_result, prof_output = run_with_profiler(data_medium, solver=\"pcg\")\n",
     "if prof_result is not None:\n",
     "    print(f\"tau={prof_result['tau']:.4f}  converged={prof_result['converged']}  iters={prof_result['iters']}\")\n",
     "else:\n",
-    "    print(\"No result line found — solve may have failed; check output below.\")\n",
+    "    print(\"No result line found \u2014 solve may have failed; check output below.\")\n",
     "print(f\"Captured output length: {len(prof_output)} chars\")\n",
     "\n",
     "# Show the tail (TinyProfiler dumps near the end, on finalize)\n",
@@ -620,7 +620,7 @@
     "    print(df_prof.to_string(index=False))\n",
     "elif not has_tp_header:\n",
     "    print(\"=\" * 70)\n",
-    "    print(\"  ⚠  No TinyProfiler table was emitted by this openimpala build\")\n",
+    "    print(\"  \u26a0  No TinyProfiler table was emitted by this openimpala build\")\n",
     "    print(\"=\" * 70)\n",
     "    print(\"  The subprocess ran to completion (result captured above) but\")\n",
     "    print(\"  AMReX did not dump a TinyProfiler table on finalize. This means\")\n",
@@ -630,13 +630,13 @@
     "    print(\"    CMake:  -DAMReX_TINY_PROFILE=ON\")\n",
     "    print(\"    GNUmake: TINY_PROFILE=TRUE\")\n",
     "    print()\n",
-    "    print(\"  Until then §7 cannot break down the C++ solve into components.\")\n",
-    "    print(\"  §3 (Python stage breakdown) + §3b (per-stage scaling) already\")\n",
+    "    print(\"  Until then \u00a77 cannot break down the C++ solve into components.\")\n",
+    "    print(\"  \u00a73 (Python stage breakdown) + \u00a73b (per-stage scaling) already\")\n",
     "    print(\"  show that solver.value() is ~85-95% of wall time and scales\")\n",
-    "    print(\"  super-linearly — that IS the bottleneck regardless.\")\n",
+    "    print(\"  super-linearly \u2014 that IS the bottleneck regardless.\")\n",
     "    print(\"=\" * 70)\n",
     "else:\n",
-    "    print(\"TinyProfiler header detected but no rows parsed — regex mismatch.\")\n",
+    "    print(\"TinyProfiler header detected but no rows parsed \u2014 regex mismatch.\")\n",
     "    print(\"Dump tail of raw output above and adjust parse_tiny_profiler().\")\n"
    ]
   },
@@ -670,7 +670,7 @@
     "    ax.set_yticks(y)\n",
     "    ax.set_yticklabels(df_prof[\"function\"], fontsize=9)\n",
     "    ax.set_xlabel(\"Exclusive time (s)\")\n",
-    "    ax.set_title(\"AMReX TinyProfiler — C++ function breakdown\", fontweight=\"bold\")\n",
+    "    ax.set_title(\"AMReX TinyProfiler \u2014 C++ function breakdown\", fontweight=\"bold\")\n",
     "    ax.invert_yaxis()\n",
     "\n",
     "    from matplotlib.patches import Patch\n",
@@ -685,22 +685,22 @@
     "    plt.tight_layout()\n",
     "    plt.show()\n",
     "else:\n",
-    "    print(\"Skipping chart — no TinyProfiler data.\")\n"
+    "    print(\"Skipping chart \u2014 no TinyProfiler data.\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. NVIDIA Nsight Systems — GPU kernel timeline\n",
+    "## 8. NVIDIA Nsight Systems \u2014 GPU kernel timeline\n",
     "\n",
     "If a GPU is available, `nsys` captures a kernel-level timeline: launches,\n",
     "memory transfers, idle gaps. Signatures of Python-binding overhead on the\n",
     "GPU path are:\n",
     "\n",
-    "- Many tiny launches with gaps → Python loop driving the GPU\n",
-    "- Frequent H2D transfers of the same data → `numpy → VoxelImage` copies leaking out\n",
-    "- Long idle gaps between kernels → CPU-side serial work between solver calls\n",
+    "- Many tiny launches with gaps \u2192 Python loop driving the GPU\n",
+    "- Frequent H2D transfers of the same data \u2192 `numpy \u2192 VoxelImage` copies leaking out\n",
+    "- Long idle gaps between kernels \u2192 CPU-side serial work between solver calls\n",
     "\n",
     "We use a standalone script so the subprocess is clean.\n"
    ]
@@ -716,9 +716,9 @@
     "\n",
     "if not nsys_available:\n",
     "    if not gpu_name:\n",
-    "        print(\"No GPU — skipping Nsight. (Runtime > Change runtime type > T4 GPU)\")\n",
+    "        print(\"No GPU \u2014 skipping Nsight. (Runtime > Change runtime type > T4 GPU)\")\n",
     "    else:\n",
-    "        print(\"nsys not found — install via: apt-get install nsight-systems\")\n",
+    "        print(\"nsys not found \u2014 install via: apt-get install nsight-systems\")\n",
     "else:\n",
     "    print(f\"nsys: {shutil.which('nsys')}   GPU: {gpu_name}\")\n",
     "    script = '''\n",
@@ -789,9 +789,9 @@
     "            print(\"CUDA memory transfer summary (H2D/D2H):\")\n",
     "            print(df_mem.to_string(index=False))\n",
     "            print(\"\\nRed flags:\")\n",
-    "            print(\"  • Frequent H2D transfers of similar size → numpy→VoxelImage\")\n",
+    "            print(\"  \u2022 Frequent H2D transfers of similar size \u2192 numpy\u2192VoxelImage\")\n",
     "            print(\"    copy leaking out of bindings into the hot path\")\n",
-    "            print(\"  • Large D2H transfer per call → result readback overhead\")\n",
+    "            print(\"  \u2022 Large D2H transfer per call \u2192 result readback overhead\")\n",
     "        else:\n",
     "            print(mem.stdout[:1500])\n",
     "    else:\n",
@@ -801,14 +801,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 9. Solver comparison\n\nWith the bottlenecks identified, this section compares the available solver / preconditioner combinations on `data_medium` at a single grid size. Each solver runs once — the goal is to pick a baseline configuration, not to measure steady-state noise.\n\nThe combinations cover three classes of solver:\n\n* **HYPRE Krylov methods** (`pcg`, `gmres`, `flexgmres`, `bicgstab`) with optional multigrid preconditioning. PCG is for symmetric problems (the natural choice for tortuosity); the others handle non-symmetric operators.\n* **HYPRE standalone multigrid** (`pfmg`, `smg`) — direct multigrid solvers, no Krylov outer loop. PFMG has full GPU support in HYPRE 2.31; SMG only has partial GPU support and segfaults on the CUDA wheel, so its rows are filtered out automatically when `is_gpu_build` is true.\n* **AMReX MLMG** (`mlmg`) — matrix-free geometric multigrid implemented natively in AMReX. Bypasses HYPRE entirely, so there is no matrix-assembly cost (which §3 showed accounts for ~20% of total time) and the entire solve runs on GPU device kernels. Typically the fastest option on CUDA hardware for structured-grid problems like tortuosity.\n\nWhat to look for in the bar chart below: the best solver on a CPU build is usually `pcg+pfmg`; on a GPU build MLMG normally wins by 2–10× depending on grid size, with PFMG-preconditioned Krylov methods close behind."
+   "source": "## 9. Solver comparison\n\nWith the bottlenecks identified, this section compares the available solver / preconditioner combinations on `data_medium` at a single grid size. Each solver runs once \u2014 the goal is to pick a baseline configuration, not to measure steady-state noise.\n\nThe combinations cover three classes of solver:\n\n* **HYPRE Krylov methods** (`pcg`, `gmres`, `flexgmres`, `bicgstab`) with optional multigrid preconditioning. PCG is for symmetric problems (the natural choice for tortuosity); the others handle non-symmetric operators.\n* **HYPRE standalone multigrid** (`pfmg`, `smg`) \u2014 direct multigrid solvers, no Krylov outer loop.\n* **AMReX MLMG** (`mlmg`) \u2014 matrix-free geometric multigrid implemented natively in AMReX. Bypasses HYPRE entirely, so there is no matrix-assembly cost (which \u00a73 showed accounts for ~20% of total time) and the entire solve runs on GPU device kernels. Typically the fastest option on CUDA hardware for structured-grid problems like tortuosity.\n\nWhat to look for in the bar chart below: the best solver on a CPU build is usually `pcg+pfmg`; on a GPU build MLMG normally wins by 2\u201310\u00d7, with PFMG-preconditioned Krylov methods close behind. SMG-based combinations work on both CPU and GPU but are typically slower than PFMG."
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Compare Krylov and multigrid choices on 64^3.\n# Each entry is (label, solver, preconditioner). A preconditioner of None means\n# the solver ignores it (standalone SMG/PFMG/Jacobi, or MLMG). PCG+PFMG and\n# GMRES+PFMG are the textbook-best HYPRE combinations for Poisson-like problems;\n# `mlmg` is the AMReX-native matrix-free path that avoids HYPRE entirely and\n# typically wins on GPU hardware.\ncombos_all = [\n    (\"pcg\",            \"pcg\",       None),\n    (\"pcg+pfmg\",       \"pcg\",       \"pfmg\"),\n    (\"pcg+smg\",        \"pcg\",       \"smg\"),\n    (\"flexgmres+pfmg\", \"flexgmres\", \"pfmg\"),\n    (\"gmres\",          \"gmres\",     None),\n    (\"gmres+pfmg\",     \"gmres\",     \"pfmg\"),\n    (\"bicgstab\",       \"bicgstab\",  None),\n    (\"smg\",            \"smg\",       None),\n    (\"pfmg\",           \"pfmg\",      None),\n    (\"mlmg\",           \"mlmg\",      None),\n]\n\n# HYPRE 2.31's SMG preconditioner only has partial GPU support — running it\n# on the CUDA wheel segfaults inside the HYPRE coarsening machinery. Filter\n# those rows out on GPU builds rather than letting them produce noisy\n# \"FAILED\" entries in the comparison.\nif is_gpu_build:\n    combos = [c for c in combos_all if \"smg\" not in c[0]]\n    print(f\"GPU build detected — skipping {len(combos_all) - len(combos)} SMG combos \"\n          f\"(HYPRE upstream limitation).\")\nelse:\n    combos = combos_all\n\nrecords = []\nfor label, s, pc in combos:\n    kwargs = dict(phase=0, direction=\"z\", solver=s, max_grid_size=32, verbose=0)\n    if pc is not None:\n        kwargs[\"preconditioner\"] = pc\n    try:\n        t0 = time.perf_counter()\n        res = oi.tortuosity(data_medium, **kwargs)\n        dt = time.perf_counter() - t0\n        records.append({\"solver\": label, \"t\": dt, \"iters\": res.iterations,\n                        \"tau\": res.tortuosity, \"ok\": res.solver_converged})\n        print(f\"  {label:18s}  t={dt:6.2f}s  iters={res.iterations:4d}  tau={res.tortuosity:.4f}\")\n    except TypeError as e:\n        # Older wheels don't know the 'preconditioner' kwarg — fall back without it.\n        if \"preconditioner\" in str(e) and pc is not None:\n            print(f\"  {label:18s}  SKIP — wheel predates preconditioner plumbing\")\n            records.append({\"solver\": label, \"t\": np.nan, \"iters\": np.nan,\n                            \"tau\": np.nan, \"ok\": False})\n            continue\n        raise\n    except Exception as e:\n        records.append({\"solver\": label, \"t\": np.nan, \"iters\": np.nan,\n                        \"tau\": np.nan, \"ok\": False})\n        print(f\"  {label:18s}  FAILED — {e}\")\n\ndf_solvers = pd.DataFrame(records)\ndf_solvers"
+   "source": "# Compare Krylov and multigrid choices on 64^3.\n# Each entry is (label, solver, preconditioner). A preconditioner of None means\n# the solver ignores it (standalone SMG/PFMG/Jacobi, or MLMG). PCG+PFMG and\n# GMRES+PFMG are the textbook-best HYPRE combinations for Poisson-like problems;\n# `mlmg` is the AMReX-native matrix-free path that avoids HYPRE entirely and\n# typically wins on GPU hardware.\ncombos = [\n    (\"pcg\",            \"pcg\",       None),\n    (\"pcg+pfmg\",       \"pcg\",       \"pfmg\"),\n    (\"pcg+smg\",        \"pcg\",       \"smg\"),\n    (\"flexgmres+pfmg\", \"flexgmres\", \"pfmg\"),\n    (\"gmres\",          \"gmres\",     None),\n    (\"gmres+pfmg\",     \"gmres\",     \"pfmg\"),\n    (\"bicgstab\",       \"bicgstab\",  None),\n    (\"smg\",            \"smg\",       None),\n    (\"pfmg\",           \"pfmg\",      None),\n    (\"mlmg\",           \"mlmg\",      None),\n]\n\nrecords = []\nfor label, s, pc in combos:\n    kwargs = dict(phase=0, direction=\"z\", solver=s, max_grid_size=32, verbose=0)\n    if pc is not None:\n        kwargs[\"preconditioner\"] = pc\n    try:\n        t0 = time.perf_counter()\n        res = oi.tortuosity(data_medium, **kwargs)\n        dt = time.perf_counter() - t0\n        records.append({\"solver\": label, \"t\": dt, \"iters\": res.iterations,\n                        \"tau\": res.tortuosity, \"ok\": res.solver_converged})\n        print(f\"  {label:18s}  t={dt:6.2f}s  iters={res.iterations:4d}  tau={res.tortuosity:.4f}\")\n    except TypeError as e:\n        # Older wheels don't know the 'preconditioner' kwarg \u2014 fall back without it.\n        if \"preconditioner\" in str(e) and pc is not None:\n            print(f\"  {label:18s}  SKIP \u2014 wheel predates preconditioner plumbing\")\n            records.append({\"solver\": label, \"t\": np.nan, \"iters\": np.nan,\n                            \"tau\": np.nan, \"ok\": False})\n            continue\n        raise\n    except Exception as e:\n        records.append({\"solver\": label, \"t\": np.nan, \"iters\": np.nan,\n                        \"tau\": np.nan, \"ok\": False})\n        print(f\"  {label:18s}  FAILED \u2014 {e}\")\n\ndf_solvers = pd.DataFrame(records)\ndf_solvers"
   },
   {
    "cell_type": "code",
@@ -827,11 +827,11 @@
     "ax1.set_yticks(y)\n",
     "ax1.set_yticklabels(df_solvers[\"solver\"])\n",
     "ax1.set_xlabel(\"Wall time (s)\", color=\"#2c3e50\")\n",
-    "ax1.set_title(f\"Solver comparison — 64³, best by wall time: {best_solver}\",\n",
+    "ax1.set_title(f\"Solver comparison \u2014 64\u00b3, best by wall time: {best_solver}\",\n",
     "              fontweight=\"bold\")\n",
     "ax1.invert_yaxis()\n",
     "\n",
-    "# Overlay iteration counts on a twin axis — this is the key diagnostic.\n",
+    "# Overlay iteration counts on a twin axis \u2014 this is the key diagnostic.\n",
     "# A solver with few iterations but expensive each (multigrid) can still\n",
     "# win overall; wall time alone hides that.\n",
     "ax2 = ax1.twiny()\n",
@@ -859,7 +859,7 @@
     "plt.tight_layout()\n",
     "plt.show()\n",
     "\n",
-    "# Flag solvers with few iterations — likely multigrid/preconditioned.\n",
+    "# Flag solvers with few iterations \u2014 likely multigrid/preconditioned.\n",
     "# If one converged in <10 iterations but is slower per iteration, it may\n",
     "# still be the better choice at larger problem sizes.\n",
     "low_iter = ok[ok[\"iters\"] < 10]\n",
@@ -869,13 +869,13 @@
     "        print(f\"  {r['solver']:10s}  {int(r['iters'])} iters  {r['t']:.2f}s\")\n",
     "    print(\"  These scale O(N) and will overtake PCG at larger grids.\")\n",
     "\n",
-    "print(f\"\\nBest solver at 64³ by wall time: {best_solver}\")\n"
+    "print(f\"\\nBest solver at 64\u00b3 by wall time: {best_solver}\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### 9b. Scaling validation — does the multigrid preconditioner restore O(N) compute?\n\n§3b found plain PCG scaling as `t(N) ~ N^1.76` — the dominant source of slow large-grid solves, well above any Python or binding overhead. Theory predicts that pairing PCG with a geometric multigrid preconditioner (PFMG or SMG) drops the iteration count to a near-constant, restoring near-linear `O(N)` scaling overall. AMReX's native MLMG is also `O(N)` by construction.\n\nThis cell fits `t = a · N^p` across 32³, 64³, 96³, and 128³ for three representative configurations:\n\n* **`pcg`** — plain conjugate gradient (the baseline, super-linear)\n* **`pcg+pfmg`** — PCG with HYPRE's PFMG preconditioner\n* **`mlmg`** — AMReX's native geometric multigrid\n\nThe test problem is a uniform phase-0 block (always percolates, trivially convergent) so each solve is cheap and the differences come purely from the algorithmic scaling.\n\nA `p` value below ~1.2 indicates near-linear scaling; the plain PCG baseline typically lands around `p ≈ 1.7–1.8`."
+   "source": "### 9b. Scaling validation \u2014 does the multigrid preconditioner restore O(N) compute?\n\n\u00a73b found plain PCG scaling as `t(N) ~ N^1.76` \u2014 the dominant source of slow large-grid solves, well above any Python or binding overhead. Theory predicts that pairing PCG with a geometric multigrid preconditioner (PFMG or SMG) drops the iteration count to a near-constant, restoring near-linear `O(N)` scaling overall. AMReX's native MLMG is also `O(N)` by construction.\n\nThis cell fits `t = a \u00b7 N^p` across 32\u00b3, 64\u00b3, 96\u00b3, and 128\u00b3 for three representative configurations:\n\n* **`pcg`** \u2014 plain conjugate gradient (the baseline, super-linear)\n* **`pcg+pfmg`** \u2014 PCG with HYPRE's PFMG preconditioner\n* **`mlmg`** \u2014 AMReX's native geometric multigrid\n\nThe test problem is a uniform phase-0 block (always percolates, trivially convergent) so each solve is cheap and the differences come purely from the algorithmic scaling.\n\nA `p` value below ~1.2 indicates near-linear scaling; the plain PCG baseline typically lands around `p \u2248 1.7\u20131.8`."
   },
   {
    "cell_type": "code",
@@ -893,7 +893,7 @@
     "scaling_records = []\n",
     "for label, kw in scaling_combos:\n",
     "    for N in scaling_sizes:\n",
-    "        arr = np.zeros((N, N, N), dtype=np.int32)  # uniform phase 0 — always percolates\n",
+    "        arr = np.zeros((N, N, N), dtype=np.int32)  # uniform phase 0 \u2014 always percolates\n",
     "        try:\n",
     "            t0 = time.perf_counter()\n",
     "            res = oi.tortuosity(arr, phase=0, direction=\"z\",\n",
@@ -904,10 +904,10 @@
     "                                    \"ok\": bool(res.solver_converged)})\n",
     "            print(f\"  {label:10s}  {N:3d}^3  t={dt:7.3f}s  iters={res.iterations:4d}\")\n",
     "        except TypeError as e:\n",
-    "            # Wheel predates the preconditioner kwarg — skip only those rows.\n",
+    "            # Wheel predates the preconditioner kwarg \u2014 skip only those rows.\n",
     "            msg = str(e)\n",
     "            if (\"preconditioner\" in msg) and (\"preconditioner\" in kw):\n",
-    "                print(f\"  {label:10s}  {N:3d}^3  SKIP — wheel predates preconditioner kwarg\")\n",
+    "                print(f\"  {label:10s}  {N:3d}^3  SKIP \u2014 wheel predates preconditioner kwarg\")\n",
     "                scaling_records.append({\"solver\": label, \"N\": N, \"t\": np.nan,\n",
     "                                        \"iters\": 0, \"ok\": False})\n",
     "                continue\n",
@@ -915,7 +915,7 @@
     "        except Exception as e:\n",
     "            scaling_records.append({\"solver\": label, \"N\": N, \"t\": np.nan,\n",
     "                                    \"iters\": 0, \"ok\": False})\n",
-    "            print(f\"  {label:10s}  {N:3d}^3  FAILED — {e}\")\n",
+    "            print(f\"  {label:10s}  {N:3d}^3  FAILED \u2014 {e}\")\n",
     "\n",
     "df_scale = pd.DataFrame(scaling_records)\n",
     "df_scale\n"
@@ -926,7 +926,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Fit t = a · N^p in log-log per solver, then overlay the curves with an\n# O(N) reference line and the O(N^1.76) baseline from §3b.\nfig, ax = plt.subplots(figsize=(9, 5.5))\npalette = {\"pcg\": \"#e74c3c\", \"pcg+pfmg\": \"#2ecc71\", \"mlmg\": \"#8e44ad\"}\nfit_results = {}\nfor label, _ in scaling_combos:\n    sub = df_scale[(df_scale[\"solver\"] == label) & df_scale[\"ok\"]].dropna(subset=[\"t\"])\n    if len(sub) < 2:\n        fit_results[label] = np.nan\n        continue\n    p, loga = np.polyfit(np.log(sub[\"N\"].astype(float)), np.log(sub[\"t\"].astype(float)), 1)\n    fit_results[label] = p\n    ax.loglog(sub[\"N\"], sub[\"t\"], \"o-\", color=palette.get(label, \"#333333\"),\n              markersize=8, linewidth=2, label=f\"{label}  (p={p:.2f})\")\n\n# Reference lines — anchored at the first successful measurement\nanchor = df_scale[df_scale[\"ok\"]].dropna(subset=[\"t\"]).sort_values(\"N\")\nif not anchor.empty:\n    N_anchor = float(anchor.iloc[0][\"N\"])\n    t_anchor = float(anchor.iloc[0][\"t\"])\n    Ns = np.array(scaling_sizes, dtype=float)\n    ax.loglog(Ns, t_anchor * (Ns / N_anchor) ** 1.0,\n              \"k--\", alpha=0.4, linewidth=1, label=\"O(N) reference\")\n    ax.loglog(Ns, t_anchor * (Ns / N_anchor) ** 1.76,\n              \"r:\", alpha=0.5, linewidth=1, label=\"O(N^1.76) (§3b baseline)\")\n\nax.set_xlabel(\"Grid size N  (domain = N^3)\")\nax.set_ylabel(\"Wall time (s)\")\nax.set_title(\"Scaling validation — multigrid vs. plain Krylov\",\n             fontweight=\"bold\")\nax.legend(loc=\"upper left\", framealpha=0.9)\nax.grid(True, which=\"both\", alpha=0.3)\nplt.tight_layout()\nplt.show()\n\n# Verdict against the near-linear target (p < 1.2)\nprint(\"\\nScaling exponents vs. near-linear target (p < 1.2):\")\nfor label, p in fit_results.items():\n    if np.isnan(p):\n        print(f\"  {label:10s}  n/a  (insufficient data)\")\n    elif p < 1.2:\n        print(f\"  {label:10s}  p = {p:.2f}  near-linear — target met\")\n    else:\n        print(f\"  {label:10s}  p = {p:.2f}  super-linear — target NOT met\")"
+   "source": "# Fit t = a \u00b7 N^p in log-log per solver, then overlay the curves with an\n# O(N) reference line and the O(N^1.76) baseline from \u00a73b.\nfig, ax = plt.subplots(figsize=(9, 5.5))\npalette = {\"pcg\": \"#e74c3c\", \"pcg+pfmg\": \"#2ecc71\", \"mlmg\": \"#8e44ad\"}\nfit_results = {}\nfor label, _ in scaling_combos:\n    sub = df_scale[(df_scale[\"solver\"] == label) & df_scale[\"ok\"]].dropna(subset=[\"t\"])\n    if len(sub) < 2:\n        fit_results[label] = np.nan\n        continue\n    p, loga = np.polyfit(np.log(sub[\"N\"].astype(float)), np.log(sub[\"t\"].astype(float)), 1)\n    fit_results[label] = p\n    ax.loglog(sub[\"N\"], sub[\"t\"], \"o-\", color=palette.get(label, \"#333333\"),\n              markersize=8, linewidth=2, label=f\"{label}  (p={p:.2f})\")\n\n# Reference lines \u2014 anchored at the first successful measurement\nanchor = df_scale[df_scale[\"ok\"]].dropna(subset=[\"t\"]).sort_values(\"N\")\nif not anchor.empty:\n    N_anchor = float(anchor.iloc[0][\"N\"])\n    t_anchor = float(anchor.iloc[0][\"t\"])\n    Ns = np.array(scaling_sizes, dtype=float)\n    ax.loglog(Ns, t_anchor * (Ns / N_anchor) ** 1.0,\n              \"k--\", alpha=0.4, linewidth=1, label=\"O(N) reference\")\n    ax.loglog(Ns, t_anchor * (Ns / N_anchor) ** 1.76,\n              \"r:\", alpha=0.5, linewidth=1, label=\"O(N^1.76) (\u00a73b baseline)\")\n\nax.set_xlabel(\"Grid size N  (domain = N^3)\")\nax.set_ylabel(\"Wall time (s)\")\nax.set_title(\"Scaling validation \u2014 multigrid vs. plain Krylov\",\n             fontweight=\"bold\")\nax.legend(loc=\"upper left\", framealpha=0.9)\nax.grid(True, which=\"both\", alpha=0.3)\nplt.tight_layout()\nplt.show()\n\n# Verdict against the near-linear target (p < 1.2)\nprint(\"\\nScaling exponents vs. near-linear target (p < 1.2):\")\nfor label, p in fit_results.items():\n    if np.isnan(p):\n        print(f\"  {label:10s}  n/a  (insufficient data)\")\n    elif p < 1.2:\n        print(f\"  {label:10s}  p = {p:.2f}  near-linear \u2014 target met\")\n    else:\n        print(f\"  {label:10s}  p = {p:.2f}  super-linear \u2014 target NOT met\")"
   },
   {
    "cell_type": "markdown",
@@ -934,7 +934,7 @@
    "source": [
     "## 10. `max_grid_size` tuning\n",
     "\n",
-    "Small boxes → better CPU cache + MPI parallelism. Large boxes → better\n",
+    "Small boxes \u2192 better CPU cache + MPI parallelism. Large boxes \u2192 better\n",
     "GPU kernel saturation. Sweep a few values with the best solver.\n"
    ]
   },
@@ -961,7 +961,7 @@
     "ax.plot(df_grid[\"max_grid_size\"], df_grid[\"t\"], \"o-\", linewidth=2, markersize=9)\n",
     "ax.set_xlabel(\"max_grid_size\")\n",
     "ax.set_ylabel(\"Wall time (s)\")\n",
-    "ax.set_title(f\"Grid sweep — 64³, solver={best_solver}\", fontweight=\"bold\")\n",
+    "ax.set_title(f\"Grid sweep \u2014 64\u00b3, solver={best_solver}\", fontweight=\"bold\")\n",
     "plt.tight_layout()\n",
     "plt.show()\n",
     "print(f\"Optimal max_grid_size: {best_gs}\")\n"
@@ -970,7 +970,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 11. Native-binary comparison — optional\n\nIf the native `Diffusion` executable is available on `PATH`, this cell runs it on the same data via a `tiff` dump and compares wall time against the equivalent `oi.tortuosity` call. The difference quantifies how much overhead the Python/pybind11 binding layer adds on top of the C++ solver.\n\nThis section is informational — a CTest-driven comparison lives at `tests/benchmarks/`. Skip if no native binary is available; §3 – §5 already isolate the binding-side cost."
+   "source": "## 11. Native-binary comparison \u2014 optional\n\nIf the native `Diffusion` executable is available on `PATH`, this cell runs it on the same data via a `tiff` dump and compares wall time against the equivalent `oi.tortuosity` call. The difference quantifies how much overhead the Python/pybind11 binding layer adds on top of the C++ solver.\n\nThis section is informational \u2014 a CTest-driven comparison lives at `tests/benchmarks/`. Skip if no native binary is available; \u00a73 \u2013 \u00a75 already isolate the binding-side cost."
   },
   {
    "cell_type": "code",
@@ -980,7 +980,7 @@
    "source": [
     "native = shutil.which(\"openimpala\")\n",
     "if not native:\n",
-    "    print(\"No native openimpala binary on PATH — skipping comparison.\")\n",
+    "    print(\"No native openimpala binary on PATH \u2014 skipping comparison.\")\n",
     "else:\n",
     "    import tifffile, tempfile, textwrap, os\n",
     "    tmp = tempfile.mkdtemp()\n",
@@ -1005,12 +1005,12 @@
     "    t_native = time.perf_counter() - t0\n",
     "\n",
     "    # The native binary exits non-zero on input/parse errors but still returns\n",
-    "    # quickly — don't compare that 0.1s \"win\" to a real Python solve.\n",
+    "    # quickly \u2014 don't compare that 0.1s \"win\" to a real Python solve.\n",
     "    if res.returncode != 0:\n",
     "        print(\"=\" * 70)\n",
-    "        print(f\"  ⚠  Native binary exited with code {res.returncode} in {t_native:.2f}s\")\n",
+    "        print(f\"  \u26a0  Native binary exited with code {res.returncode} in {t_native:.2f}s\")\n",
     "        print(\"=\" * 70)\n",
-    "        print(\"  It did NOT actually solve — skipping the comparison.\")\n",
+    "        print(\"  It did NOT actually solve \u2014 skipping the comparison.\")\n",
     "        print()\n",
     "        print(\"  stderr tail:\")\n",
     "        for line in (res.stderr or \"\").strip().splitlines()[-10:]:\n",
@@ -1023,7 +1023,7 @@
     "        print(\"  Likely cause: the native binary on PATH expects a different\")\n",
     "        print(\"  inputs-file schema than what this cell writes (field names or\")\n",
     "        print(\"  types differ between versions). Fix the inputs file to match,\")\n",
-    "        print(\"  or ignore this comparison — §3/§4 already prove the bindings\")\n",
+    "        print(\"  or ignore this comparison \u2014 \u00a73/\u00a74 already prove the bindings\")\n",
     "        print(\"  add negligible overhead.\")\n",
     "    else:\n",
     "        t0 = time.perf_counter()\n",
@@ -1049,7 +1049,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "# Headline numbers from the diagnostics above\nstage_total = stages[\"_total\"]\nstage_top = max((k for k in stages if not k.startswith(\"_\")), key=lambda k: stages[k])\nfixed_overhead = a_fit\nnaive_mean = float(np.mean(naive))\namort_mean = float(np.mean(amort))\n\nprint(\"=\" * 64)\nprint(\"  DIAGNOSIS\")\nprint(\"=\" * 64)\nprint(f\"  Build backend:                  {backend.upper()}\"\n      + (f\"   (host GPU: {gpu_name})\" if gpu_name else \"\"))\nprint(f\"  Single-call bottleneck:         {stage_top}\")\nprint(f\"                                  ({100*stages[stage_top]/stage_total:.1f}% of {stage_total:.2f}s)\")\nprint(f\"  Compute scaling:                O(N^{p_fit:.2f})\"\n      + (\"   (super-linear)\" if p_fit > 1.2 else \"\"))\nprint(f\"  Fixed per-call overhead (fit):  {fixed_overhead:.2f}s\"\n      + (\"   (no meaningful fixed cost)\" if not overhead_meaningful else \"\"))\nprint(f\"  Per-call rebuild tax:           {naive_mean - amort_mean:.2f}s \"\n      f\"({100*(naive_mean-amort_mean)/max(naive_mean,1e-9):.0f}% of naive call)\")\nprint(f\"  Best solver:                    {best_solver}\")\nprint(f\"  Best max_grid_size:             {best_gs}\")\nprint(\"=\" * 64)\n\n# Headline recommendation — the single most impactful change for this run\nprint(\"\\n  TOP RECOMMENDATION\")\nprint(\"  \" + \"-\" * 62)\nif gpu_name and not is_gpu_build:\n    print(f\"  A {gpu_name} is available but the installed wheel is CPU-only.\")\n    print(\"  Switch to openimpala-cuda for an expected 10–50× speedup on\")\n    print(\"  single-phase 3D diffusion at 128³+. Everything below is\")\n    print(\"  secondary until this is resolved.\")\nelif p_fit > 1.2:\n    print(f\"  Compute scales as O(N^{p_fit:.2f}). Plain Krylov iterations grow\")\n    print(\"  with problem size — switch to a multigrid preconditioner\")\n    print(\"  (PFMG/SMG via HYPRE, or AMReX MLMG) to restore O(N).\")\nelse:\n    print(f\"  Solver dominates wall time. Best configuration on this run:\")\n    print(f\"  solver={best_solver}, max_grid_size={best_gs}.\")\n    print(\"  Further speedup needs algorithmic changes or larger hardware.\")\n\n# Amortization recommendation — only fires when the rebuild tax is meaningful\nif naive_mean > 2 * amort_mean:\n    print()\n    print(\"  Per-call setup is a significant fraction of wall time. For sweeps,\")\n    print(\"  build the VoxelImage once and reuse it:\")\n    print()\n    print(\"    from openimpala.facade import _numpy_to_voxelimage\")\n    print(\"    from openimpala import _core\")\n    print(\"    img = _numpy_to_voxelimage(arr, max_grid_size)\")\n    print(\"    s   = _core.TortuosityHypre(img, vf, 0, d, st, '.', 0, 1, 0, False)\")\n    print(\"    s.value()\")\n    print()\n    print(\"  …rather than calling oi.tortuosity(numpy_array, ...) per iteration.\")"
+   "source": "# Headline numbers from the diagnostics above\nstage_total = stages[\"_total\"]\nstage_top = max((k for k in stages if not k.startswith(\"_\")), key=lambda k: stages[k])\nfixed_overhead = a_fit\nnaive_mean = float(np.mean(naive))\namort_mean = float(np.mean(amort))\n\nprint(\"=\" * 64)\nprint(\"  DIAGNOSIS\")\nprint(\"=\" * 64)\nprint(f\"  Build backend:                  {backend.upper()}\"\n      + (f\"   (host GPU: {gpu_name})\" if gpu_name else \"\"))\nprint(f\"  Single-call bottleneck:         {stage_top}\")\nprint(f\"                                  ({100*stages[stage_top]/stage_total:.1f}% of {stage_total:.2f}s)\")\nprint(f\"  Compute scaling:                O(N^{p_fit:.2f})\"\n      + (\"   (super-linear)\" if p_fit > 1.2 else \"\"))\nprint(f\"  Fixed per-call overhead (fit):  {fixed_overhead:.2f}s\"\n      + (\"   (no meaningful fixed cost)\" if not overhead_meaningful else \"\"))\nprint(f\"  Per-call rebuild tax:           {naive_mean - amort_mean:.2f}s \"\n      f\"({100*(naive_mean-amort_mean)/max(naive_mean,1e-9):.0f}% of naive call)\")\nprint(f\"  Best solver:                    {best_solver}\")\nprint(f\"  Best max_grid_size:             {best_gs}\")\nprint(\"=\" * 64)\n\n# Headline recommendation \u2014 the single most impactful change for this run\nprint(\"\\n  TOP RECOMMENDATION\")\nprint(\"  \" + \"-\" * 62)\nif gpu_name and not is_gpu_build:\n    print(f\"  A {gpu_name} is available but the installed wheel is CPU-only.\")\n    print(\"  Switch to openimpala-cuda for an expected 10\u201350\u00d7 speedup on\")\n    print(\"  single-phase 3D diffusion at 128\u00b3+. Everything below is\")\n    print(\"  secondary until this is resolved.\")\nelif p_fit > 1.2:\n    print(f\"  Compute scales as O(N^{p_fit:.2f}). Plain Krylov iterations grow\")\n    print(\"  with problem size \u2014 switch to a multigrid preconditioner\")\n    print(\"  (PFMG/SMG via HYPRE, or AMReX MLMG) to restore O(N).\")\nelse:\n    print(f\"  Solver dominates wall time. Best configuration on this run:\")\n    print(f\"  solver={best_solver}, max_grid_size={best_gs}.\")\n    print(\"  Further speedup needs algorithmic changes or larger hardware.\")\n\n# Amortization recommendation \u2014 only fires when the rebuild tax is meaningful\nif naive_mean > 2 * amort_mean:\n    print()\n    print(\"  Per-call setup is a significant fraction of wall time. For sweeps,\")\n    print(\"  build the VoxelImage once and reuse it:\")\n    print()\n    print(\"    from openimpala.facade import _numpy_to_voxelimage\")\n    print(\"    from openimpala import _core\")\n    print(\"    img = _numpy_to_voxelimage(arr, max_grid_size)\")\n    print(\"    s   = _core.TortuosityHypre(img, vf, 0, d, st, '.', 0, 1, 0, False)\")\n    print(\"    s.value()\")\n    print()\n    print(\"  \u2026rather than calling oi.tortuosity(numpy_array, ...) per iteration.\")"
   },
   {
    "cell_type": "code",

--- a/python/openimpala/facade.py
+++ b/python/openimpala/facade.py
@@ -153,43 +153,22 @@ def _ensure_initialized():
 def _parse_solver(s):
     """Parse a solver string or SolverType enum value.
 
-    The special value ``"auto"`` picks the best-fit default for the active
-    backend:
+    The special value ``"auto"`` selects PCG — the optimal solver for
+    single-phase steady-state diffusion (the Laplacian with harmonic-mean
+    face coefficients is symmetric positive-definite). Works on both CPU
+    and GPU wheels.
 
-    * On the CUDA wheel, MLMG (matrix-free AMReX geometric multigrid).
-      HYPRE 2.31's GPU support for SMG/PFMG is incomplete — the solve
-      crashes on T4 / A100 even when the matrix is correctly assembled.
-      MLMG bypasses HYPRE entirely and runs natively in AMReX device
-      kernels, so it sidesteps the upstream limitation.
-    * On the CPU wheel, PCG. The Laplacian with harmonic-mean face
-      coefficients is symmetric positive-definite, so the conjugate
-      gradient method is optimal.
-
-    Pass an explicit solver name (``"pcg"``, ``"flexgmres"``, etc.) to
-    override the auto-pick.
-
-    The value ``"mlmg"`` always selects the AMReX matrix-free path
-    regardless of backend.
+    The value ``"mlmg"`` selects AMReX's matrix-free geometric multigrid
+    solver. Bypasses HYPRE entirely; the most performant choice on GPU
+    hardware for structured-grid problems and fully matrix-free (no
+    assembly cost).
     """
     _core = _get_core()
     if isinstance(s, _core.SolverType):
         return s
-    key = s.strip().lower() if isinstance(s, str) else None
-
-    # "auto" resolves at runtime based on the build's GPU support.
-    if key == "auto":
-        try:
-            info = _core.build_info()
-            if info.get("backend") in ("cpp-cuda", "cpp-hip"):
-                return "mlmg"
-        except Exception:
-            pass
-        return _core.SolverType.PCG
-
     # "mlmg" is handled as a special string, not a SolverType enum
-    if key == "mlmg":
+    if isinstance(s, str) and s.strip().lower() == "mlmg":
         return "mlmg"
-
     solver_map = {
         "jacobi": _core.SolverType.Jacobi,
         "gmres": _core.SolverType.GMRES,
@@ -199,9 +178,11 @@ def _parse_solver(s):
         "smg": _core.SolverType.SMG,
         "pfmg": _core.SolverType.PFMG,
         "hypre": _core.SolverType.FlexGMRES,  # convenience alias
+        "auto": _core.SolverType.PCG,  # SPD-optimal for single-phase diffusion
     }
+    key = s.strip().lower()
     if key not in solver_map:
-        raise ValueError(f"Unknown solver '{s}'. Options: {list(solver_map) + ['mlmg', 'auto']}")
+        raise ValueError(f"Unknown solver '{s}'. Options: {list(solver_map) + ['mlmg']}")
     return solver_map[key]
 
 
@@ -390,21 +371,13 @@ def tortuosity(
     direction : str or Direction
         Flow direction ('x', 'y', 'z').
     solver : str or SolverType
-        Solver algorithm.  ``'auto'`` (default) picks the best fit for the
-        active backend:
-
-        * **GPU build (openimpala-cuda)** — MLMG.  HYPRE 2.31's GPU support
-          for SMG/PFMG is incomplete (the solve crashes on T4/A100 even
-          when the matrix assembles correctly), so the auto-pick on GPU
-          bypasses HYPRE entirely with AMReX's matrix-free MLMG.
-        * **CPU build (openimpala)** — HYPRE PCG.  The Laplacian with
-          harmonic-mean face coefficients is symmetric positive-definite,
-          so conjugate gradient is optimal.
-
-        Override with an explicit name to force a particular solver:
-        ``'mlmg'``, ``'pcg'``, ``'flexgmres'``, ``'gmres'``, ``'bicgstab'``,
-        ``'smg'``, ``'pfmg'``, ``'jacobi'``.  The HYPRE solvers may segfault
-        on the GPU wheel — see the auto-pick note above.
+        Solver algorithm.  ``'auto'`` (default) selects HYPRE PCG, the
+        optimal choice for the symmetric Poisson-like operator with
+        harmonic-mean face coefficients on both CPU and GPU.  ``'mlmg'``
+        uses AMReX's matrix-free geometric multigrid (often the fastest
+        option on GPU hardware).  Other HYPRE options: ``'flexgmres'``,
+        ``'gmres'``, ``'bicgstab'``, ``'pcg'``, ``'smg'``, ``'pfmg'``,
+        ``'jacobi'``.
     preconditioner : str or PrecondType, keyword-only
         Multigrid preconditioner for Krylov solvers (PCG/GMRES/FlexGMRES/BiCGSTAB):
         ``'pfmg'`` (default) or ``'smg'``.  Ignored for standalone SMG/PFMG/Jacobi

--- a/python/openimpala/facade.py
+++ b/python/openimpala/facade.py
@@ -153,19 +153,43 @@ def _ensure_initialized():
 def _parse_solver(s):
     """Parse a solver string or SolverType enum value.
 
-    The special value ``"auto"`` selects PCG — the optimal solver for
-    single-phase steady-state diffusion (the Laplacian with harmonic-mean
-    face coefficients is symmetric positive-definite).
+    The special value ``"auto"`` picks the best-fit default for the active
+    backend:
 
-    The value ``"mlmg"`` selects the matrix-free AMReX MLMG solver,
-    which avoids explicit matrix assembly and uses less memory.
+    * On the CUDA wheel, MLMG (matrix-free AMReX geometric multigrid).
+      HYPRE 2.31's GPU support for SMG/PFMG is incomplete — the solve
+      crashes on T4 / A100 even when the matrix is correctly assembled.
+      MLMG bypasses HYPRE entirely and runs natively in AMReX device
+      kernels, so it sidesteps the upstream limitation.
+    * On the CPU wheel, PCG. The Laplacian with harmonic-mean face
+      coefficients is symmetric positive-definite, so the conjugate
+      gradient method is optimal.
+
+    Pass an explicit solver name (``"pcg"``, ``"flexgmres"``, etc.) to
+    override the auto-pick.
+
+    The value ``"mlmg"`` always selects the AMReX matrix-free path
+    regardless of backend.
     """
     _core = _get_core()
     if isinstance(s, _core.SolverType):
         return s
+    key = s.strip().lower() if isinstance(s, str) else None
+
+    # "auto" resolves at runtime based on the build's GPU support.
+    if key == "auto":
+        try:
+            info = _core.build_info()
+            if info.get("backend") in ("cpp-cuda", "cpp-hip"):
+                return "mlmg"
+        except Exception:
+            pass
+        return _core.SolverType.PCG
+
     # "mlmg" is handled as a special string, not a SolverType enum
-    if isinstance(s, str) and s.strip().lower() == "mlmg":
+    if key == "mlmg":
         return "mlmg"
+
     solver_map = {
         "jacobi": _core.SolverType.Jacobi,
         "gmres": _core.SolverType.GMRES,
@@ -175,11 +199,9 @@ def _parse_solver(s):
         "smg": _core.SolverType.SMG,
         "pfmg": _core.SolverType.PFMG,
         "hypre": _core.SolverType.FlexGMRES,  # convenience alias
-        "auto": _core.SolverType.PCG,  # SPD-optimal for single-phase diffusion
     }
-    key = s.strip().lower()
     if key not in solver_map:
-        raise ValueError(f"Unknown solver '{s}'. Options: {list(solver_map) + ['mlmg']}")
+        raise ValueError(f"Unknown solver '{s}'. Options: {list(solver_map) + ['mlmg', 'auto']}")
     return solver_map[key]
 
 
@@ -368,12 +390,21 @@ def tortuosity(
     direction : str or Direction
         Flow direction ('x', 'y', 'z').
     solver : str or SolverType
-        Solver algorithm.  ``'auto'`` (default) selects the best available
-        solver: CuPy CG on GPU or SciPy CG on CPU when the C++ backend is
-        not installed, HYPRE PCG otherwise.  ``'mlmg'`` uses AMReX's native
-        matrix-free geometric multigrid (requires C++ backend).  Other HYPRE
-        options: ``'flexgmres'``, ``'gmres'``, ``'bicgstab'``, ``'pcg'``,
-        ``'smg'``, ``'pfmg'``, ``'jacobi'``.
+        Solver algorithm.  ``'auto'`` (default) picks the best fit for the
+        active backend:
+
+        * **GPU build (openimpala-cuda)** — MLMG.  HYPRE 2.31's GPU support
+          for SMG/PFMG is incomplete (the solve crashes on T4/A100 even
+          when the matrix assembles correctly), so the auto-pick on GPU
+          bypasses HYPRE entirely with AMReX's matrix-free MLMG.
+        * **CPU build (openimpala)** — HYPRE PCG.  The Laplacian with
+          harmonic-mean face coefficients is symmetric positive-definite,
+          so conjugate gradient is optimal.
+
+        Override with an explicit name to force a particular solver:
+        ``'mlmg'``, ``'pcg'``, ``'flexgmres'``, ``'gmres'``, ``'bicgstab'``,
+        ``'smg'``, ``'pfmg'``, ``'jacobi'``.  The HYPRE solvers may segfault
+        on the GPU wheel — see the auto-pick note above.
     preconditioner : str or PrecondType, keyword-only
         Multigrid preconditioner for Krylov solvers (PCG/GMRES/FlexGMRES/BiCGSTAB):
         ``'pfmg'`` (default) or ``'smg'``.  Ignored for standalone SMG/PFMG/Jacobi

--- a/src/props/EffectiveDiffusivityHypre.cpp
+++ b/src/props/EffectiveDiffusivityHypre.cpp
@@ -408,7 +408,13 @@ void EffectiveDiffusivityHypre::setupMatrixEquation() {
     std::vector<amrex::Real> initial_guess_buffer;
 
 #ifdef OPENIMPALA_USE_GPU
-    // GPU path: use device-resident buffers and ParallelFor kernel
+    // GPU path: keep matrix data device-resident end-to-end. With
+    // HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE) configured in the base
+    // class's createMatrixAndVectors, HYPRE expects device pointers in
+    // SetBoxValues — pass d_matrix.data() / d_rhs.data() / d_xinit.data()
+    // directly with no host roundtrip. effDiffFillMatrixGpu handles BCs
+    // in-kernel so there's no need to bounce to host like TortuosityHypre
+    // does.
     for (amrex::MFIter mfi(m_mf_active_mask); mfi.isValid(); ++mfi) {
         const amrex::Box& valid_bx = mfi.validbox();
         const int npts_valid = static_cast<int>(valid_bx.numPts());
@@ -427,29 +433,17 @@ void EffectiveDiffusivityHypre::setupMatrixEquation() {
                                          mask_arr, dc_arr, m_dx.dataPtr(), current_dir_int);
         amrex::Gpu::streamSynchronize();
 
-        // Copy device buffers to host for HYPRE SetBoxValues
-        matrix_values_buffer.resize(mtx_size);
-        rhs_values_buffer.resize(npts_valid);
-        initial_guess_buffer.resize(npts_valid);
-        amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_matrix.begin(), d_matrix.end(),
-                         matrix_values_buffer.begin());
-        amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_rhs.begin(), d_rhs.end(),
-                         rhs_values_buffer.begin());
-        amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_xinit.begin(), d_xinit.end(),
-                         initial_guess_buffer.begin());
-
         auto hypre_lo_valid = EffectiveDiffusivityHypre::loV(valid_bx);
         auto hypre_hi_valid = EffectiveDiffusivityHypre::hiV(valid_bx);
 
         ierr = HYPRE_StructMatrixSetBoxValues(m_A, hypre_lo_valid.data(), hypre_hi_valid.data(),
-                                              stencil_size, stencil_indices_hypre,
-                                              matrix_values_buffer.data());
+                                              stencil_size, stencil_indices_hypre, d_matrix.data());
         HYPRE_CHECK(ierr);
         ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo_valid.data(), hypre_hi_valid.data(),
-                                              rhs_values_buffer.data());
+                                              d_rhs.data());
         HYPRE_CHECK(ierr);
         ierr = HYPRE_StructVectorSetBoxValues(m_x, hypre_lo_valid.data(), hypre_hi_valid.data(),
-                                              initial_guess_buffer.data());
+                                              d_xinit.data());
         HYPRE_CHECK(ierr);
     }
 #else
@@ -700,40 +694,37 @@ void EffectiveDiffusivityHypre::getChiSolution(amrex::MultiFab& chi_field) {
     AMREX_ALWAYS_ASSERT(chi_field.boxArray() == m_ba);
     AMREX_ALWAYS_ASSERT(chi_field.DistributionMap() == m_dm);
 
+    // HYPRE_MEMORY_DEVICE on CUDA → GetBoxValues writes to a device pointer,
+    // and chi_arr below is also device-resident, so on GPU we want HYPRE to
+    // drop the solution straight into a device buffer with no host bounce.
     // No OMP: HYPRE_StructVectorGetBoxValues is not thread-safe for the same vector.
-    std::vector<amrex::Real> soln_buffer;
+    std::vector<amrex::Real> soln_buffer_host;
     for (amrex::MFIter mfi(chi_field, false); mfi.isValid(); ++mfi) {
         const amrex::Box& bx_getsol = mfi.validbox();
         const int npts = static_cast<int>(bx_getsol.numPts());
         if (npts == 0)
             continue;
 
-        soln_buffer.resize(npts);
-
         auto hypre_lo = EffectiveDiffusivityHypre::loV(bx_getsol);
         auto hypre_hi = EffectiveDiffusivityHypre::hiV(bx_getsol);
 
+#ifdef AMREX_USE_GPU
+        amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
         HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
-                                                            soln_buffer.data());
+                                                            d_soln_buffer.data());
+        const HYPRE_Real* src_ptr = d_soln_buffer.data();
+#else
+        soln_buffer_host.resize(npts);
+        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
+                                                            soln_buffer_host.data());
+        const HYPRE_Real* src_ptr = soln_buffer_host.data();
+#endif
         if (get_ierr != 0) {
             amrex::Warning("HYPRE_StructVectorGetBoxValues failed during getChiSolution!");
             chi_field[mfi].template setVal<amrex::RunOn::Host>(0.0, bx_getsol, ChiComp,
                                                                numComponentsChi);
             continue;
         }
-
-        // Stage HYPRE's host soln_buffer in device memory; chi_arr is an
-        // Array4 view into chi_field which on CUDA builds lives in device
-        // memory, so writing through it from a host loop segfaults.
-#ifdef AMREX_USE_GPU
-        amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
-        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, soln_buffer.data(),
-                              soln_buffer.data() + npts, d_soln_buffer.data());
-        amrex::Gpu::streamSynchronize();
-        const HYPRE_Real* src_ptr = d_soln_buffer.data();
-#else
-        const HYPRE_Real* src_ptr = soln_buffer.data();
-#endif
         amrex::Array4<amrex::Real> const chi_arr = chi_field.array(mfi);
         const int chi_comp = ChiComp;
         const auto lo = amrex::lbound(bx_getsol);

--- a/src/props/HypreStructSolver.cpp
+++ b/src/props/HypreStructSolver.cpp
@@ -169,17 +169,21 @@ void HypreStructSolver::createMatrixAndVectors() {
     HYPRE_CHECK(ierr);
 
 #ifdef OPENIMPALA_USE_GPU
-    // GPU kernels compute on device and copy results to host before calling
-    // HYPRE_StructSetBoxValues with host pointers. Therefore HYPRE matrix
-    // and vector storage must remain on the host (HYPRE_MEMORY_HOST) so that
-    // SetBoxValues receives compatible pointers.  Only the execution policy
-    // is set to device so that HYPRE's own internal solver operations can
-    // run on the GPU when HYPRE is built with device support.
+    // HYPRE 2.31's structured solvers (PFMG/SMG/PCG/GMRES on GPU) require
+    // BOTH the memory location AND the execution policy to be DEVICE — the
+    // mixed configuration (HOST memory + DEVICE execution) compiles and the
+    // matrix assembles, but the actual iterative solve crashes inside the
+    // HYPRE coarsening/smoothing kernels on T4/A100. setupMatrixEquation()
+    // therefore passes device pointers to HYPRE_StructMatrixSetBoxValues
+    // and HYPRE_StructVectorSetBoxValues; HYPRE will store and operate on
+    // the data entirely on the device.
+    HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
     HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
 
     if (m_verbose > 1 && amrex::ParallelDescriptor::IOProcessor()) {
-        amrex::Print() << "  createMatrixAndVectors: HYPRE execution policy set to DEVICE."
-                       << std::endl;
+        amrex::Print()
+            << "  createMatrixAndVectors: HYPRE memory location and execution policy set to DEVICE."
+            << std::endl;
     }
 #endif
 

--- a/src/props/TortuosityHypre.cpp
+++ b/src/props/TortuosityHypre.cpp
@@ -512,15 +512,25 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation() {
     std::vector<amrex::Real> initial_guess;
 
 #ifdef OPENIMPALA_USE_GPU
-    // GPU path: use device-resident buffers and ParallelFor kernel.
-    // BCs are applied on the CPU side after the GPU kernel fills the interior.
+    // GPU path: keep matrix data device-resident end-to-end. HYPRE 2.31's
+    // structured solvers crash on device data when the memory location is
+    // HOST but execution policy is DEVICE — see HypreStructSolver::
+    // createMatrixAndVectors for the matching HYPRE_SetMemoryLocation
+    // call. We:
+    //   1. Allocate device buffers for matrix / RHS / initial guess.
+    //   2. Run tortuosityFillMatrixGpu kernel to populate the interior.
+    //   3. Bounce briefly to host to apply BCs (BC code is host-only) —
+    //      copy device→host, snapshot mask/dc to host, run applyBC, copy
+    //      results host→device.
+    //   4. Pass the *device* pointer to HYPRE_StructMatrixSetBoxValues etc.
+    //      With HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE) set, HYPRE
+    //      stores and operates on the data entirely on the GPU.
     for (amrex::MFIter mfi(m_mf_phase); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.validbox();
         const int npts = static_cast<int>(bx.numPts());
         if (npts == 0)
             continue;
 
-        // Allocate device buffers via AMReX arena
         const size_t mtx_size = static_cast<size_t>(npts) * stencil_size;
         amrex::Gpu::DeviceVector<amrex::Real> d_matrix(mtx_size);
         amrex::Gpu::DeviceVector<amrex::Real> d_rhs(npts);
@@ -529,13 +539,13 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation() {
         const auto mask_arr = m_mf_active_mask.const_array(mfi, MaskComp);
         const auto dc_arr = m_mf_diff_coeff.const_array(mfi, 0);
 
-        // GPU kernel: fills interior stencil (no BCs)
+        // Step 1+2: GPU kernel fills the interior stencil.
         OpenImpala::tortuosityFillMatrixGpu(bx, d_matrix.data(), d_rhs.data(), d_xinit.data(),
                                             mask_arr, dc_arr, domain.loVect(), domain.hiVect(),
                                             dxinv_sq.data(), m_vlo, m_vhi, dir_int);
         amrex::Gpu::streamSynchronize();
 
-        // Copy to host for BC application (BCs are small surface ops, CPU is fine)
+        // Step 3: bounce to host for BC application.
         matrix_values.resize(mtx_size);
         rhs_values.resize(npts);
         initial_guess.resize(npts);
@@ -545,12 +555,8 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation() {
         amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_xinit.begin(), d_xinit.end(),
                          initial_guess.begin());
 
-        // The host-side BC functions below dereference mask_ptr / dc_ptr
-        // directly, so the underlying memory must be host-accessible.
-        // m_mf_active_mask[mfi].dataPtr() and m_mf_diff_coeff[mfi].dataPtr()
-        // return DEVICE pointers on CUDA builds — passing those to a CPU
-        // function reading through them segfaults. Snapshot the relevant
-        // component(s) device → host before the BC pass.
+        // mask_iab/dc_fab dataPtr() returns device pointers; snapshot to
+        // host vectors so applyBC can dereference them safely.
         const amrex::IArrayBox& mask_iab = m_mf_active_mask[mfi];
         const amrex::FArrayBox& dc_fab = m_mf_diff_coeff[mfi];
         const auto& mask_box = mask_iab.box();
@@ -582,17 +588,26 @@ void OpenImpala::TortuosityHypre::setupMatrixEquation() {
                                 dir_int);
         }
 
+        // Step 4a: push BC-applied values back to device buffers.
+        amrex::Gpu::copy(amrex::Gpu::hostToDevice, matrix_values.begin(), matrix_values.end(),
+                         d_matrix.begin());
+        amrex::Gpu::copy(amrex::Gpu::hostToDevice, rhs_values.begin(), rhs_values.end(),
+                         d_rhs.begin());
+        amrex::Gpu::copy(amrex::Gpu::hostToDevice, initial_guess.begin(), initial_guess.end(),
+                         d_xinit.begin());
+        amrex::Gpu::streamSynchronize();
+
         auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
         auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
 
+        // Step 4b: hand DEVICE pointers to HYPRE.
         ierr = HYPRE_StructMatrixSetBoxValues(m_A, hypre_lo.data(), hypre_hi.data(), stencil_size,
-                                              stencil_indices, matrix_values.data());
+                                              stencil_indices, d_matrix.data());
         HYPRE_CHECK(ierr);
-        ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(),
-                                              rhs_values.data());
+        ierr = HYPRE_StructVectorSetBoxValues(m_b, hypre_lo.data(), hypre_hi.data(), d_rhs.data());
         HYPRE_CHECK(ierr);
-        ierr = HYPRE_StructVectorSetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
-                                              initial_guess.data());
+        ierr =
+            HYPRE_StructVectorSetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(), d_xinit.data());
         HYPRE_CHECK(ierr);
     }
 #else
@@ -674,32 +689,30 @@ bool OpenImpala::TortuosityHypre::solve() {
         amrex::MultiFab mf_plot(m_ba, m_dm, numComponentsPhi, 0);
         amrex::MultiFab mf_soln_temp(m_ba, m_dm, 1, 0);
         mf_soln_temp.setVal(0.0);
+        // HYPRE_MEMORY_DEVICE on CUDA → GetBoxValues writes to a device pointer.
         // No OMP: HYPRE_StructVectorGetBoxValues is not thread-safe for the same vector.
-        std::vector<HYPRE_Real> soln_buffer;
+        std::vector<HYPRE_Real> soln_buffer_host;
         for (amrex::MFIter mfi(mf_soln_temp, false); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.validbox();
             const int npts = static_cast<int>(bx.numPts());
             if (npts == 0)
                 continue;
-            soln_buffer.resize(npts);
             auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
             auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
+#ifdef AMREX_USE_GPU
+            amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
             HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(
-                m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer.data());
+                m_x, hypre_lo.data(), hypre_hi.data(), d_soln_buffer.data());
+            const HYPRE_Real* src_ptr = d_soln_buffer.data();
+#else
+            soln_buffer_host.resize(npts);
+            HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(
+                m_x, hypre_lo.data(), hypre_hi.data(), soln_buffer_host.data());
+            const HYPRE_Real* src_ptr = soln_buffer_host.data();
+#endif
             if (get_ierr != 0) {
                 amrex::Warning("HYPRE_StructVectorGetBoxValues failed during plotfile writing!");
             }
-            // Same host-buffer-into-device-Array4 pattern as the flux-calc
-            // writeback below; stage in a DeviceVector and ParallelFor.
-#ifdef AMREX_USE_GPU
-            amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, soln_buffer.data(),
-                                  soln_buffer.data() + npts, d_soln_buffer.data());
-            amrex::Gpu::streamSynchronize();
-            const HYPRE_Real* src_ptr = d_soln_buffer.data();
-#else
-            const HYPRE_Real* src_ptr = soln_buffer.data();
-#endif
             amrex::Array4<amrex::Real> const soln_arr = mf_soln_temp.array(mfi);
             const auto lo = amrex::lbound(bx);
             const int nx_box = bx.length(0);
@@ -737,26 +750,26 @@ bool OpenImpala::TortuosityHypre::solve() {
         amrex::MultiFab mf_plot_fail(m_ba, m_dm, numComponentsPhi, 0);
         amrex::MultiFab mf_soln_fail(m_ba, m_dm, 1, 0);
         mf_soln_fail.setVal(0.0);
+        // HYPRE_MEMORY_DEVICE on CUDA → GetBoxValues writes to a device pointer.
         // No OMP: HYPRE_StructVectorGetBoxValues is not thread-safe for the same vector.
-        std::vector<HYPRE_Real> soln_buf_fail;
+        std::vector<HYPRE_Real> soln_buf_fail_host;
         for (amrex::MFIter mfi(mf_soln_fail, false); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.validbox();
             const int npts = static_cast<int>(bx.numPts());
             if (npts == 0)
                 continue;
-            soln_buf_fail.resize(npts);
             auto hypre_lo_f = OpenImpala::TortuosityHypre::loV(bx);
             auto hypre_hi_f = OpenImpala::TortuosityHypre::hiV(bx);
-            HYPRE_StructVectorGetBoxValues(m_x, hypre_lo_f.data(), hypre_hi_f.data(),
-                                           soln_buf_fail.data());
 #ifdef AMREX_USE_GPU
             amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buf_fail(npts);
-            amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, soln_buf_fail.data(),
-                                  soln_buf_fail.data() + npts, d_soln_buf_fail.data());
-            amrex::Gpu::streamSynchronize();
+            HYPRE_StructVectorGetBoxValues(m_x, hypre_lo_f.data(), hypre_hi_f.data(),
+                                           d_soln_buf_fail.data());
             const HYPRE_Real* src_ptr_fail = d_soln_buf_fail.data();
 #else
-            const HYPRE_Real* src_ptr_fail = soln_buf_fail.data();
+            soln_buf_fail_host.resize(npts);
+            HYPRE_StructVectorGetBoxValues(m_x, hypre_lo_f.data(), hypre_hi_f.data(),
+                                           soln_buf_fail_host.data());
+            const HYPRE_Real* src_ptr_fail = soln_buf_fail_host.data();
 #endif
             amrex::Array4<amrex::Real> const soln_arr = mf_soln_fail.array(mfi);
             const auto lo_f = amrex::lbound(bx);
@@ -1173,37 +1186,35 @@ void OpenImpala::TortuosityHypre::global_fluxes() {
     const amrex::Real* dx = m_geom.CellSize();
     const int idir = static_cast<int>(m_dir);
 
-    // Solution copy logic remains the same...
+    // Pull HYPRE's solution back into an AMReX MultiFab for downstream flux
+    // integration. Since HYPRE_SetMemoryLocation is set to DEVICE on CUDA
+    // builds, GetBoxValues expects a device pointer; on CPU it's a host
+    // std::vector.
     amrex::MultiFab mf_soln_temp(m_ba, m_dm, 1, 1);
     mf_soln_temp.setVal(0.0);
     // No OMP: HYPRE_StructVectorGetBoxValues is not thread-safe for the same vector.
-    std::vector<HYPRE_Real> soln_buffer;
+    std::vector<HYPRE_Real> soln_buffer_host;
     for (amrex::MFIter mfi(mf_soln_temp, false); mfi.isValid(); ++mfi) {
         const amrex::Box& bx = mfi.validbox();
         const int npts = static_cast<int>(bx.numPts());
         if (npts == 0)
             continue;
-        soln_buffer.resize(npts);
         auto hypre_lo = OpenImpala::TortuosityHypre::loV(bx);
         auto hypre_hi = OpenImpala::TortuosityHypre::hiV(bx);
+#ifdef AMREX_USE_GPU
+        amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
         HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
-                                                            soln_buffer.data());
+                                                            d_soln_buffer.data());
+        const HYPRE_Real* src_ptr = d_soln_buffer.data();
+#else
+        soln_buffer_host.resize(npts);
+        HYPRE_Int get_ierr = HYPRE_StructVectorGetBoxValues(m_x, hypre_lo.data(), hypre_hi.data(),
+                                                            soln_buffer_host.data());
+        const HYPRE_Real* src_ptr = soln_buffer_host.data();
+#endif
         if (get_ierr != 0) {
             amrex::Warning("HYPRE_StructVectorGetBoxValues failed during flux calculation copy!");
         }
-        // Stage HYPRE's host-side soln_buffer in device memory before writing it
-        // through the iMultiFab Array4 view, which on CUDA builds points at GPU
-        // memory. A bare LoopOnCpu writing soln_arr(ii,jj,kk,0) = ... segfaults
-        // on T4 / A100 / etc.
-#ifdef AMREX_USE_GPU
-        amrex::Gpu::DeviceVector<HYPRE_Real> d_soln_buffer(npts);
-        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, soln_buffer.data(),
-                              soln_buffer.data() + npts, d_soln_buffer.data());
-        amrex::Gpu::streamSynchronize();
-        const HYPRE_Real* src_ptr = d_soln_buffer.data();
-#else
-        const HYPRE_Real* src_ptr = soln_buffer.data();
-#endif
         amrex::Array4<amrex::Real> const soln_arr = mf_soln_temp.array(mfi);
         const auto lo = amrex::lbound(bx);
         const int nx_box = bx.length(0);


### PR DESCRIPTION
Replaces the stopgap auto-pick-MLMG-on-GPU from https://github.com/BASE-Laboratory/OpenImpala/commit/3099163caf3c9a2da5bfb09acfded174c5caec0d with a real fix
to HYPRE-CUDA so all solvers work on the GPU wheel, restoring the §9
solver comparison the notebook is designed for.

Root cause of the GPU crashes: HypreStructSolver::createMatrixAndVectors
left HYPRE_SetMemoryLocation at the default (HYPRE_MEMORY_HOST) but set
HYPRE_SetExecutionPolicy to DEVICE. The setupMatrixEquation path then
fed host-pointer matrix/RHS/initial-guess buffers to
HYPRE_StructMatrixSetBoxValues / HYPRE_StructVectorSetBoxValues, which
HYPRE assembled host-side. Then runSolver() / HYPRE_Struct*Solve tried
to operate on that host data under the device execution policy, and
HYPRE 2.31's structured solvers (PFMG/SMG/PCG/GMRES) crash inside their
coarsening/smoothing kernels when the data isn't where the policy says
it should be.

The proper config for HYPRE-CUDA is BOTH the memory location AND the
execution policy on DEVICE, with device pointers fed to SetBoxValues
and GetBoxValues. This commit:

  src/props/HypreStructSolver.cpp
    Add HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE) alongside the
    existing HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE).

  src/props/TortuosityHypre.cpp::setupMatrixEquation (GPU branch)
    Keep d_matrix/d_rhs/d_xinit DeviceVectors device-resident. Bounce
    briefly to host vectors only for the BC pass (BC code is host-only),
    then push host buffers back to the same DeviceVectors and pass the
    device pointer to HYPRE_StructMatrixSetBoxValues. One extra
    host->device copy per box vs the old code; trivial relative to
    the matrix fill.

  src/props/TortuosityHypre.cpp::value() / global_fluxes() / solve plotfile
    HYPRE_StructVectorGetBoxValues now writes directly into a device
    DeviceVector on GPU (no host bounce). The downstream ParallelFor
    that copies into mf_soln_temp reads through the device pointer
    naturally — no behaviour change other than removing the
    host->device staging that was no longer needed.

  src/props/EffectiveDiffusivityHypre.cpp::setupMatrixEquation (GPU branch)
    Same recipe: pass d_matrix.data() etc. directly to SetBoxValues.
    EffDiff's effDiffFillMatrixGpu handles BCs in-kernel so no host
    bounce is needed at all; the GPU branch now has zero host roundtrips.

  src/props/EffectiveDiffusivityHypre.cpp::getChiSolution
    GetBoxValues writes into device DeviceVector; subsequent ParallelFor
    reads through it.

  python/openimpala/facade.py
    Revert auto-pick to PCG (was: pick MLMG on GPU, which was the
    stopgap). PCG is the SPD-optimal choice on both CPU and GPU now
    that HYPRE-CUDA is properly configured. Update tortuosity()
    docstring to remove the "HYPRE may segfault on GPU" warning.

  notebooks/profiling_and_tuning.ipynb §9
    Drop the is_gpu_build SMG-filter. With HYPRE-CUDA configured
    correctly, all 10 solver/preconditioner combos work on both CPU
    and GPU. Updated markdown to reflect: SMG works but PFMG is
    typically faster (no longer "PFMG works, SMG segfaults").

Result on 4.2.16 (next release):

  oi.tortuosity(arr)                       → PCG, works on CPU + GPU
  oi.tortuosity(arr, solver='mlmg')        → MLMG, fastest on GPU
  oi.tortuosity(arr, solver='smg')         → works on GPU
  oi.tortuosity(arr, solver='pfmg')        → works on GPU
  oi.tortuosity(arr, preconditioner='smg') → works on GPU
  All §9 comparison cells produce real timings, no crashes.