### PR TITLE
wheels: drop sm_75 SASS to fit EB under PyPI 320 MB limit

### DIFF
--- a/.github/workflows/pypi-wheels-gpu.yml
+++ b/.github/workflows/pypi-wheels-gpu.yml
@@ -136,9 +136,9 @@ jobs:
             -DAMReX_PARTICLES=OFF
             -DAMReX_TINY_PROFILE=ON
             -DAMReX_GPU_BACKEND=CUDA
-            '-DAMReX_CUDA_ARCH=75;80'
+            '-DAMReX_CUDA_ARCH=80'
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            '-DCMAKE_CUDA_ARCHITECTURES=75-real;80-real;90-virtual'
+            '-DCMAKE_CUDA_ARCHITECTURES=80-real;90-virtual'
             -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++
             '-DCMAKE_CUDA_FLAGS=-Xfatbin --compress-all' &&
             cmake --build /tmp/amrex/build -j$(nproc) &&
@@ -175,7 +175,7 @@ jobs:
             CMAKE_CXX_COMPILER="mpicxx"
             CMAKE_PREFIX_PATH="/usr/local"
             CMAKE_GENERATOR="Unix Makefiles"
-            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=75-real;80-real;90-virtual' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
+            CMAKE_ARGS="-DGPU_BACKEND=CUDA '-DCMAKE_CUDA_ARCHITECTURES=80-real;90-virtual' -DCMAKE_CUDA_HOST_COMPILER=/opt/rh/gcc-toolset-13/root/usr/bin/g++"
             CUDAFLAGS="-Xfatbin --compress-all"
             SETUPTOOLS_SCM_PRETEND_VERSION="${{ steps.version.outputs.version }}"
 


### PR DESCRIPTION
Fatbin compression had no effect (auditwheel --strip likely strips the compressed sections). Drop the Turing (sm_75) SASS target instead — each SASS architecture is a full copy of device code (~50 MB). T4 users JIT-compile from the sm_90 PTX on first kernel launch (~10-30s one-time cost). Keep sm_80-real (A100/A10) as the primary SASS target.

AMReX_CUDA_ARCH and CMAKE_CUDA_ARCHITECTURES both updated to match: 80-real;90-virtual (was 75-real;80-real;90-virtual).