### PR TITLE
session: NULL-terminate argv passed to amrex::Initialize

### DIFF
--- a/python/bindings/module.cpp
+++ b/python/bindings/module.cpp
@@ -59,10 +59,15 @@ static void init_amrex() {
             "amrex.the_arena_init_size=0",
         };
         std::vector<char*> argv_ptrs;
+        argv_ptrs.reserve(argv_storage.size() + 1);
         for (auto& s : argv_storage) {
             argv_ptrs.push_back(s.data());
         }
-        int argc = static_cast<int>(argv_ptrs.size());
+        // POSIX/MPI convention: argv must be NULL-terminated. Without
+        // this, opal_argv_join (called by MPI_Init) reads past the end
+        // and segfaults intermittently depending on heap layout.
+        argv_ptrs.push_back(nullptr);
+        int argc = static_cast<int>(argv_storage.size());
         char** argv = argv_ptrs.data();
         amrex::Initialize(argc, argv);
     }


### PR DESCRIPTION
POSIX and MPI both require argv to be NULL-terminated (argv[argc] == nullptr). My previous commit constructed argv from a vector and forgot the terminator. OpenMPI's opal_argv_join (called inside MPI_Init) iterates argv looking for NULL — without it, it reads past the vector into uninitialised memory and segfaults intermittently depending on heap layout (subprocess happened to get NULL by luck, Jupyter kernel did not).

Stack trace from the failing case:
  [0] opal_argv_join+0x35
  [1] ompi_mpi_init+0xb5e
  [2] MPI_Init+0x72
  [3] amrex::ParallelDescriptor::StartParallel
  [4] amrex::Initialize