### PR TITLE
clang-tidy CI: retry install on Rocky 8 mirror 404 and bail clearly o…

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,9 +82,33 @@ jobs:
         run: |
           sudo apptainer exec --writable-tmpfs --bind $PWD:/src ./dependency_image.sif \
             bash -c '
+              set -e
               source /opt/rh/gcc-toolset-11/enable
-              dnf install -y clang-tools-extra 2>&1 | tail -3
-              echo "clang-tidy version: $(clang-tidy --version 2>&1 | head -1)"
+
+              # Rocky 8 mirrors occasionally 404 on repodata for a few minutes
+              # before AlmaLinux mirrors catch up. Retry the install with
+              # backoff up to 3 times — typical transient outages recover
+              # well within that window — then fail clearly with an
+              # infrastructure-error message rather than silently leaving
+              # clang-tidy unavailable.
+              install_ok=0
+              for attempt in 1 2 3; do
+                  if dnf install -y clang-tools-extra 2>&1 | tail -3 && \
+                     command -v clang-tidy >/dev/null 2>&1; then
+                      install_ok=1
+                      break
+                  fi
+                  echo "clang-tidy install attempt $attempt failed; sleeping ${attempt}0s..."
+                  sleep $((attempt * 10))
+                  dnf clean all >/dev/null 2>&1 || true
+              done
+
+              if [ $install_ok -ne 1 ] || ! command -v clang-tidy >/dev/null 2>&1; then
+                  echo "::error::clang-tidy could not be installed (Rocky 8 mirror 404). This is an infrastructure issue, not a code issue. Re-run the job."
+                  exit 2
+              fi
+
+              echo "clang-tidy version: $(clang-tidy --version | head -1)"
               cd /src
               # Fetch nlohmann/json header (used by ResultsJSON.H, normally via CMake FetchContent)
               NLOHMANN_VERSION="v3.11.3"


### PR DESCRIPTION
…n failure

The build-test workflow's clang-tidy stage failed today with:

    Status code: 404 for mirrors.melbourne.co.uk/rocky/8.10/BaseOS/...
    Status code: 404 for ftp.halifax.rwth-aachen.de/rockylinux/8.10/...
    Error: Failed to download metadata for repo 'baseos'

The Rocky 8 mirror network occasionally serves a 404 on repodata XML for a few minutes when an upstream mirror desyncs from the master. The dnf install of clang-tools-extra failed, but the script piped its output through `tail -3`, silently swallowing the error, then ran `clang-tidy` against 41 source files. Each failed with "command not found", was counted as one "issue", and the script reported "clang-tidy found issues in 41 file(s)" — which is misleading: there were zero lint findings, just a missing tool.

Three changes to the workflow step:

  set -e on entry so a hard install failure aborts immediately.

  Retry the dnf install up to 3 times with 10s/20s/30s backoff and a
  `dnf clean all` between attempts. Typical Rocky mirror outages
  recover within a minute, so a single re-run rarely needs more than
  one retry. Each iteration verifies `command -v clang-tidy` actually
  resolves before declaring success.

  If clang-tidy is still unavailable after all 3 attempts, exit 2
  with a clear `::error::` message that distinguishes infrastructure
  problems from code problems. The CI badge will go red but reviewers
  see "Rocky 8 mirror 404" instead of "found issues in 41 files",
  and the obvious remediation is just "re-run the job" — which used
  to work but was hidden by the misleading error message.

No actual lint rule changes; this is purely making the existing job more resilient to transient mirror outages.

https://claude.ai/code/session_011dJ5Bwq4Tnr8wxH597XJFf