### PR TITLE
wheels: enable AMReX EB in CPU and GPU wheel builds

### DIFF
--- a/.github/workflows/pypi-wheels-cpu.yml
+++ b/.github/workflows/pypi-wheels-cpu.yml
@@ -103,6 +103,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF
             -DAMReX_MPI=ON
             -DAMReX_OMP=ON
+            -DAMReX_EB=ON
             -DAMReX_SPACEDIM=3
             -DAMReX_FORTRAN=ON
             -DAMReX_PARTICLES=OFF

--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -130,6 +130,7 @@ jobs:
             -DBUILD_SHARED_LIBS=OFF
             -DAMReX_MPI=ON
             -DAMReX_OMP=ON
+            -DAMReX_EB=ON
             -DAMReX_SPACEDIM=3
             -DAMReX_FORTRAN=ON
             -DAMReX_PARTICLES=OFF


### PR DESCRIPTION
Both pypi-wheels-cpu.yml and pypi-wheels-gpu.yml were building AMReX without -DAMReX_EB=ON, so the EB headers (AMReX_EB2.H, AMReX_MLEBABecLap.H) were missing at wheel compile time. Add the flag to match the container builds (Dockerfile:93, Singularity.deps.def:176).