### PR TITLE
revert Krylov default preconditioner from PFMG back to SMG

### DIFF
--- a/python/bindings/solvers.cpp
+++ b/python/bindings/solvers.cpp
@@ -42,7 +42,7 @@ void init_solvers(py::module_& m) {
              py::arg("img"), py::arg("vf"), py::arg("phase"), py::arg("dir"),
              py::arg("solver_type"), py::arg("results_path"), py::arg("vlo") = 0.0,
              py::arg("vhi") = 1.0, py::arg("verbose") = 0, py::arg("write_plotfile") = false,
-             py::arg("preconditioner") = OpenImpala::PrecondType::PFMG,
+             py::arg("preconditioner") = OpenImpala::PrecondType::SMG,
              // keep VoxelImage alive while this object lives
              py::keep_alive<1, 2>())
 

--- a/python/openimpala/facade.py
+++ b/python/openimpala/facade.py
@@ -352,7 +352,7 @@ def tortuosity(
     direction: Union[str, "Direction"] = "x",
     solver: Union[str, "SolverType"] = "auto",
     *,
-    preconditioner: Union[str, "PrecondType"] = "pfmg",
+    preconditioner: Union[str, "PrecondType"] = "smg",
     max_grid_size: Union[int, str] = 32,
     results_path: str = ".",
     verbose: int = 0,
@@ -380,12 +380,12 @@ def tortuosity(
         ``'jacobi'``.
     preconditioner : str or PrecondType, keyword-only
         Multigrid preconditioner for Krylov solvers (PCG/GMRES/FlexGMRES/BiCGSTAB):
-        ``'pfmg'`` (default) or ``'smg'``.  Ignored for standalone SMG/PFMG/Jacobi
-        and for MLMG.  PFMG is the default because it has full GPU support in
-        HYPRE; SMG only has partial GPU support and may segfault on the CUDA wheel.
-        On CPU builds either works.  PCG+PFMG is typically the best combination
-        for large grids — plain PCG scales super-linearly with N, a multigrid
-        preconditioner restores near-O(N) scaling.
+        ``'smg'`` (default) or ``'pfmg'``.  Ignored for standalone SMG/PFMG/Jacobi
+        and for MLMG.  SMG is the default because its point-based smoothing
+        handles the decoupled inactive rows that arise from masked porous-media
+        inputs; PFMG's semicoarsening tends to stall on those rows and may not
+        converge.  Use PFMG for fully-active grids (no masked cells) — it scales
+        better.  Both work on CPU and GPU.
     max_grid_size : int or str
         AMReX box decomposition size.  ``'auto'`` picks a value based on the
         domain dimensions.

--- a/src/props/HypreStructSolver.H
+++ b/src/props/HypreStructSolver.H
@@ -28,14 +28,18 @@ namespace OpenImpala {
 
 /** @brief Preconditioner type for HYPRE Krylov solvers.
  *
- *  PFMG is the default because it has full GPU support in HYPRE 2.31; SMG
- *  is only partially supported on device (the coarsening uses CPU code
- *  paths in several HYPRE configurations and segfaults on device-resident
- *  data). On CPU builds either works equivalently for structured Poisson.
+ *  SMG is the default because its point-based smoothing handles the
+ *  decoupled rows that arise from masked cells (inactive cells have
+ *  ``A_ii=1, b_i=0``, which PFMG's semicoarsening fails to coarsen
+ *  meaningfully — symptom: PCG+PFMG hits max iterations without
+ *  converging on porous-media inputs). PFMG is the more scalable choice
+ *  for fully active grids (no masked-out regions). Both have full GPU
+ *  support in HYPRE 2.31 when ``HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE)``
+ *  is active (see ``HypreStructSolver::createMatrixAndVectors``).
  */
 enum class PrecondType {
-    SMG, /**< Semicoarsening multigrid — robust on CPU, partial GPU support */
-    PFMG /**< Parallel semicoarsening multigrid — full GPU support, default */
+    SMG, /**< Semicoarsening multigrid — robust default, handles masked rows */
+    PFMG /**< Parallel semicoarsening multigrid — scales better on full grids */
 };
 
 /** @brief Base class for HYPRE structured-grid solvers.
@@ -113,7 +117,7 @@ protected:
      *
      *  Updates m_num_iterations, m_final_res_norm, and m_converged.
      */
-    bool runSolver(PrecondType precond_type = PrecondType::PFMG);
+    bool runSolver(PrecondType precond_type = PrecondType::SMG);
 
     // --- HYPRE handles (owned by this base class, cleaned up in destructor) ---
     HYPRE_StructGrid m_grid = nullptr;

--- a/src/props/TortuosityHypre.H
+++ b/src/props/TortuosityHypre.H
@@ -67,15 +67,15 @@ public:
      * false.
      * @param precond_type Preconditioner used by Krylov solvers (PCG/GMRES/FlexGMRES/BiCGSTAB).
      *   Ignored when @p solvertype is a standalone multigrid (SMG/PFMG) or Jacobi.
-     *   Default PFMG — full GPU support in HYPRE; SMG only has partial GPU support.
+     *   Default SMG — robust on masked porous-media inputs where PFMG's
+     *   semicoarsening fails to converge on the decoupled inactive rows.
      */
     TortuosityHypre(const amrex::Geometry& geom, const amrex::BoxArray& ba,
                     const amrex::DistributionMapping& dm, const amrex::iMultiFab& mf_phase_input,
                     const amrex::Real vf, const int phase, const OpenImpala::Direction dir,
                     const SolverType solvertype, const std::string& resultspath,
                     const amrex::Real vlo = 0.0, const amrex::Real vhi = 1.0, int verbose = 0,
-                    bool write_plotfile = false,
-                    const PrecondType precond_type = PrecondType::PFMG);
+                    bool write_plotfile = false, const PrecondType precond_type = PrecondType::SMG);
 
     /** Destructor. Base class handles HYPRE resource cleanup. */
     virtual ~TortuosityHypre() override = default;
@@ -181,7 +181,7 @@ private:
     bool m_write_plotfile;
 
     // Preconditioner for Krylov solvers (ignored for standalone SMG/PFMG/Jacobi)
-    PrecondType m_precond_type = PrecondType::PFMG;
+    PrecondType m_precond_type = PrecondType::SMG;
 
     // Boundary condition configuration
     BCType m_bc_inlet_outlet_type = BCType::DirichletExternal;


### PR DESCRIPTION
After 68d93c2 properly configured HYPRE-CUDA (HYPRE_MEMORY_DEVICE + device pointers), HYPRE actually runs on GPU. But the notebook §3 warm-up call (PCG + the previous PFMG default, on a 32^3 porespy blob with ~50% inactive cells) hits the convergence cap:

    RuntimeError: TortuosityHypre.value() failed: solver did not converge

This isn't a GPU bug — PFMG's semicoarsening can't coarsen the decoupled rows that arise from masked-out (inactive) cells where A_ii=1 and b_i=0. PFMG just stalls on porous-media inputs with significant inactive volume.

SMG handles this naturally: its point-based smoother converges on any positive-definite operator regardless of how many rows are decoupled. The original default was SMG for exactly this reason — I flipped it to PFMG in 19e4b82 thinking SMG was GPU-broken (it was, but only because of the HOST-memory + DEVICE-exec mismatch I've now fixed). With HYPRE-CUDA configured correctly, SMG runs on GPU too.

Revert the preconditioner default in all four places:

  src/props/HypreStructSolver.H       enum doc + runSolver() default
  src/props/TortuosityHypre.H         ctor default + member default
  python/bindings/solvers.cpp          pybind11 default
  python/openimpala/facade.py          high-level default + docstring

PFMG remains available for fully-active grids where its better asymptotic scaling matters; the docstring now explains when to pick which.

Expected behaviour on 4.2.16:

  oi.tortuosity(arr)                          → PCG + SMG (default)
  oi.tortuosity(arr, preconditioner='pfmg')   → PCG + PFMG (opt-in)
  oi.tortuosity(arr, solver='mlmg')           → MLMG (matrix-free)

For the §3 porespy-blob warm-up, PCG+SMG should converge in ~tens of iterations and report a real tortuosity value.
