### PR TITLE
mlmg: pin non-percolating inactive cells via alpha*a row decoupling

### DIFF
--- a/src/props/TortuosityMLMG.cpp
+++ b/src/props/TortuosityMLMG.cpp
@@ -24,6 +24,13 @@
 
 namespace OpenImpala {
 
+namespace {
+// Active-mask sentinels — must match TortuositySolverBase.cpp.
+constexpr int MaskComp = 0;
+constexpr int cell_inactive = 0;
+constexpr int cell_active = 1;
+} // namespace
+
 // --- Constructor ---
 TortuosityMLMG::TortuosityMLMG(const amrex::Geometry& geom, const amrex::BoxArray& ba,
                                const amrex::DistributionMapping& dm,
@@ -86,7 +93,10 @@ bool TortuosityMLMG::solve() {
     }
     mlabec.setDomainBC(lo_bc, hi_bc);
 
-    // Set initial guess: linear ramp in flow direction for better convergence
+    // Set initial guess: linear ramp on active cells, zero on inactive.
+    // Inactive cells (non-percolating phase-target islands) are pinned to
+    // phi=0 by the alpha*a row below; seeding their initial guess at 0
+    // gives MLMG a residual of zero on those rows from V-cycle 1.
     m_mf_solution.setVal(0.0);
     {
         const amrex::Box& domain = m_geom.Domain();
@@ -104,8 +114,13 @@ bool TortuosityMLMG::solve() {
         for (amrex::MFIter mfi(m_mf_solution, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             const amrex::Box& bx = mfi.growntilebox();
             amrex::Array4<amrex::Real> const phi = m_mf_solution.array(mfi);
+            amrex::Array4<const int> const mask = m_mf_active_mask.const_array(mfi);
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::IntVect iv(i, j, k);
+                if (mask(i, j, k, MaskComp) != cell_active) {
+                    phi(i, j, k) = 0.0;
+                    return;
+                }
                 int idx_in_dir = iv[idir] - dom_lo_dir;
                 amrex::Real frac =
                     static_cast<amrex::Real>(idx_in_dir) / static_cast<amrex::Real>(n_cells - 1);
@@ -124,15 +139,41 @@ bool TortuosityMLMG::solve() {
     // Set level BC (ghost cell values encode the Dirichlet data)
     mlabec.setLevelBC(0, &m_mf_solution);
 
-    // Set coefficients: alpha*a - beta*div(B*grad)
-    mlabec.setScalars(0.0, 1.0); // alpha=0, beta=1
+    // Set coefficients: alpha*a*phi - beta*div(B*grad phi) = rhs
+    //
+    // We need alpha != 0 to pin non-percolating cells. With alpha=1:
+    //   active cells:    a=0, rhs=0 -> -div(B grad phi) = 0   (Laplacian)
+    //   inactive cells:  a=1, rhs=0, B=0 on all adjacent faces
+    //                    -> phi = 0   (pinned, decoupled)
+    //
+    // This is the matrix-free analogue of the HYPRE A_ii=1, A_ij=0, rhs=0
+    // row-decoupling for inactive cells (TortuosityHypre.cpp:1100). Without
+    // it, dead-end phase-target islands form Neumann subdomains with no
+    // Dirichlet contact: MLMG drives the local residual to zero but their
+    // potentials remain indeterminate, breaking the boundary flux balance
+    // that TortuositySolverBase::value() audits.
+    mlabec.setScalars(1.0, 1.0);
 
-    // A-coefficient (not used since alpha=0, but must be set)
+    // A-coefficient: 1 on inactive cells (pin to rhs=0), 0 on active cells.
     amrex::MultiFab acoef(m_ba, m_dm, 1, 0);
     acoef.setVal(0.0);
+#ifdef AMREX_USE_OMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(acoef, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        amrex::Array4<amrex::Real> const a_arr = acoef.array(mfi);
+        amrex::Array4<const int> const mask = m_mf_active_mask.const_array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            a_arr(i, j, k) = (mask(i, j, k, MaskComp) == cell_active) ? 0.0 : 1.0;
+        });
+    }
     mlabec.setACoeffs(0, acoef);
 
-    // B-coefficients: face-centred diffusivities via harmonic mean
+    // B-coefficients: harmonic mean of cell-centred D, but zeroed on any
+    // face touching an inactive cell. Combined with the A-coefficient pin
+    // above, this fully decouples inactive cells from the active subdomain
+    // and from each other — the operator becomes well-posed everywhere.
     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> bcoefs;
     for (int d = 0; d < AMREX_SPACEDIM; ++d) {
         amrex::BoxArray edge_ba = m_ba;
@@ -141,19 +182,48 @@ bool TortuosityMLMG::solve() {
         bcoefs[d].setVal(0.0);
     }
 
+    // The active mask has 1 ghost layer, but FillBoundary only updates
+    // periodic ghosts — non-periodic (Dirichlet/Neumann) ghosts stay at
+    // their setVal(cell_inactive) initial value. For boundary faces of
+    // the domain we must therefore consult only the interior cell's mask
+    // status, otherwise inlet/outlet face B-coefficients get spuriously
+    // zeroed and the Dirichlet BC drives zero flux.
+    const amrex::Box domain_cells = m_geom.Domain();
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
     for (amrex::MFIter mfi(m_mf_diff_coeff, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         amrex::Array4<const amrex::Real> const dc = m_mf_diff_coeff.const_array(mfi);
+        amrex::Array4<const int> const mask = m_mf_active_mask.const_array(mfi);
         for (int d = 0; d < AMREX_SPACEDIM; ++d) {
             const amrex::Box& ebx = amrex::surroundingNodes(mfi.tilebox(), d);
             amrex::Array4<amrex::Real> const bf = bcoefs[d].array(mfi);
             const amrex::IntVect shift = amrex::IntVect::TheDimensionVector(d);
+            const int dom_lo_d = domain_cells.smallEnd(d);
+            const int dom_hi_d = domain_cells.bigEnd(d);
             amrex::ParallelFor(ebx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                 amrex::IntVect iv(i, j, k);
-                amrex::Real D_lo = dc(iv - shift);
-                amrex::Real D_hi = dc(iv);
+                amrex::IntVect iv_lo = iv - shift;
+                // Face sits between cells iv_lo and iv in direction d.
+                // Determine which adjacent cells are interior (vs domain ghost).
+                const bool lo_interior = (iv[d] > dom_lo_d);
+                const bool hi_interior = (iv[d] <= dom_hi_d);
+                const bool lo_active = lo_interior && mask(iv_lo, MaskComp) == cell_active;
+                const bool hi_active = hi_interior && mask(iv, MaskComp) == cell_active;
+                // Interior face: both cells must be active.
+                // Boundary face: the single interior cell must be active.
+                bool face_couples;
+                if (lo_interior && hi_interior) {
+                    face_couples = lo_active && hi_active;
+                } else {
+                    face_couples = lo_interior ? lo_active : hi_active;
+                }
+                if (!face_couples) {
+                    bf(i, j, k) = 0.0;
+                    return;
+                }
+                amrex::Real D_lo = lo_interior ? dc(iv_lo) : dc(iv);
+                amrex::Real D_hi = hi_interior ? dc(iv) : dc(iv_lo);
                 if (D_lo + D_hi > 0.0) {
                     bf(i, j, k) = 2.0 * D_lo * D_hi / (D_lo + D_hi);
                 } else {
@@ -164,7 +234,8 @@ bool TortuosityMLMG::solve() {
     }
     mlabec.setBCoeffs(0, amrex::GetArrOfConstPtrs(bcoefs));
 
-    // RHS = 0 (steady-state Laplacian)
+    // RHS = 0 everywhere: pinned inactive cells satisfy 1*phi = 0,
+    // active cells satisfy -div(B grad phi) = 0 (Laplacian).
     amrex::MultiFab rhs(m_ba, m_dm, 1, 0);
     rhs.setVal(0.0);
 


### PR DESCRIPTION
TortuosityHypre zeros A_ij and sets A_ii=1, rhs=0 on cells that the flood fill marked as non-percolating phase-target islands (dead-end pores, isolated clusters). The matrix-free MLMG path was building the MLABecLaplacian B-coefficients straight from m_mf_diff_coeff, which is 1 on every phase-target cell — so dead-end branches stayed coupled to their neighbours but had no Dirichlet contact, forming Neumann subdomains. MLMG drove the local residual to zero, declared convergence, and left those potentials indeterminate. The integrated boundary fluxes then disagreed and TortuositySolverBase::value() returned NaN — surfacing to Python as 'TortuosityMLMG.value() failed: converged but produced an invalid result' on every porespy / porous-media bake-off run.

Fix: use MLABecLaplacian's a-coefficient to pin inactive cells. setScalars(1.0, 1.0) makes the equation a*phi - div(B grad phi) = rhs. On active cells a=0 (pure Laplacian); on inactive cells a=1 with rhs=0, and all B-faces touching the cell are zeroed, so each inactive cell satisfies phi = 0 in isolation. Boundary faces of the domain still use just the interior cell's mask status, since the active-mask iMultiFab's non-periodic ghost layer holds setVal(cell_inactive) and would otherwise spuriously zero inlet/outlet B-coefficients.